### PR TITLE
Rdm 1433

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -176,6 +176,9 @@ dependencies {
     compile group: 'com.sun.mail', name: 'mailapi', version: '1.6.0'
     compile group: 'commons-lang', name: 'commons-lang', version: '2.6'
 
+    //simplifies handling of exceptions in Java CompletableFutures
+    compile group: 'org.zalando', name: 'faux-pas', version: '0.6.0'
+
 
     // FIXME 0.6 doesn't support jsonb; 0.7 doesn't work on Windows
 //    runtime group: 'com.impossibl.pgjdbc-ng', name: 'pgjdbc-ng', version: '0.6'

--- a/build.gradle
+++ b/build.gradle
@@ -176,7 +176,7 @@ dependencies {
     compile group: 'com.sun.mail', name: 'mailapi', version: '1.6.0'
     compile group: 'commons-lang', name: 'commons-lang', version: '2.6'
 
-    //simplifies handling of exceptions in Java CompletableFutures
+    //simplifies handling of exceptions with Java CompletableFuture
     compile group: 'org.zalando', name: 'faux-pas', version: '0.6.0'
 
 

--- a/src/main/java/uk/gov/hmcts/ccd/ApplicationParams.java
+++ b/src/main/java/uk/gov/hmcts/ccd/ApplicationParams.java
@@ -55,6 +55,12 @@ public class ApplicationParams {
     @Value("${definition.cache.ttl.secs}")
     private String definitionCacheTTLSecs;
 
+    @Value("${async.core.pool.size}")
+    private String asyncCorePoolSize;
+
+    @Value("${async.max.pool.size}")
+    private String asyncMaxPoolSize;
+
     private static String encode(final String stringToEncode) {
         try {
             return URLEncoder.encode(stringToEncode, "UTF-8");
@@ -165,5 +171,13 @@ public class ApplicationParams {
 
     public int getDefinitionCacheTTLSecs() {
         return Integer.valueOf(this.definitionCacheTTLSecs);
+    }
+
+    public int getAsyncCorePoolSize() {
+        return Integer.valueOf(this.asyncCorePoolSize);
+    }
+
+    public int getAsyncMaxPoolSize() {
+        return Integer.valueOf(this.asyncMaxPoolSize);
     }
 }

--- a/src/main/java/uk/gov/hmcts/ccd/ApplicationParams.java
+++ b/src/main/java/uk/gov/hmcts/ccd/ApplicationParams.java
@@ -79,6 +79,10 @@ public class ApplicationParams {
         return caseDefinitionHost + "/api/data/jurisdictions/" + encode(jurisdictionId) + "/case-type";
     }
 
+    public String jurisdictionDefURL() {
+        return caseDefinitionHost + "/api/data/jurisdictions";
+    }
+
     public String caseTypeDefURL(final String caseTypeId) {
         return caseDefinitionHost + "/api/data/case-type/" + encode(caseTypeId);
     }

--- a/src/main/java/uk/gov/hmcts/ccd/ApplicationParams.java
+++ b/src/main/java/uk/gov/hmcts/ccd/ApplicationParams.java
@@ -50,16 +50,16 @@ public class ApplicationParams {
     private String defaultPrintType;
 
     @Value("${pagination.page.size}")
-    private String paginationPageSize;
+    private Integer paginationPageSize;
 
     @Value("${definition.cache.ttl.secs}")
-    private String definitionCacheTTLSecs;
+    private Integer definitionCacheTTLSecs;
 
     @Value("${async.core.pool.size}")
-    private String asyncCorePoolSize;
+    private Integer asyncCorePoolSize;
 
     @Value("${async.max.pool.size}")
-    private String asyncMaxPoolSize;
+    private Integer asyncMaxPoolSize;
 
     private static String encode(final String stringToEncode) {
         try {
@@ -166,18 +166,18 @@ public class ApplicationParams {
     }
 
     public int getPaginationPageSize() {
-        return Integer.valueOf(paginationPageSize);
+        return paginationPageSize;
     }
 
     public int getDefinitionCacheTTLSecs() {
-        return Integer.valueOf(this.definitionCacheTTLSecs);
+        return definitionCacheTTLSecs;
     }
 
     public int getAsyncCorePoolSize() {
-        return Integer.valueOf(this.asyncCorePoolSize);
+        return asyncCorePoolSize;
     }
 
     public int getAsyncMaxPoolSize() {
-        return Integer.valueOf(this.asyncMaxPoolSize);
+        return asyncMaxPoolSize;
     }
 }

--- a/src/main/java/uk/gov/hmcts/ccd/CachingConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/ccd/CachingConfiguration.java
@@ -1,7 +1,5 @@
 package uk.gov.hmcts.ccd;
 
-import java.util.Optional;
-
 import com.hazelcast.config.Config;
 import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.MapConfig;

--- a/src/main/java/uk/gov/hmcts/ccd/CachingConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/ccd/CachingConfiguration.java
@@ -20,17 +20,14 @@ public class CachingConfiguration {
     @Autowired
     ApplicationParams applicationParams;
 
-
     @Bean
     public Config hazelCastConfig(){
-
-        int definitionCacheTTL = Optional.ofNullable(applicationParams.getDefinitionCacheTTLSecs()).orElse(DEFAULT_CACHE_TTL);
 
         Config config = new Config();
         NetworkConfig networkConfig = config.setInstanceName("hazelcast-instance-ccd").getNetworkConfig();
         networkConfig.getJoin().getMulticastConfig().setEnabled(false);
         networkConfig.getJoin().getTcpIpConfig().setEnabled(false);
-        configCaches(definitionCacheTTL, config);
+        configCaches(applicationParams.getDefinitionCacheTTLSecs(), config);
         return config;
     }
 

--- a/src/main/java/uk/gov/hmcts/ccd/CoreCaseDataApplication.java
+++ b/src/main/java/uk/gov/hmcts/ccd/CoreCaseDataApplication.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.ccd;
 
-import java.util.Optional;
 import java.util.concurrent.Executor;
 
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/uk/gov/hmcts/ccd/CoreCaseDataApplication.java
+++ b/src/main/java/uk/gov/hmcts/ccd/CoreCaseDataApplication.java
@@ -46,7 +46,7 @@ public class CoreCaseDataApplication {
 
     @Bean
     public Executor asyncExecutor() {
-
+        //thread pool used for the execution of async tasks (methods marked with @Async)
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize(applicationParams.getAsyncCorePoolSize());
         executor.setMaxPoolSize(applicationParams.getAsyncMaxPoolSize());

--- a/src/main/java/uk/gov/hmcts/ccd/CoreCaseDataApplication.java
+++ b/src/main/java/uk/gov/hmcts/ccd/CoreCaseDataApplication.java
@@ -1,7 +1,9 @@
 package uk.gov.hmcts.ccd;
 
+import java.util.Optional;
 import java.util.concurrent.Executor;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.MethodInvokingFactoryBean;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -22,6 +24,9 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @EnableAsync
 public class CoreCaseDataApplication {
 
+    @Autowired
+    ApplicationParams applicationParams;
+
     public static final String LOGGING_LEVEL_SPRINGFRAMEWORK = "logging.level.org.springframework.web";
     public static final String LOGGING_LEVEL_CCD = "logging.level.uk.gov.hmcts.ccd";
 
@@ -41,9 +46,10 @@ public class CoreCaseDataApplication {
 
     @Bean
     public Executor asyncExecutor() {
+
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(4);
-        executor.setMaxPoolSize(4);
+        executor.setCorePoolSize(applicationParams.getAsyncCorePoolSize());
+        executor.setMaxPoolSize(applicationParams.getAsyncMaxPoolSize());
         executor.setQueueCapacity(500);
         executor.setThreadNamePrefix("async-exec-");
         executor.initialize();

--- a/src/main/java/uk/gov/hmcts/ccd/CoreCaseDataApplication.java
+++ b/src/main/java/uk/gov/hmcts/ccd/CoreCaseDataApplication.java
@@ -56,9 +56,9 @@ public class CoreCaseDataApplication {
         return executor;
     }
 
-    //allows security context to be propagated to child threads running async calls
     @Bean
     public MethodInvokingFactoryBean methodInvokingFactoryBean() {
+        //allows security context to be propagated to child threads running async calls
         MethodInvokingFactoryBean methodInvokingFactoryBean = new MethodInvokingFactoryBean();
         methodInvokingFactoryBean.setTargetClass(SecurityContextHolder.class);
         methodInvokingFactoryBean.setTargetMethod("setStrategyName");

--- a/src/main/java/uk/gov/hmcts/ccd/CoreCaseDataApplication.java
+++ b/src/main/java/uk/gov/hmcts/ccd/CoreCaseDataApplication.java
@@ -1,10 +1,17 @@
 package uk.gov.hmcts.ccd;
 
+import java.util.concurrent.Executor;
+
+import org.springframework.beans.factory.config.MethodInvokingFactoryBean;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @SpringBootApplication
@@ -12,6 +19,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @EnableRetry
 @ComponentScan("uk.gov.hmcts.ccd")
 @EnableCaching
+@EnableAsync
 public class CoreCaseDataApplication {
 
     public static final String LOGGING_LEVEL_SPRINGFRAMEWORK = "logging.level.org.springframework.web";
@@ -29,6 +37,27 @@ public class CoreCaseDataApplication {
 //            Configurator.setLevel(LOGGING_LEVEL_SPRINGFRAMEWORK, Level.valueOf(System.getProperty(LOGGING_LEVEL_SPRINGFRAMEWORK).toUpperCase()));
         }
         SpringApplication.run(CoreCaseDataApplication.class, args);
+    }
+
+    @Bean
+    public Executor asyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(4);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(500);
+        executor.setThreadNamePrefix("async-exec-");
+        executor.initialize();
+        return executor;
+    }
+
+    //allows security context to be propagated to child threads running async calls
+    @Bean
+    public MethodInvokingFactoryBean methodInvokingFactoryBean() {
+        MethodInvokingFactoryBean methodInvokingFactoryBean = new MethodInvokingFactoryBean();
+        methodInvokingFactoryBean.setTargetClass(SecurityContextHolder.class);
+        methodInvokingFactoryBean.setTargetMethod("setStrategyName");
+        methodInvokingFactoryBean.setArguments(new String[]{SecurityContextHolder.MODE_INHERITABLETHREADLOCAL});
+        return methodInvokingFactoryBean;
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/JurisdictionMapper.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/JurisdictionMapper.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.ccd.data.casedetails;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import uk.gov.hmcts.ccd.domain.model.aggregated.JurisdictionDisplayProperties;
+import uk.gov.hmcts.ccd.domain.model.definition.Jurisdiction;
+
+@Named
+@Singleton
+public class JurisdictionMapper {
+
+    public JurisdictionDisplayProperties toResponse(Jurisdiction jurisdiction) {
+        JurisdictionDisplayProperties result = new JurisdictionDisplayProperties();
+        result.setId(jurisdiction.getId());
+        result.setName(jurisdiction.getName());
+        result.setDescription(jurisdiction.getDescription());
+        return result;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/ccd/data/definition/CachedCaseDefinitionRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/definition/CachedCaseDefinitionRepository.java
@@ -61,8 +61,8 @@ public class CachedCaseDefinitionRepository implements CaseDefinitionRepository 
     }
 
     @Override
-    public List<Jurisdiction> getJurisdictions(List<String> ids) {
-        return caseDefinitionRepository.getJurisdictions(ids);
+    public CompletableFuture<List<Jurisdiction>> getJurisdictionsAsync(List<String> ids) {
+        return caseDefinitionRepository.getJurisdictionsAsync(ids);
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/ccd/data/definition/CachedCaseDefinitionRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/definition/CachedCaseDefinitionRepository.java
@@ -8,10 +8,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.context.annotation.RequestScope;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseType;
 import uk.gov.hmcts.ccd.domain.model.definition.FieldType;
+import uk.gov.hmcts.ccd.domain.model.definition.Jurisdiction;
 import uk.gov.hmcts.ccd.domain.model.definition.UserRole;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 import static com.google.common.collect.Maps.newHashMap;
 
@@ -56,6 +58,16 @@ public class CachedCaseDefinitionRepository implements CaseDefinitionRepository 
     @Override
     public CaseType getCaseType(int version, String caseTypeId) {
         return caseDefinitionRepository.getCaseType(version, caseTypeId);
+    }
+
+    @Override
+    public List<Jurisdiction> getJurisdictions(List<String> ids) {
+        return caseDefinitionRepository.getJurisdictions(ids);
+    }
+
+    @Override
+    public CompletableFuture<List<Jurisdiction>> getAllJurisdictionsAsync() {
+        return caseDefinitionRepository.getAllJurisdictionsAsync();
     }
 
     public List<FieldType> getBaseTypes() {

--- a/src/main/java/uk/gov/hmcts/ccd/data/definition/CachedCaseDefinitionRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/definition/CachedCaseDefinitionRepository.java
@@ -61,8 +61,8 @@ public class CachedCaseDefinitionRepository implements CaseDefinitionRepository 
     }
 
     @Override
-    public CompletableFuture<List<Jurisdiction>> getJurisdictionsAsync(List<String> ids) {
-        return caseDefinitionRepository.getJurisdictionsAsync(ids);
+    public List<Jurisdiction> getAllJurisdictions() {
+        return caseDefinitionRepository.getAllJurisdictions();
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/ccd/data/definition/CaseDefinitionRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/definition/CaseDefinitionRepository.java
@@ -19,6 +19,8 @@ public interface CaseDefinitionRepository {
 
     UserRole getUserRoleClassifications(String userRole);
 
+    List<Jurisdiction> getAllJurisdictions();
+
     CompletableFuture<List<Jurisdiction>> getAllJurisdictionsAsync();
 
     CaseTypeDefinitionVersion getLatestVersion(String caseTypeId);

--- a/src/main/java/uk/gov/hmcts/ccd/data/definition/CaseDefinitionRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/definition/CaseDefinitionRepository.java
@@ -19,8 +19,6 @@ public interface CaseDefinitionRepository {
 
     UserRole getUserRoleClassifications(String userRole);
 
-    CompletableFuture<List<Jurisdiction>> getJurisdictionsAsync(List<String> ids);
-
     CompletableFuture<List<Jurisdiction>> getAllJurisdictionsAsync();
 
     CaseTypeDefinitionVersion getLatestVersion(String caseTypeId);

--- a/src/main/java/uk/gov/hmcts/ccd/data/definition/CaseDefinitionRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/definition/CaseDefinitionRepository.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.ccd.data.definition;
 
-import org.springframework.scheduling.annotation.Async;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseType;
 import uk.gov.hmcts.ccd.domain.model.definition.FieldType;
 import uk.gov.hmcts.ccd.domain.model.definition.Jurisdiction;
@@ -20,7 +19,7 @@ public interface CaseDefinitionRepository {
 
     UserRole getUserRoleClassifications(String userRole);
 
-    List<Jurisdiction> getJurisdictions(List<String> ids);
+    CompletableFuture<List<Jurisdiction>> getJurisdictionsAsync(List<String> ids);
 
     CompletableFuture<List<Jurisdiction>> getAllJurisdictionsAsync();
 

--- a/src/main/java/uk/gov/hmcts/ccd/data/definition/CaseDefinitionRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/definition/CaseDefinitionRepository.java
@@ -1,10 +1,13 @@
 package uk.gov.hmcts.ccd.data.definition;
 
+import org.springframework.scheduling.annotation.Async;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseType;
 import uk.gov.hmcts.ccd.domain.model.definition.FieldType;
+import uk.gov.hmcts.ccd.domain.model.definition.Jurisdiction;
 import uk.gov.hmcts.ccd.domain.model.definition.UserRole;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 public interface CaseDefinitionRepository {
     List<CaseType> getCaseTypesForJurisdiction(String jurisdictionId);
@@ -16,6 +19,10 @@ public interface CaseDefinitionRepository {
     List<FieldType> getBaseTypes();
 
     UserRole getUserRoleClassifications(String userRole);
+
+    List<Jurisdiction> getJurisdictions(List<String> ids);
+
+    CompletableFuture<List<Jurisdiction>> getAllJurisdictionsAsync();
 
     CaseTypeDefinitionVersion getLatestVersion(String caseTypeId);
 }

--- a/src/main/java/uk/gov/hmcts/ccd/data/definition/DefaultCaseDefinitionRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/definition/DefaultCaseDefinitionRepository.java
@@ -123,26 +123,6 @@ public class DefaultCaseDefinitionRepository implements CaseDefinitionRepository
 
     @Override
     @Async
-    public CompletableFuture<List<Jurisdiction>> getJurisdictionsAsync(List<String> ids) {
-        try {
-            final HttpEntity requestEntity = new HttpEntity(securityUtils.authorizationHeaders());
-            UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(applicationParams.jurisdictionDefURL())
-                    .queryParam("ids", String.join(",", ids));
-            return CompletableFuture.completedFuture(restTemplate.exchange(builder.build().encode().toUri(),
-                    HttpMethod.GET, requestEntity, new ParameterizedTypeReference<List<Jurisdiction>>() {}).getBody());
-        } catch (Exception e) {
-            LOG.warn("Error while retrieving jurisdiction definition", e);
-            if (e instanceof HttpClientErrorException
-                    && ((HttpClientErrorException)e).getRawStatusCode() == RESOURCE_NOT_FOUND) {
-                throw new ResourceNotFoundException("Resource not found when retrieving jurisdiction definition because of " + e.getMessage());
-            } else {
-                throw new ServiceException("Problem retrieving jurisdiction definition because of " + e.getMessage());
-            }
-        }
-    }
-
-    @Override
-    @Async
     public CompletableFuture<List<Jurisdiction>> getAllJurisdictionsAsync() {
         try {
             LOG.debug("retrieving all jurisdictions definition");

--- a/src/main/java/uk/gov/hmcts/ccd/data/definition/DefaultCaseDefinitionRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/definition/DefaultCaseDefinitionRepository.java
@@ -122,23 +122,28 @@ public class DefaultCaseDefinitionRepository implements CaseDefinitionRepository
     }
 
     @Override
-    @Async
-    public CompletableFuture<List<Jurisdiction>> getAllJurisdictionsAsync() {
+    public List<Jurisdiction> getAllJurisdictions() {
         try {
             LOG.debug("retrieving all jurisdictions definition");
             final HttpEntity requestEntity = new HttpEntity(securityUtils.authorizationHeaders());
             UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(applicationParams.jurisdictionDefURL());
-            return CompletableFuture.completedFuture(restTemplate.exchange(builder.build().encode().toUri(), HttpMethod.GET,
-                    requestEntity, new ParameterizedTypeReference<List<Jurisdiction>>() {}).getBody());
+            return restTemplate.exchange(builder.build().encode().toUri(), HttpMethod.GET,
+                    requestEntity, new ParameterizedTypeReference<List<Jurisdiction>>() {}).getBody();
         } catch (Exception e) {
-            LOG.warn("Error while retrieving jurisdiction definition", e);
+            LOG.warn("Error while retrieving jurisdictions definition", e);
             if (e instanceof HttpClientErrorException
                     && ((HttpClientErrorException)e).getRawStatusCode() == RESOURCE_NOT_FOUND) {
-                throw new ResourceNotFoundException("Resource not found when retrieving jurisdiction definition because of " + e.getMessage());
+                throw new ResourceNotFoundException("Resource not found when retrieving jurisdictions definition because of " + e.getMessage());
             } else {
-                throw new ServiceException("Problem retrieving jurisdiction definition because of " + e.getMessage());
+                throw new ServiceException("Problem retrieving jurisdictions definition because of " + e.getMessage());
             }
         }
+    }
+
+    @Override
+    @Async
+    public CompletableFuture<List<Jurisdiction>> getAllJurisdictionsAsync() {
+        return CompletableFuture.completedFuture(this.getAllJurisdictions());
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/ccd/data/definition/DefaultCaseDefinitionRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/definition/DefaultCaseDefinitionRepository.java
@@ -127,8 +127,11 @@ public class DefaultCaseDefinitionRepository implements CaseDefinitionRepository
             LOG.debug("retrieving all jurisdictions definition");
             final HttpEntity requestEntity = new HttpEntity(securityUtils.authorizationHeaders());
             UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(applicationParams.jurisdictionDefURL());
-            return restTemplate.exchange(builder.build().encode().toUri(), HttpMethod.GET,
-                    requestEntity, new ParameterizedTypeReference<List<Jurisdiction>>() {}).getBody();
+            List<Jurisdiction> jurisdictionList = restTemplate.exchange(builder.build().encode().toUri(), HttpMethod.GET,
+                    requestEntity, new ParameterizedTypeReference<List<Jurisdiction>>() {
+                    }).getBody();
+            LOG.debug("retrieved jurisdictions definition: {}", jurisdictionList);
+            return jurisdictionList;
         } catch (Exception e) {
             LOG.warn("Error while retrieving jurisdictions definition", e);
             if (e instanceof HttpClientErrorException

--- a/src/main/java/uk/gov/hmcts/ccd/data/definition/DefaultCaseDefinitionRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/definition/DefaultCaseDefinitionRepository.java
@@ -6,21 +6,26 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 import uk.gov.hmcts.ccd.ApplicationParams;
 import uk.gov.hmcts.ccd.data.SecurityUtils;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseType;
 import uk.gov.hmcts.ccd.domain.model.definition.FieldType;
+import uk.gov.hmcts.ccd.domain.model.definition.Jurisdiction;
 import uk.gov.hmcts.ccd.domain.model.definition.UserRole;
 import uk.gov.hmcts.ccd.endpoint.exceptions.ResourceNotFoundException;
 import uk.gov.hmcts.ccd.endpoint.exceptions.ServiceException;
@@ -112,6 +117,45 @@ public class DefaultCaseDefinitionRepository implements CaseDefinitionRepository
             } else {
                 LOG.warn("Error while retrieving classification for user role " + userRole + " because of ", e);
                 throw new ServiceException("Error while retrieving classification for user role " + userRole + " because of " + e.getMessage());
+            }
+        }
+    }
+
+    @Override
+    public List<Jurisdiction> getJurisdictions(List<String> ids) {
+        try {
+            final HttpEntity requestEntity = new HttpEntity(securityUtils.authorizationHeaders());
+            UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(applicationParams.jurisdictionDefURL())
+                    .queryParam("ids", String.join(",", ids));
+            return restTemplate.exchange(builder.build().encode().toUri(), HttpMethod.GET, requestEntity,
+                    new ParameterizedTypeReference<List<Jurisdiction>>() {}).getBody();
+        } catch (Exception e) {
+            LOG.warn("Error while retrieving jurisdiction definition", e);
+            if (e instanceof HttpClientErrorException
+                    && ((HttpClientErrorException)e).getRawStatusCode() == RESOURCE_NOT_FOUND) {
+                throw new ResourceNotFoundException("Resource not found when retrieving jurisdiction definition because of " + e.getMessage());
+            } else {
+                throw new ServiceException("Problem retrieving jurisdiction definition because of " + e.getMessage());
+            }
+        }
+    }
+
+    @Override
+    @Async
+    public CompletableFuture<List<Jurisdiction>> getAllJurisdictionsAsync() {
+        try {
+            LOG.debug("retrieving all jurisdictions");
+            final HttpEntity requestEntity = new HttpEntity(securityUtils.authorizationHeaders());
+            UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(applicationParams.jurisdictionDefURL());
+            return CompletableFuture.completedFuture(restTemplate.exchange(builder.build().encode().toUri(), HttpMethod.GET,
+                    requestEntity, new ParameterizedTypeReference<List<Jurisdiction>>() {}).getBody());
+        } catch (Exception e) {
+            LOG.warn("Error while retrieving jurisdiction definition", e);
+            if (e instanceof HttpClientErrorException
+                    && ((HttpClientErrorException)e).getRawStatusCode() == RESOURCE_NOT_FOUND) {
+                throw new ResourceNotFoundException("Resource not found when retrieving jurisdiction definition because of " + e.getMessage());
+            } else {
+                throw new ServiceException("Problem retrieving jurisdiction definition because of " + e.getMessage());
             }
         }
     }

--- a/src/main/java/uk/gov/hmcts/ccd/data/definition/DefaultCaseDefinitionRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/definition/DefaultCaseDefinitionRepository.java
@@ -122,13 +122,14 @@ public class DefaultCaseDefinitionRepository implements CaseDefinitionRepository
     }
 
     @Override
-    public List<Jurisdiction> getJurisdictions(List<String> ids) {
+    @Async
+    public CompletableFuture<List<Jurisdiction>> getJurisdictionsAsync(List<String> ids) {
         try {
             final HttpEntity requestEntity = new HttpEntity(securityUtils.authorizationHeaders());
             UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(applicationParams.jurisdictionDefURL())
                     .queryParam("ids", String.join(",", ids));
-            return restTemplate.exchange(builder.build().encode().toUri(), HttpMethod.GET, requestEntity,
-                    new ParameterizedTypeReference<List<Jurisdiction>>() {}).getBody();
+            return CompletableFuture.completedFuture(restTemplate.exchange(builder.build().encode().toUri(),
+                    HttpMethod.GET, requestEntity, new ParameterizedTypeReference<List<Jurisdiction>>() {}).getBody());
         } catch (Exception e) {
             LOG.warn("Error while retrieving jurisdiction definition", e);
             if (e instanceof HttpClientErrorException
@@ -144,7 +145,7 @@ public class DefaultCaseDefinitionRepository implements CaseDefinitionRepository
     @Async
     public CompletableFuture<List<Jurisdiction>> getAllJurisdictionsAsync() {
         try {
-            LOG.debug("retrieving all jurisdictions");
+            LOG.debug("retrieving all jurisdictions definition");
             final HttpEntity requestEntity = new HttpEntity(securityUtils.authorizationHeaders());
             UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(applicationParams.jurisdictionDefURL());
             return CompletableFuture.completedFuture(restTemplate.exchange(builder.build().encode().toUri(), HttpMethod.GET,

--- a/src/main/java/uk/gov/hmcts/ccd/data/user/CachedUserRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/user/CachedUserRepository.java
@@ -6,10 +6,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.context.annotation.RequestScope;
 import uk.gov.hmcts.ccd.data.casedetails.SecurityClassification;
 import uk.gov.hmcts.ccd.domain.model.aggregated.IDAMProperties;
+import uk.gov.hmcts.ccd.domain.model.aggregated.UserDefault;
 import uk.gov.hmcts.ccd.domain.model.aggregated.UserProfile;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 import static com.google.common.collect.Maps.newHashMap;
 
@@ -25,7 +27,6 @@ public class CachedUserRepository implements UserRepository {
     private final Map<String, Set<SecurityClassification>> jurisdictionToUserClassifications = newHashMap();
     private final Map<String, IDAMProperties> userDetails = newHashMap();
     private final Map<String, Set<String>> userRoles = newHashMap();
-    private final Map<String, UserProfile> userProfile = newHashMap();
 
     @Autowired
     public CachedUserRepository(@Qualifier(DefaultUserRepository.QUALIFIER) UserRepository userRepository) {
@@ -33,13 +34,18 @@ public class CachedUserRepository implements UserRepository {
     }
 
     @Override
-    public UserProfile getUserSettings() {
-        return userProfile.computeIfAbsent("userProfile", e -> userRepository.getUserSettings());
+    public IDAMProperties getUserDetails() {
+        return userDetails.computeIfAbsent("userDetails", e -> userRepository.getUserDetails());
     }
 
     @Override
-    public IDAMProperties getUserDetails() {
-        return userDetails.computeIfAbsent("userDetails", e -> userRepository.getUserDetails());
+    public CompletableFuture<IDAMProperties> getUserDetailsAsync() {
+        return userRepository.getUserDetailsAsync();
+    }
+
+    @Override
+    public CompletableFuture<UserDefault> getUserDefaultSettingsAsync(String userId) {
+        return userRepository.getUserDefaultSettingsAsync(userId);
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/ccd/data/user/CachedUserRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/user/CachedUserRepository.java
@@ -7,7 +7,6 @@ import org.springframework.web.context.annotation.RequestScope;
 import uk.gov.hmcts.ccd.data.casedetails.SecurityClassification;
 import uk.gov.hmcts.ccd.domain.model.aggregated.IDAMProperties;
 import uk.gov.hmcts.ccd.domain.model.aggregated.UserDefault;
-import uk.gov.hmcts.ccd.domain.model.aggregated.UserProfile;
 
 import java.util.Map;
 import java.util.Set;

--- a/src/main/java/uk/gov/hmcts/ccd/data/user/DefaultUserRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/user/DefaultUserRepository.java
@@ -113,7 +113,7 @@ public class DefaultUserRepository implements UserRepository {
      */
     public UserDefault getUserDefaultSettings(final String userId) {
         try {
-            LOG.debug("retrieving default user settings");
+            LOG.debug("retrieving default user settings for user {}", userId);
             final HttpEntity requestEntity = new HttpEntity(securityUtils.authorizationHeaders());
             final Map<String, String> queryParams = new HashMap<>();
             queryParams.put("uid", userId);

--- a/src/main/java/uk/gov/hmcts/ccd/data/user/UserRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/user/UserRepository.java
@@ -1,15 +1,19 @@
 package uk.gov.hmcts.ccd.data.user;
 
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
 import uk.gov.hmcts.ccd.data.casedetails.SecurityClassification;
 import uk.gov.hmcts.ccd.domain.model.aggregated.IDAMProperties;
-import uk.gov.hmcts.ccd.domain.model.aggregated.UserProfile;
-
-import java.util.Set;
+import uk.gov.hmcts.ccd.domain.model.aggregated.UserDefault;
 
 public interface UserRepository {
-    UserProfile getUserSettings();
 
     IDAMProperties getUserDetails();
+
+    CompletableFuture<IDAMProperties> getUserDetailsAsync();
+
+    CompletableFuture<UserDefault> getUserDefaultSettingsAsync(String userId);
 
     Set<String> getUserRoles();
 

--- a/src/main/java/uk/gov/hmcts/ccd/data/user/UserService.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/user/UserService.java
@@ -44,9 +44,8 @@ public class UserService {
         CompletableFuture<IDAMProperties> idamPropsFuture = userRepository.getUserDetailsAsync();
         CompletableFuture<UserDefault> userDefaultFuture = idamPropsFuture
             .thenCompose(props -> userRepository.getUserDefaultSettingsAsync(props.getEmail()));
-        return userDefaultFuture.thenCombine(jurisdictionDefsFuture, ((userDefault, jurisdictions) -> {
-            return createUserProfile(idamPropsFuture.join(), userDefault, jurisdictions);
-        }));
+        return userDefaultFuture.thenCombine(jurisdictionDefsFuture, ((userDefault, jurisdictions) ->
+                createUserProfile(idamPropsFuture.join(), userDefault, jurisdictions)));
     }
 
     private UserProfile createUserProfile(IDAMProperties idamProperties, UserDefault userDefault, List<Jurisdiction> jurisdictions) {

--- a/src/main/java/uk/gov/hmcts/ccd/data/user/UserService.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/user/UserService.java
@@ -1,0 +1,97 @@
+package uk.gov.hmcts.ccd.data.user;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+import org.springframework.web.context.annotation.RequestScope;
+import uk.gov.hmcts.ccd.data.casedetails.JurisdictionMapper;
+import uk.gov.hmcts.ccd.data.definition.CachedCaseDefinitionRepository;
+import uk.gov.hmcts.ccd.data.definition.CaseDefinitionRepository;
+import uk.gov.hmcts.ccd.domain.model.aggregated.JurisdictionDisplayProperties;
+import uk.gov.hmcts.ccd.domain.model.aggregated.UserDefault;
+import uk.gov.hmcts.ccd.domain.model.aggregated.UserProfile;
+import uk.gov.hmcts.ccd.domain.model.aggregated.WorkbasketDefault;
+import uk.gov.hmcts.ccd.domain.model.definition.Jurisdiction;
+
+@Service
+public class UserService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(UserService.class);
+
+    private UserRepository userRepository;
+    private CaseDefinitionRepository caseDefinitionRepository;
+    private JurisdictionMapper jurisdictionMapper;
+
+    @Inject
+    public UserService(@Qualifier(DefaultUserRepository.QUALIFIER) UserRepository userRepository,
+                       @Qualifier(CachedCaseDefinitionRepository.QUALIFIER) CaseDefinitionRepository caseDefinitionRepository,
+                       JurisdictionMapper jurisdictionMapper) {
+        this.userRepository = userRepository;
+        this.caseDefinitionRepository = caseDefinitionRepository;
+        this.jurisdictionMapper = jurisdictionMapper;
+    }
+
+    public CompletableFuture<UserProfile> getUserProfileAsync() {
+        long start = System.nanoTime();
+        final UserProfile userProfile = new UserProfile();
+        CompletableFuture<UserDefault> userDefaultFuture = userRepository.getUserDetailsAsync()
+                .whenComplete((p,t) -> {
+                    LOG.debug("retrieved user details. duration: {}", (System.nanoTime() - start)/1_000_000);
+                })
+                .thenCompose(idamProperties -> {
+                    String userId = idamProperties.getEmail();
+                    userProfile.getUser().setIdamProperties(idamProperties);
+                    long start2 = System.nanoTime();
+                    CompletableFuture<UserDefault> userDefaultSettingsAsync = userRepository.getUserDefaultSettingsAsync(userId);
+                    userDefaultSettingsAsync.whenComplete((userDefaultSettings, t) -> {
+                        LOG.debug("retrieved user default settings. duration: {}", (System.nanoTime() - start2)/1_000_000);
+                    });
+                    return userDefaultSettingsAsync;
+                });
+
+        long start3 = System.nanoTime();
+        CompletableFuture<List<Jurisdiction>> jurisdictionDefsFuture = caseDefinitionRepository.getAllJurisdictionsAsync();
+
+        jurisdictionDefsFuture.whenComplete((j,t) -> {
+            LOG.debug("retrieved jurisdictions. duration: {}", (System.nanoTime() - start3)/1_000_000);
+        });
+
+        return userDefaultFuture.thenCombine(jurisdictionDefsFuture, ((userDefault, jurisdictions) -> {
+            List<String> userJurisdictions = userDefault.getJurisdictionsId();
+
+            JurisdictionDisplayProperties[] resultJurisdictions = toResponse(userJurisdictions, jurisdictions);
+
+            userProfile.setJurisdictions(resultJurisdictions);
+
+            final WorkbasketDefault workbasketDefault = new WorkbasketDefault();
+            workbasketDefault.setJurisdictionId(userDefault.getWorkBasketDefaultJurisdiction());
+            workbasketDefault.setCaseTypeId(userDefault.getWorkBasketDefaultCaseType());
+            workbasketDefault.setStateId(userDefault.getWorkBasketDefaultState());
+            userProfile.getDefaultSettings().setWorkbasketDefault(workbasketDefault);
+            LOG.debug("returning user profile. duration: {}", (System.nanoTime() - start)/1_000_000);
+
+            return userProfile;
+        }));
+    }
+
+    private JurisdictionDisplayProperties[] toResponse(List<String> userJurisdictions, List<Jurisdiction>
+            jurisdictions) {
+        return userJurisdictions.stream().map(id -> {
+            Optional<Jurisdiction> definition = jurisdictions.stream().filter(def -> def.getId().equals(id)).findAny();
+            if (!definition.isPresent()) {
+                LOG.warn("Could not retrieve definition for jurisdiction '{}'", id);
+            }
+            return definition.map(jurisdictionMapper::toResponse);
+        }).filter(Optional::isPresent).map(Optional::get).toArray(JurisdictionDisplayProperties[]::new);
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/ccd/data/user/UserService.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/user/UserService.java
@@ -44,7 +44,7 @@ public class UserService {
         long start = System.nanoTime();
         final UserProfile userProfile = new UserProfile();
         CompletableFuture<UserDefault> userDefaultFuture = userRepository.getUserDetailsAsync()
-                .whenComplete((p,t) -> {
+                .whenComplete((d,t) -> {
                     LOG.debug("retrieved user details. duration: {}", (System.nanoTime() - start)/1_000_000);
                 })
                 .thenCompose(idamProperties -> {
@@ -88,7 +88,7 @@ public class UserService {
         return userJurisdictions.stream().map(id -> {
             Optional<Jurisdiction> definition = jurisdictions.stream().filter(def -> def.getId().equals(id)).findAny();
             if (!definition.isPresent()) {
-                LOG.warn("Could not retrieve definition for jurisdiction '{}'", id);
+                LOG.warn("Could not retrieve definition of jurisdiction '{}'", id);
             }
             return definition.map(jurisdictionMapper::toResponse);
         }).filter(Optional::isPresent).map(Optional::get).toArray(JurisdictionDisplayProperties[]::new);

--- a/src/main/java/uk/gov/hmcts/ccd/domain/model/aggregated/UserDefault.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/model/aggregated/UserDefault.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.ccd.domain.model.aggregated;
 
+import static java.util.stream.Collectors.toList;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 import uk.gov.hmcts.ccd.domain.model.definition.Jurisdiction;
@@ -68,4 +70,9 @@ public class UserDefault {
 
     public void setWorkBasketDefaultState(final String workBasketDefaultState) {
         this.workBasketDefaultState = workBasketDefaultState;
-    }}
+    }
+
+    public List<String> getJurisdictionsId() {
+        return this.jurisdictions.stream().map(Jurisdiction::getId).collect(toList());
+    }
+}

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/aggregated/DefaultGetUserProfileOperation.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/aggregated/DefaultGetUserProfileOperation.java
@@ -1,9 +1,12 @@
 package uk.gov.hmcts.ccd.domain.service.aggregated;
 
+import java.util.concurrent.CompletableFuture;
+
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.ccd.data.user.CachedUserRepository;
 import uk.gov.hmcts.ccd.data.user.UserRepository;
+import uk.gov.hmcts.ccd.data.user.UserService;
 import uk.gov.hmcts.ccd.domain.model.aggregated.UserProfile;
 import uk.gov.hmcts.ccd.endpoint.exceptions.ResourceNotFoundException;
 
@@ -11,18 +14,20 @@ import uk.gov.hmcts.ccd.endpoint.exceptions.ResourceNotFoundException;
 @Qualifier(DefaultGetUserProfileOperation.QUALIFIER)
 public class DefaultGetUserProfileOperation implements GetUserProfileOperation {
     public static final String QUALIFIER = "default";
-    private final UserRepository userRepository;
+    private final UserService userService;
 
-    public DefaultGetUserProfileOperation(@Qualifier(CachedUserRepository.QUALIFIER) final UserRepository userRepository) {
-        this.userRepository = userRepository;
+    public DefaultGetUserProfileOperation(final UserService userService) {
+        this.userService = userService;
     }
 
     @Override
-    public UserProfile execute(final String userToken) {
-        final UserProfile userProfile = userRepository.getUserSettings();
-        if (userProfile == null) {
-            throw new ResourceNotFoundException("No such user");
-        }
+    public CompletableFuture<UserProfile> execute(final String userToken) {
+        final CompletableFuture<UserProfile> userProfile = userService.getUserProfileAsync().thenApply(profile -> {
+
+                throw new ResourceNotFoundException("No such user");
+
+
+        });
         return userProfile;
     }
 }

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/aggregated/DefaultGetUserProfileOperation.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/aggregated/DefaultGetUserProfileOperation.java
@@ -4,11 +4,8 @@ import java.util.concurrent.CompletableFuture;
 
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
-import uk.gov.hmcts.ccd.data.user.CachedUserRepository;
-import uk.gov.hmcts.ccd.data.user.UserRepository;
 import uk.gov.hmcts.ccd.data.user.UserService;
 import uk.gov.hmcts.ccd.domain.model.aggregated.UserProfile;
-import uk.gov.hmcts.ccd.endpoint.exceptions.ResourceNotFoundException;
 
 @Service
 @Qualifier(DefaultGetUserProfileOperation.QUALIFIER)
@@ -22,12 +19,6 @@ public class DefaultGetUserProfileOperation implements GetUserProfileOperation {
 
     @Override
     public CompletableFuture<UserProfile> execute(final String userToken) {
-        final CompletableFuture<UserProfile> userProfile = userService.getUserProfileAsync().thenApply(profile -> {
-
-                throw new ResourceNotFoundException("No such user");
-
-
-        });
-        return userProfile;
+        return userService.getUserProfileAsync();
     }
 }

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/aggregated/GetUserProfileOperation.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/aggregated/GetUserProfileOperation.java
@@ -1,7 +1,9 @@
 package uk.gov.hmcts.ccd.domain.service.aggregated;
 
+import java.util.concurrent.CompletableFuture;
+
 import uk.gov.hmcts.ccd.domain.model.aggregated.UserProfile;
 
 public interface GetUserProfileOperation {
-    UserProfile execute(String userToken);
+    CompletableFuture<UserProfile> execute(String userToken);
 }

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/createcase/DefaultCreateCaseOperation.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/createcase/DefaultCreateCaseOperation.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.ccd.data.definition.CachedCaseDefinitionRepository;
 import uk.gov.hmcts.ccd.data.definition.CaseDefinitionRepository;
 import uk.gov.hmcts.ccd.data.user.CachedUserRepository;
+import uk.gov.hmcts.ccd.data.user.DefaultUserRepository;
 import uk.gov.hmcts.ccd.data.user.UserRepository;
 import uk.gov.hmcts.ccd.domain.model.aggregated.IDAMProperties;
 import uk.gov.hmcts.ccd.domain.model.callbacks.AfterSubmitCallbackResponse;
@@ -44,7 +45,7 @@ public class DefaultCreateCaseOperation implements CreateCaseOperation {
     private final ValidateCaseFieldsOperation validateCaseFieldsOperation;
 
     @Inject
-    public DefaultCreateCaseOperation(@Qualifier(CachedUserRepository.QUALIFIER) final UserRepository userRepository,
+    public DefaultCreateCaseOperation(@Qualifier(DefaultUserRepository.QUALIFIER) final UserRepository userRepository,
                                       @Qualifier(CachedCaseDefinitionRepository.QUALIFIER) final CaseDefinitionRepository caseDefinitionRepository,
                                       final EventTriggerService eventTriggerService,
                                       final EventTokenService eventTokenService,

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/createcase/DefaultCreateCaseOperation.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/createcase/DefaultCreateCaseOperation.java
@@ -6,7 +6,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.ccd.data.definition.CachedCaseDefinitionRepository;
 import uk.gov.hmcts.ccd.data.definition.CaseDefinitionRepository;
-import uk.gov.hmcts.ccd.data.user.CachedUserRepository;
 import uk.gov.hmcts.ccd.data.user.DefaultUserRepository;
 import uk.gov.hmcts.ccd.data.user.UserRepository;
 import uk.gov.hmcts.ccd.domain.model.aggregated.IDAMProperties;

--- a/src/main/java/uk/gov/hmcts/ccd/endpoint/exceptions/RestExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/ccd/endpoint/exceptions/RestExceptionHandler.java
@@ -54,8 +54,6 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
     @ExceptionHandler(CompletionException.class)
     @ResponseBody
     public ResponseEntity<HttpError> handleCompletionException(final HttpServletRequest request, final CompletionException exception) {
-        LOG.error("data store request processing exception", exception);
-
         Throwable cause = exception.getCause();
         if (cause instanceof ApiException) {
             return handleApiException(request, (ApiException) cause);

--- a/src/main/java/uk/gov/hmcts/ccd/endpoint/exceptions/RestExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/ccd/endpoint/exceptions/RestExceptionHandler.java
@@ -13,6 +13,7 @@ import uk.gov.hmcts.ccd.domain.model.common.HttpError;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.Serializable;
+import java.util.concurrent.CompletionException;
 
 @ControllerAdvice
 public class RestExceptionHandler extends ResponseEntityExceptionHandler {
@@ -28,7 +29,7 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
     @ExceptionHandler(ApiException.class)
     @ResponseBody
     public ResponseEntity<HttpError> handleApiException(final HttpServletRequest request, final ApiException exception) {
-        LOG.error(exception.getMessage(), exception);
+        LOG.warn("data store request processing api exception", exception);
         appInsights.trackException(exception);
         final HttpError<Serializable> error = new HttpError<>(exception, request)
             .withDetails(exception.getDetails())
@@ -42,11 +43,25 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
     @ExceptionHandler(Exception.class)
     @ResponseBody
     public ResponseEntity<HttpError> handleException(final HttpServletRequest request, final Exception exception) {
-        LOG.error(exception.getMessage(), exception);
+        LOG.error("data store request processing exception", exception);
         appInsights.trackException(exception);
         final HttpError<Serializable> error = new HttpError<>(exception, request);
         return ResponseEntity
             .status(error.getStatus())
             .body(error);
+    }
+
+    @ExceptionHandler(CompletionException.class)
+    @ResponseBody
+    public ResponseEntity<HttpError> handleCompletionException(final HttpServletRequest request, final CompletionException exception) {
+        LOG.error("data store request processing exception", exception);
+
+        Throwable cause = exception.getCause();
+        if (cause instanceof ApiException) {
+            return handleApiException(request, (ApiException) cause);
+        } else if (cause instanceof Exception) {
+            return handleException(request, (Exception) cause);
+        }
+        return ResponseEntity.status(new HttpError<>(exception, request).getStatus()).build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/ccd/endpoint/ui/UserProfileEndpoint.java
+++ b/src/main/java/uk/gov/hmcts/ccd/endpoint/ui/UserProfileEndpoint.java
@@ -16,6 +16,8 @@ import javax.transaction.Transactional;
 
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
+import java.util.concurrent.Future;
+
 @RestController
 public class UserProfileEndpoint {
     private static final String BEARER = "Bearer ";
@@ -30,7 +32,7 @@ public class UserProfileEndpoint {
     @RequestMapping(value = "/caseworkers/{uid}/profile", method = RequestMethod.GET)
     @ApiOperation(value = "Get default setting for user")
     @ApiResponse(code = 200, message = "User default settings")
-    public UserProfile getUserProfile(@RequestHeader(value = AUTHORIZATION) final String authHeader) {
+    public Future<UserProfile> getUserProfile(@RequestHeader(value = AUTHORIZATION) final String authHeader) {
         final String userToken = authHeader.substring(BEARER.length());
         return getUserProfileOperation.execute(userToken);
     }

--- a/src/main/java/uk/gov/hmcts/ccd/endpoint/ui/UserProfileEndpoint.java
+++ b/src/main/java/uk/gov/hmcts/ccd/endpoint/ui/UserProfileEndpoint.java
@@ -16,8 +16,6 @@ import javax.transaction.Transactional;
 
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
-import java.util.concurrent.Future;
-
 @RestController
 public class UserProfileEndpoint {
     private static final String BEARER = "Bearer ";
@@ -32,8 +30,8 @@ public class UserProfileEndpoint {
     @RequestMapping(value = "/caseworkers/{uid}/profile", method = RequestMethod.GET)
     @ApiOperation(value = "Get default setting for user")
     @ApiResponse(code = 200, message = "User default settings")
-    public Future<UserProfile> getUserProfile(@RequestHeader(value = AUTHORIZATION) final String authHeader) {
+    public UserProfile getUserProfile(@RequestHeader(value = AUTHORIZATION) final String authHeader) {
         final String userToken = authHeader.substring(BEARER.length());
-        return getUserProfileOperation.execute(userToken);
+        return getUserProfileOperation.execute(userToken).join();
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,6 +18,10 @@ liquibase.change-log=classpath:/db/changelog/db.changelog-master.xml
 #ttl of cached definitions in seconds
 definition.cache.ttl.secs=${DEFINITION_CACHE_TTL_SEC:1800}
 
+#size of the thread pool dedicated to the execution of async tasks
+async.core.pool.size=${ASYNC_CORE_POOL_SIZE:4}
+async.max.pool.size=${ASYNC_MAX_POOL_SIZE:4}
+
 # Jackson ObjectMapper configuration
 spring.jackson.serialization.WRITE_DATES_AS_TIMESTAMPS=false
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,8 +19,8 @@ liquibase.change-log=classpath:/db/changelog/db.changelog-master.xml
 definition.cache.ttl.secs=${DEFINITION_CACHE_TTL_SEC:1800}
 
 #size of the thread pool dedicated to the execution of async tasks
-async.core.pool.size=${ASYNC_CORE_POOL_SIZE:4}
-async.max.pool.size=${ASYNC_MAX_POOL_SIZE:4}
+async.core.pool.size=${ASYNC_CORE_POOL_SIZE:15}
+async.max.pool.size=${ASYNC_MAX_POOL_SIZE:15}
 
 # Jackson ObjectMapper configuration
 spring.jackson.serialization.WRITE_DATES_AS_TIMESTAMPS=false

--- a/src/test/java/uk/gov/hmcts/ccd/BaseTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/BaseTest.java
@@ -23,7 +23,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.hmcts.ccd.data.SecurityUtils;
 import uk.gov.hmcts.ccd.data.casedetails.SecurityClassification;
-import uk.gov.hmcts.ccd.data.definition.CaseDefinitionRepository;
 import uk.gov.hmcts.ccd.data.definition.DefaultCaseDefinitionRepository;
 import uk.gov.hmcts.ccd.data.definition.HttpUIDefinitionGateway;
 import uk.gov.hmcts.ccd.data.user.DefaultUserRepository;
@@ -76,8 +75,7 @@ public abstract class BaseTest {
     @Inject
     protected UIDService uidService;
     @Inject
-    @Qualifier(DefaultCaseDefinitionRepository.QUALIFIER)
-    private CaseDefinitionRepository caseDefinitionRepository;
+    private DefaultCaseDefinitionRepository caseDefinitionRepository;
     @Inject
     private HttpUIDefinitionGateway uiDefinitionRepository;
     @Inject

--- a/src/test/java/uk/gov/hmcts/ccd/TestConfiguration.java
+++ b/src/test/java/uk/gov/hmcts/ccd/TestConfiguration.java
@@ -27,6 +27,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 @Configuration
@@ -110,6 +111,7 @@ class TestConfiguration extends ContextCleanupListener {
         when(caseDefinitionRepository.getCaseTypesForJurisdiction(any())).thenCallRealMethod();
         when(caseDefinitionRepository.getBaseTypes()).thenReturn(Arrays.asList(fieldTypes));
         when(caseDefinitionRepository.getUserRoleClassifications(any())).thenCallRealMethod();
+        when(caseDefinitionRepository.getAllJurisdictions()).thenCallRealMethod();
         return caseDefinitionRepository;
     }
 

--- a/src/test/java/uk/gov/hmcts/ccd/TestConfiguration.java
+++ b/src/test/java/uk/gov/hmcts/ccd/TestConfiguration.java
@@ -112,6 +112,7 @@ class TestConfiguration extends ContextCleanupListener {
         when(caseDefinitionRepository.getBaseTypes()).thenReturn(Arrays.asList(fieldTypes));
         when(caseDefinitionRepository.getUserRoleClassifications(any())).thenCallRealMethod();
         when(caseDefinitionRepository.getAllJurisdictions()).thenCallRealMethod();
+        when(caseDefinitionRepository.getAllJurisdictionsAsync()).thenCallRealMethod();
         return caseDefinitionRepository;
     }
 

--- a/src/test/java/uk/gov/hmcts/ccd/WireMockBaseTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/WireMockBaseTest.java
@@ -52,7 +52,6 @@ public abstract class WireMockBaseTest extends BaseTest {
 
     protected void stupApiCalls() throws IOException {
         stubGetWizardPageStructure();
-        stubGetDefinitionVersion();
     }
 
     private void stubGetWizardPageStructure() throws IOException {
@@ -62,13 +61,5 @@ public abstract class WireMockBaseTest extends BaseTest {
         wireMockRule.stubFor(WireMock.get(urlMatching("/api/display/wizard-page-structure.*"))
                                      .willReturn(okJson(mapper.writeValueAsString(wizardStructureResponse)).withStatus(
                                              200)));
-    }
-
-    private void stubGetDefinitionVersion() throws JsonProcessingException {
-        CaseTypeDefinitionVersion stubDefinitionVersion = new CaseTypeDefinitionVersion();
-        stubDefinitionVersion.setVersion(33);
-        wireMockRule.stubFor(WireMock.get(urlMatching("/api/data/case-type/.*/version"))
-                .willReturn(okJson(mapper.writeValueAsString(stubDefinitionVersion)).withStatus(
-                        200)));
     }
 }

--- a/src/test/java/uk/gov/hmcts/ccd/WireMockBaseTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/WireMockBaseTest.java
@@ -41,6 +41,7 @@ public abstract class WireMockBaseTest extends BaseTest {
         final String hostUrl = "http://localhost:" + port;
         LOG.info("Wire mock test, host url is {}", hostUrl);
 
+        //FIXME can this be replaced with json stubs like we have for other calls?
         stupApiCalls();
 
         ReflectionTestUtils.setField(applicationParams, "caseDefinitionHost", hostUrl);

--- a/src/test/java/uk/gov/hmcts/ccd/WireMockBaseTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/WireMockBaseTest.java
@@ -41,25 +41,9 @@ public abstract class WireMockBaseTest extends BaseTest {
         final String hostUrl = "http://localhost:" + port;
         LOG.info("Wire mock test, host url is {}", hostUrl);
 
-        //FIXME can this be replaced with json stubs like we have for other calls?
-        stupApiCalls();
-
         ReflectionTestUtils.setField(applicationParams, "caseDefinitionHost", hostUrl);
         ReflectionTestUtils.setField(applicationParams, "uiDefinitionHost", hostUrl);
         ReflectionTestUtils.setField(applicationParams, "idamHost", hostUrl);
         ReflectionTestUtils.setField(applicationParams, "userProfileHost", hostUrl);
-    }
-
-    protected void stupApiCalls() throws IOException {
-        stubGetWizardPageStructure();
-    }
-
-    private void stubGetWizardPageStructure() throws IOException {
-        final JsonNode WIZARD_DATA = mapper.readTree(
-            "{\"wizard_pages\": [\n {\n \"id\": \"createCaseInfoPage\",\n \"label\": \"Required Information1\",\n \"order\": 1,\n \"wizard_page_fields\": [\n {\n \"case_field_id\": \"PersonFirstName\",\n \"order\": 1\n },\n {\n \"case_field_id\": \"PersonLastNameWithValidation\",\n \"order\": 2\n }\n ]\n }\n ]}");
-        wizardStructureResponse.setData(mapper.convertValue(WIZARD_DATA, STRING_NODE_TYPE));
-        wireMockRule.stubFor(WireMock.get(urlMatching("/api/display/wizard-page-structure.*"))
-                                     .willReturn(okJson(mapper.writeValueAsString(wizardStructureResponse)).withStatus(
-                                             200)));
     }
 }

--- a/src/test/java/uk/gov/hmcts/ccd/data/casedetails/DefaultCaseDetailsRepositoryTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/data/casedetails/DefaultCaseDetailsRepositoryTest.java
@@ -20,7 +20,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 
-import static org.apache.logging.log4j.ThreadContext.isEmpty;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;

--- a/src/test/java/uk/gov/hmcts/ccd/data/definition/DefaultCaseDefinitionRepositoryIT.java
+++ b/src/test/java/uk/gov/hmcts/ccd/data/definition/DefaultCaseDefinitionRepositoryIT.java
@@ -1,20 +1,5 @@
 package uk.gov.hmcts.ccd.data.definition;
 
-import jdk.nashorn.internal.runtime.options.Option;
-import org.assertj.core.util.Lists;
-import org.hamcrest.collection.IsCollectionWithSize;
-import org.junit.Ignore;
-import org.junit.Test;
-import uk.gov.hmcts.ccd.WireMockBaseTest;
-import uk.gov.hmcts.ccd.domain.model.definition.CaseType;
-import uk.gov.hmcts.ccd.domain.model.definition.FieldType;
-import uk.gov.hmcts.ccd.domain.model.definition.UserRole;
-
-import javax.inject.Inject;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
@@ -24,9 +9,22 @@ import static org.hamcrest.beans.HasPropertyWithValue.hasProperty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-public class CaseDefinitionRepositoryTest extends WireMockBaseTest {
+import java.util.List;
+import javax.inject.Inject;
+
+import org.hamcrest.collection.IsCollectionWithSize;
+import org.junit.Test;
+import uk.gov.hmcts.ccd.WireMockBaseTest;
+import uk.gov.hmcts.ccd.domain.model.definition.CaseType;
+import uk.gov.hmcts.ccd.domain.model.definition.FieldType;
+import uk.gov.hmcts.ccd.domain.model.definition.Jurisdiction;
+import uk.gov.hmcts.ccd.domain.model.definition.UserRole;
+
+public class DefaultCaseDefinitionRepositoryIT extends WireMockBaseTest {
+
+    //NOTE: caseDefinitionRepository is a mock configured in TestConfiguration to call some of the real methods
     @Inject
-    private CaseDefinitionRepository caseDefinitionRepository;
+    private DefaultCaseDefinitionRepository caseDefinitionRepository;
 
     @Test
     public void shouldGetCaseTypesForJurisdiction() {
@@ -80,5 +78,17 @@ public class CaseDefinitionRepositoryTest extends WireMockBaseTest {
     public void shouldReturnNullWhenNoClassificationFound() {
         final UserRole userRole = caseDefinitionRepository.getUserRoleClassifications("caseworker-probate-loa0");
         assertThat(userRole, is(nullValue()));
+    }
+
+    @Test
+    public void shouldGetJurisdictionsDefinition() {
+
+        List<Jurisdiction> allJurisdictions = caseDefinitionRepository.getAllJurisdictions();
+
+        assertAll(
+                () -> assertThat(allJurisdictions, hasSize(2)),
+                () -> assertThat(allJurisdictions, hasItem(hasProperty("name", is("JUR1")))),
+                () -> assertThat(allJurisdictions, hasItem(hasProperty("name", is("JUR2"))))
+        );
     }
 }

--- a/src/test/java/uk/gov/hmcts/ccd/data/definition/DefaultCaseDefinitionRepositoryIT.java
+++ b/src/test/java/uk/gov/hmcts/ccd/data/definition/DefaultCaseDefinitionRepositoryIT.java
@@ -86,9 +86,9 @@ public class DefaultCaseDefinitionRepositoryIT extends WireMockBaseTest {
         List<Jurisdiction> allJurisdictions = caseDefinitionRepository.getAllJurisdictions();
 
         assertAll(
-                () -> assertThat(allJurisdictions, hasSize(2)),
-                () -> assertThat(allJurisdictions, hasItem(hasProperty("name", is("JUR1")))),
-                () -> assertThat(allJurisdictions, hasItem(hasProperty("name", is("JUR2"))))
+                () -> assertThat(allJurisdictions, hasSize(3)),
+                () -> assertThat(allJurisdictions, hasItem(hasProperty("id", is("SSCS")))),
+                () -> assertThat(allJurisdictions, hasItem(hasProperty("id", is("PROBATE"))))
         );
     }
 }

--- a/src/test/java/uk/gov/hmcts/ccd/data/user/CachedUserRepositoryTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/data/user/CachedUserRepositoryTest.java
@@ -42,13 +42,13 @@ class CachedUserRepositoryTest {
         @DisplayName("should initially retrieve user settings from decorated repository")
         void shouldRetrieveUserSettingsFromDecorated () {
             final UserProfile expectedUserSettings = new UserProfile();
-            doReturn(expectedUserSettings).when(userRepository).getUserSettings();
+            doReturn(expectedUserSettings).when(userRepository).getUserProfile();
 
-            final UserProfile userSettings = cachedUserRepository.getUserSettings();
+            final UserProfile userSettings = cachedUserRepository.getUserProfile();
 
             assertAll(
                 () -> assertThat(userSettings, is(expectedUserSettings)),
-                () -> verify(userRepository, times(1)).getUserSettings()
+                () -> verify(userRepository, times(1)).getUserProfile()
             );
         }
 
@@ -56,15 +56,15 @@ class CachedUserRepositoryTest {
         @DisplayName("should cache user settings for subsequent calls")
         void shouldCacheUserSettingsForSubsequentCalls () {
             final UserProfile expectedUserSettings = new UserProfile();
-            doReturn(expectedUserSettings).when(userRepository).getUserSettings();
+            doReturn(expectedUserSettings).when(userRepository).getUserProfile();
 
-            cachedUserRepository.getUserSettings();
+            cachedUserRepository.getUserProfile();
 
-            verify(userRepository, times(1)).getUserSettings();
+            verify(userRepository, times(1)).getUserProfile();
 
-            doReturn(new UserProfile()).when(userRepository).getUserSettings();
+            doReturn(new UserProfile()).when(userRepository).getUserProfile();
 
-            final UserProfile userSettings = cachedUserRepository.getUserSettings();
+            final UserProfile userSettings = cachedUserRepository.getUserProfile();
 
             assertAll(
                 () -> assertThat(userSettings, is(expectedUserSettings)),

--- a/src/test/java/uk/gov/hmcts/ccd/data/user/CachedUserRepositoryTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/data/user/CachedUserRepositoryTest.java
@@ -35,45 +35,6 @@ class CachedUserRepositoryTest {
     }
 
     @Nested
-    @DisplayName("getUserSettings()")
-    class getUserSettings {
-
-//        @Test
-//        @DisplayName("should initially retrieve user settings from decorated repository")
-//        void shouldRetrieveUserSettingsFromDecorated () {
-//            final UserProfile expectedUserSettings = new UserProfile();
-//            doReturn(expectedUserSettings).when(userRepository).getUserProfile();
-//
-//            final UserProfile userSettings = cachedUserRepository.getUserProfile();
-//
-//            assertAll(
-//                () -> assertThat(userSettings, is(expectedUserSettings)),
-//                () -> verify(userRepository, times(1)).getUserProfile()
-//            );
-//        }
-//
-//        @Test
-//        @DisplayName("should cache user settings for subsequent calls")
-//        void shouldCacheUserSettingsForSubsequentCalls () {
-//            final UserProfile expectedUserSettings = new UserProfile();
-//            doReturn(expectedUserSettings).when(userRepository).getUserProfile();
-//
-//            cachedUserRepository.getUserProfile();
-//
-//            verify(userRepository, times(1)).getUserProfile();
-//
-//            doReturn(new UserProfile()).when(userRepository).getUserProfile();
-//
-//            final UserProfile userSettings = cachedUserRepository.getUserProfile();
-//
-//            assertAll(
-//                () -> assertThat(userSettings, is(expectedUserSettings)),
-//                () -> verifyNoMoreInteractions(userRepository)
-//            );
-//        }
-    }
-
-    @Nested
     @DisplayName("getUserDetails()")
     class getUserDetails {
 

--- a/src/test/java/uk/gov/hmcts/ccd/data/user/CachedUserRepositoryTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/data/user/CachedUserRepositoryTest.java
@@ -38,39 +38,39 @@ class CachedUserRepositoryTest {
     @DisplayName("getUserSettings()")
     class getUserSettings {
 
-        @Test
-        @DisplayName("should initially retrieve user settings from decorated repository")
-        void shouldRetrieveUserSettingsFromDecorated () {
-            final UserProfile expectedUserSettings = new UserProfile();
-            doReturn(expectedUserSettings).when(userRepository).getUserProfile();
-
-            final UserProfile userSettings = cachedUserRepository.getUserProfile();
-
-            assertAll(
-                () -> assertThat(userSettings, is(expectedUserSettings)),
-                () -> verify(userRepository, times(1)).getUserProfile()
-            );
-        }
-
-        @Test
-        @DisplayName("should cache user settings for subsequent calls")
-        void shouldCacheUserSettingsForSubsequentCalls () {
-            final UserProfile expectedUserSettings = new UserProfile();
-            doReturn(expectedUserSettings).when(userRepository).getUserProfile();
-
-            cachedUserRepository.getUserProfile();
-
-            verify(userRepository, times(1)).getUserProfile();
-
-            doReturn(new UserProfile()).when(userRepository).getUserProfile();
-
-            final UserProfile userSettings = cachedUserRepository.getUserProfile();
-
-            assertAll(
-                () -> assertThat(userSettings, is(expectedUserSettings)),
-                () -> verifyNoMoreInteractions(userRepository)
-            );
-        }
+//        @Test
+//        @DisplayName("should initially retrieve user settings from decorated repository")
+//        void shouldRetrieveUserSettingsFromDecorated () {
+//            final UserProfile expectedUserSettings = new UserProfile();
+//            doReturn(expectedUserSettings).when(userRepository).getUserProfile();
+//
+//            final UserProfile userSettings = cachedUserRepository.getUserProfile();
+//
+//            assertAll(
+//                () -> assertThat(userSettings, is(expectedUserSettings)),
+//                () -> verify(userRepository, times(1)).getUserProfile()
+//            );
+//        }
+//
+//        @Test
+//        @DisplayName("should cache user settings for subsequent calls")
+//        void shouldCacheUserSettingsForSubsequentCalls () {
+//            final UserProfile expectedUserSettings = new UserProfile();
+//            doReturn(expectedUserSettings).when(userRepository).getUserProfile();
+//
+//            cachedUserRepository.getUserProfile();
+//
+//            verify(userRepository, times(1)).getUserProfile();
+//
+//            doReturn(new UserProfile()).when(userRepository).getUserProfile();
+//
+//            final UserProfile userSettings = cachedUserRepository.getUserProfile();
+//
+//            assertAll(
+//                () -> assertThat(userSettings, is(expectedUserSettings)),
+//                () -> verifyNoMoreInteractions(userRepository)
+//            );
+//        }
     }
 
     @Nested

--- a/src/test/java/uk/gov/hmcts/ccd/data/user/UserRepositoryTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/data/user/UserRepositoryTest.java
@@ -13,6 +13,7 @@ import org.springframework.web.client.RestTemplate;
 import uk.gov.hmcts.ccd.ApplicationParams;
 import uk.gov.hmcts.ccd.MockUtils;
 import uk.gov.hmcts.ccd.data.SecurityUtils;
+import uk.gov.hmcts.ccd.data.casedetails.JurisdictionMapper;
 import uk.gov.hmcts.ccd.data.casedetails.SecurityClassification;
 import uk.gov.hmcts.ccd.data.definition.CaseDefinitionRepository;
 import uk.gov.hmcts.ccd.domain.model.definition.UserRole;
@@ -54,6 +55,8 @@ public class UserRepositoryTest {
     @Mock
     private SecurityContext securityContext;
 
+    private JurisdictionMapper jurisdictionMapper;
+
     private UserRepository userRepository;
 
     @BeforeEach
@@ -64,7 +67,7 @@ public class UserRepositoryTest {
         SecurityContextHolder.setContext(securityContext);
 
         userRepository = spy(new DefaultUserRepository(applicationParams,
-                                                       caseDefinitionRepository, securityUtils, restTemplate));
+                                                       caseDefinitionRepository, securityUtils, restTemplate, jurisdictionMapper));
     }
 
     @Nested

--- a/src/test/java/uk/gov/hmcts/ccd/data/user/UserRepositoryTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/data/user/UserRepositoryTest.java
@@ -13,7 +13,6 @@ import org.springframework.web.client.RestTemplate;
 import uk.gov.hmcts.ccd.ApplicationParams;
 import uk.gov.hmcts.ccd.MockUtils;
 import uk.gov.hmcts.ccd.data.SecurityUtils;
-import uk.gov.hmcts.ccd.data.casedetails.JurisdictionMapper;
 import uk.gov.hmcts.ccd.data.casedetails.SecurityClassification;
 import uk.gov.hmcts.ccd.data.definition.CaseDefinitionRepository;
 import uk.gov.hmcts.ccd.domain.model.definition.UserRole;

--- a/src/test/java/uk/gov/hmcts/ccd/data/user/UserRepositoryTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/data/user/UserRepositoryTest.java
@@ -55,8 +55,6 @@ public class UserRepositoryTest {
     @Mock
     private SecurityContext securityContext;
 
-    private JurisdictionMapper jurisdictionMapper;
-
     private UserRepository userRepository;
 
     @BeforeEach

--- a/src/test/java/uk/gov/hmcts/ccd/data/user/UserRepositoryTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/data/user/UserRepositoryTest.java
@@ -67,7 +67,7 @@ public class UserRepositoryTest {
         SecurityContextHolder.setContext(securityContext);
 
         userRepository = spy(new DefaultUserRepository(applicationParams,
-                                                       caseDefinitionRepository, securityUtils, restTemplate, jurisdictionMapper));
+                                                       caseDefinitionRepository, securityUtils, restTemplate));
     }
 
     @Nested

--- a/src/test/java/uk/gov/hmcts/ccd/data/user/UserServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/data/user/UserServiceTest.java
@@ -1,0 +1,96 @@
+package uk.gov.hmcts.ccd.data.user;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import uk.gov.hmcts.ccd.data.casedetails.JurisdictionMapper;
+import uk.gov.hmcts.ccd.data.definition.CaseDefinitionRepository;
+import uk.gov.hmcts.ccd.domain.model.aggregated.IDAMProperties;
+import uk.gov.hmcts.ccd.domain.model.aggregated.JurisdictionDisplayProperties;
+import uk.gov.hmcts.ccd.domain.model.aggregated.UserDefault;
+import uk.gov.hmcts.ccd.domain.model.aggregated.UserProfile;
+import uk.gov.hmcts.ccd.domain.model.aggregated.WorkbasketDefault;
+import uk.gov.hmcts.ccd.domain.model.definition.Jurisdiction;
+
+public class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepoMock;
+    @Mock
+    private CaseDefinitionRepository caseDefinitionRepoMock;
+    @Mock
+    private JurisdictionMapper jurisdictionMapperMock;
+    @Mock
+    private IDAMProperties mockIDAMProps;
+    @Mock
+    private JurisdictionDisplayProperties jdp1;
+    @Mock
+    private JurisdictionDisplayProperties jdp2;
+
+    private Jurisdiction j1;
+    private Jurisdiction j2;
+    private Jurisdiction unknownJurisdiction;
+    private UserService userService;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        userService = new UserService(userRepoMock, caseDefinitionRepoMock, jurisdictionMapperMock);
+        when(mockIDAMProps.getEmail()).thenReturn("email");
+        initialiseJurisdictions();
+    }
+
+    @Test
+    public void testReturnsUserProfileDiscardingUnknownJurisdictions() {
+
+        when(userRepoMock.getUserDetailsAsync()).thenReturn(CompletableFuture.completedFuture(mockIDAMProps));
+        UserDefault userDefaultMock = aUserDefault();
+        when(userRepoMock.getUserDefaultSettingsAsync("email")).thenReturn(CompletableFuture.completedFuture(userDefaultMock));
+        CompletableFuture<List<Jurisdiction>> jurisdictionsDef = CompletableFuture.completedFuture(newArrayList(j1, j2));
+        when(caseDefinitionRepoMock.getAllJurisdictionsAsync()).thenReturn(jurisdictionsDef);
+        when(jurisdictionMapperMock.toResponse(j1)).thenReturn(jdp1);
+        when(jurisdictionMapperMock.toResponse(j2)).thenReturn(jdp2);
+
+        UserProfile userProfile = userService.getUserProfileAsync().join();
+
+        assertThat(userProfile.getUser().getIdamProperties(), is(mockIDAMProps));
+        assertThat(userProfile.getJurisdictions(), equalTo(new JurisdictionDisplayProperties[] {jdp1, jdp2}));
+        WorkbasketDefault workbasketDefault = userProfile.getDefaultSettings().getWorkbasketDefault();
+        assertThat(workbasketDefault.getJurisdictionId(), is("J1"));
+        assertThat(workbasketDefault.getCaseTypeId(), is("CT"));
+        assertThat(workbasketDefault.getStateId(), is("ST"));
+    }
+
+    private UserDefault aUserDefault() {
+        UserDefault userDefault = new UserDefault();
+        userDefault.setWorkBasketDefaultJurisdiction("J1");
+        userDefault.setWorkBasketDefaultCaseType("CT");
+        userDefault.setWorkBasketDefaultState("ST");
+        List<Jurisdiction> userJurisdictions = newArrayList(j1, j2, unknownJurisdiction);
+        userDefault.setJurisdictions(userJurisdictions);
+        return userDefault;
+    }
+
+    private void initialiseJurisdictions() {
+        j1 = new Jurisdiction();
+        j1.setId("J1");
+        j1.setName("J1Name");
+        j1.setDescription("Desc1");
+        j2 = new Jurisdiction();
+        j2.setId("J2");
+        j2.setName("J2Name");
+        j2.setDescription("Desc2");
+        unknownJurisdiction = new Jurisdiction();
+        unknownJurisdiction.setId("J3");
+    }
+}

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/aggregated/DefaultGetUserProfileOperationTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/aggregated/DefaultGetUserProfileOperationTest.java
@@ -15,6 +15,9 @@ import static org.junit.Assert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.doReturn;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
 public class DefaultGetUserProfileOperationTest {
 
     @Mock
@@ -39,22 +42,22 @@ public class DefaultGetUserProfileOperationTest {
         userProfile.setJurisdictions(new JurisdictionDisplayProperties[] {test1JurisdictionDisplayProperties, test2JurisdictionDisplayProperties});
         userProfile.setChannels(new String[] {test1Channel, test2Channel});
         userProfile.setDefaultSettings(testDefaultSettings);
-        doReturn(userProfile).when(userService).getUserProfileAsync();
-        //FIXME
+        doReturn(CompletableFuture.completedFuture(userProfile)).when(userService).getUserProfileAsync();
     }
 
     @Test
-    void shouldReturnUserProfile() {
-//        String userToken = "testToken";
-//
-//        UserProfile userProfile = defaultGetUserProfileOperation.execute(userToken);
-//
-//        assertAll(
-//            () -> assertThat(userProfile.getUser(), is(equalTo(user))),
-//            () -> assertThat(userProfile.getDefaultSettings(), is(equalTo(testDefaultSettings))),
-//            () -> assertThat(userProfile.getChannels(), arrayContainingInAnyOrder(test1Channel, test2Channel)),
-//            () -> assertThat(userProfile.getJurisdictions(), arrayContainingInAnyOrder(test1JurisdictionDisplayProperties, test2JurisdictionDisplayProperties))
-//        );
+    void shouldReturnUserProfile() throws ExecutionException, InterruptedException {
+        String userToken = "testToken";
+
+        CompletableFuture<UserProfile> userProfileFuture = defaultGetUserProfileOperation.execute(userToken);
+
+        UserProfile userProfile = userProfileFuture.get();
+        assertAll(
+            () -> assertThat(userProfile.getUser(), is(equalTo(user))),
+            () -> assertThat(userProfile.getDefaultSettings(), is(equalTo(testDefaultSettings))),
+            () -> assertThat(userProfile.getChannels(), arrayContainingInAnyOrder(test1Channel, test2Channel)),
+            () -> assertThat(userProfile.getJurisdictions(), arrayContainingInAnyOrder(test1JurisdictionDisplayProperties, test2JurisdictionDisplayProperties))
+        );
 
     }
 }

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/aggregated/DefaultGetUserProfileOperationTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/aggregated/DefaultGetUserProfileOperationTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import uk.gov.hmcts.ccd.data.user.UserRepository;
+import uk.gov.hmcts.ccd.data.user.UserService;
 import uk.gov.hmcts.ccd.domain.model.aggregated.*;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -17,7 +18,7 @@ import static org.mockito.Mockito.doReturn;
 public class DefaultGetUserProfileOperationTest {
 
     @Mock
-    private UserRepository userRepository;
+    private UserService userService;
 
     private DefaultGetUserProfileOperation defaultGetUserProfileOperation;
 
@@ -32,27 +33,28 @@ public class DefaultGetUserProfileOperationTest {
     @BeforeEach
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        defaultGetUserProfileOperation = new DefaultGetUserProfileOperation(userRepository);
+        defaultGetUserProfileOperation = new DefaultGetUserProfileOperation(userService);
 
         userProfile.setUser(user);
         userProfile.setJurisdictions(new JurisdictionDisplayProperties[] {test1JurisdictionDisplayProperties, test2JurisdictionDisplayProperties});
         userProfile.setChannels(new String[] {test1Channel, test2Channel});
         userProfile.setDefaultSettings(testDefaultSettings);
-        doReturn(userProfile).when(userRepository).getUserProfile();
+        doReturn(userProfile).when(userService).getUserProfileAsync();
+        //FIXME
     }
 
     @Test
     void shouldReturnUserProfile() {
-        String userToken = "testToken";
-
-        UserProfile userProfile = defaultGetUserProfileOperation.execute(userToken);
-
-        assertAll(
-            () -> assertThat(userProfile.getUser(), is(equalTo(user))),
-            () -> assertThat(userProfile.getDefaultSettings(), is(equalTo(testDefaultSettings))),
-            () -> assertThat(userProfile.getChannels(), arrayContainingInAnyOrder(test1Channel, test2Channel)),
-            () -> assertThat(userProfile.getJurisdictions(), arrayContainingInAnyOrder(test1JurisdictionDisplayProperties, test2JurisdictionDisplayProperties))
-        );
+//        String userToken = "testToken";
+//
+//        UserProfile userProfile = defaultGetUserProfileOperation.execute(userToken);
+//
+//        assertAll(
+//            () -> assertThat(userProfile.getUser(), is(equalTo(user))),
+//            () -> assertThat(userProfile.getDefaultSettings(), is(equalTo(testDefaultSettings))),
+//            () -> assertThat(userProfile.getChannels(), arrayContainingInAnyOrder(test1Channel, test2Channel)),
+//            () -> assertThat(userProfile.getJurisdictions(), arrayContainingInAnyOrder(test1JurisdictionDisplayProperties, test2JurisdictionDisplayProperties))
+//        );
 
     }
 }

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/aggregated/DefaultGetUserProfileOperationTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/aggregated/DefaultGetUserProfileOperationTest.java
@@ -38,7 +38,7 @@ public class DefaultGetUserProfileOperationTest {
         userProfile.setJurisdictions(new JurisdictionDisplayProperties[] {test1JurisdictionDisplayProperties, test2JurisdictionDisplayProperties});
         userProfile.setChannels(new String[] {test1Channel, test2Channel});
         userProfile.setDefaultSettings(testDefaultSettings);
-        doReturn(userProfile).when(userRepository).getUserSettings();
+        doReturn(userProfile).when(userRepository).getUserProfile();
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/ccd/endpoint/exceptions/RestExceptionHandlerIT.java
+++ b/src/test/java/uk/gov/hmcts/ccd/endpoint/exceptions/RestExceptionHandlerIT.java
@@ -1,0 +1,91 @@
+package uk.gov.hmcts.ccd.endpoint.exceptions;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.concurrent.CompletionException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import uk.gov.hmcts.ccd.AppInsights;
+import uk.gov.hmcts.ccd.endpoint.std.CaseDetailsEndpoint;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RestExceptionHandlerIT {
+
+    private static final String URL = "/caseworkers/uid/jurisdictions/jid/case-types/ctid/cases/cid/documents";
+    private static final MediaType JSON_CONTENT_TYPE = new MediaType(MediaType.APPLICATION_JSON.getType(), MediaType.APPLICATION_JSON.getSubtype(), Charset.forName("utf8"));
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private CaseDetailsEndpoint caseDetailsEndpoint;
+
+    @Mock
+    private AppInsights appInsights;
+
+    @Before
+    public void setup() {
+        this.mockMvc = MockMvcBuilders.standaloneSetup(caseDetailsEndpoint).setControllerAdvice(new RestExceptionHandler(appInsights)).build();
+    }
+
+    @DisplayName("CompletionException wrapping a ApiException should be unwrapped and handled as ApiException")
+    @Test
+    public void testCompletionExceptionsCausedByApiException() throws Exception {
+
+        when(caseDetailsEndpoint.getDocumentsForEvent("jid", "ctid", "cid")).thenThrow(new CompletionException(new ApiException("test exception")));
+
+        mockMvc.perform(get(URL).contentType(JSON_CONTENT_TYPE))
+                .andDo(print())
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.error").value("Unprocessable Entity"));
+    }
+
+    @DisplayName("CompletionException not wrapping a ApiException should be unwrapped and handled as Exception")
+    @Test
+    public void testCompletionExceptionsCausedByNotApiException() throws Exception {
+
+        when(caseDetailsEndpoint.getDocumentsForEvent("jid", "ctid", "cid")).thenThrow(new CompletionException(new IOException("test exception")));
+
+        mockMvc.perform(get(URL).contentType(JSON_CONTENT_TYPE))
+                .andDo(print())
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.error").value("Unexpected Error"));
+    }
+
+    @DisplayName("api exceptions should be handled an the configured error code should be returned")
+    @Test
+    public void testApiExceptionsAreHandled() throws Exception {
+
+        when(caseDetailsEndpoint.getDocumentsForEvent("jid", "ctid", "cid")).thenThrow(new BadRequestException("test exception"));
+
+        mockMvc.perform(get(URL).contentType(JSON_CONTENT_TYPE))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("Bad Request"));
+    }
+
+    @DisplayName("unknown exceptions should be handled as internal server error")
+    @Test
+    public void testUnknownExceptionsAreHandledAsInternalServerError() throws Exception {
+
+        when(caseDetailsEndpoint.getDocumentsForEvent("jid", "ctid", "cid")).thenThrow(new RuntimeException("test exception"));
+
+        mockMvc.perform(get(URL).contentType(JSON_CONTENT_TYPE))
+                .andDo(print())
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.error").value("Unexpected Error"));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/ccd/endpoint/ui/UserProfileEndpointTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/endpoint/ui/UserProfileEndpointTest.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.ccd.endpoint.ui;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -18,8 +20,12 @@ import javax.inject.Inject;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.concurrent.Future;
 
 public class UserProfileEndpointTest extends WireMockBaseTest {
     private static final String URL = "/caseworkers/user1/profile";
@@ -38,41 +44,43 @@ public class UserProfileEndpointTest extends WireMockBaseTest {
     public void validUser() throws Exception {
         final MvcResult result = mockMvc.perform(get(URL)
             .header(AUTHORIZATION, "Bearer user1"))
-            .andExpect(status().is(200))
+            .andExpect(request().asyncStarted())
             .andReturn();
 
-        final UserProfile userProfile = mapper.readValue(result.getResponse().getContentAsString(), UserProfile.class);
+        mockMvc.perform(asyncDispatch(result)).andExpect(status().is(200)).andDo(res -> {
+            final UserProfile userProfile = mapper.readValue(res.getResponse().getContentAsString(), UserProfile.class);
 
-        final IDAMProperties idamProperties = userProfile.getUser().getIdamProperties();
-        assertEquals("123", idamProperties.getId());
-        assertEquals("Cloud.Strife@test.com", idamProperties.getEmail());
-        assertEquals("Cloud", idamProperties.getForename());
-        assertEquals("Strife", idamProperties.getSurname());
-        assertEquals("caseworker", idamProperties.getRoles()[0]);
+            final IDAMProperties idamProperties = userProfile.getUser().getIdamProperties();
+            assertEquals("123", idamProperties.getId());
+            assertEquals("Cloud.Strife@test.com", idamProperties.getEmail());
+            assertEquals("Cloud", idamProperties.getForename());
+            assertEquals("Strife", idamProperties.getSurname());
+            assertEquals("caseworker", idamProperties.getRoles()[0]);
 
-        assertNull(userProfile.getChannels());
+            assertNull(userProfile.getChannels());
 
-        final JurisdictionDisplayProperties[] jurisdictions = userProfile.getJurisdictions();
-        assertEquals(3, jurisdictions.length);
+            final JurisdictionDisplayProperties[] jurisdictions = userProfile.getJurisdictions();
+            assertEquals(3, jurisdictions.length);
 
-        final JurisdictionDisplayProperties jurisdiction = jurisdictions[0];
-        assertEquals("PROBATE", jurisdiction.getId());
-        assertEquals("Test", jurisdiction.getName());
-        assertEquals("Test Jurisdiction", jurisdiction.getDescription());
+            final JurisdictionDisplayProperties jurisdiction = jurisdictions[0];
+            assertEquals("PROBATE", jurisdiction.getId());
+            assertEquals("Test", jurisdiction.getName());
+            assertEquals("Test Jurisdiction", jurisdiction.getDescription());
 
-        final WorkbasketDefault workbasketDefault = userProfile.getDefaultSettings().getWorkbasketDefault();
-        assertEquals("PROBATE", workbasketDefault.getJurisdictionId());
-        assertEquals("TestAddressBookCase", workbasketDefault.getCaseTypeId());
-        assertEquals("CaseCreated", workbasketDefault.getStateId());
+            final WorkbasketDefault workbasketDefault = userProfile.getDefaultSettings().getWorkbasketDefault();
+            assertEquals("PROBATE", workbasketDefault.getJurisdictionId());
+            assertEquals("TestAddressBookCase", workbasketDefault.getCaseTypeId());
+            assertEquals("CaseCreated", workbasketDefault.getStateId());
 
-        final JurisdictionDisplayProperties jurisdiction2 = jurisdictions[1];
-        assertEquals("DIVORCE", jurisdiction2.getId());
-        assertEquals("Test 2", jurisdiction2.getName());
-        assertEquals("Test Jurisdiction 2", jurisdiction2.getDescription());
+            final JurisdictionDisplayProperties jurisdiction2 = jurisdictions[1];
+            assertEquals("DIVORCE", jurisdiction2.getId());
+            assertEquals("Test 2", jurisdiction2.getName());
+            assertEquals("Test Jurisdiction 2", jurisdiction2.getDescription());
 
-        final JurisdictionDisplayProperties jurisdiction3 = jurisdictions[2];
-        assertEquals("SSCS", jurisdiction3.getId());
-        assertEquals("Test 3", jurisdiction3.getName());
-        assertEquals("Test Jurisdiction 3", jurisdiction3.getDescription());
+            final JurisdictionDisplayProperties jurisdiction3 = jurisdictions[2];
+            assertEquals("SSCS", jurisdiction3.getId());
+            assertEquals("Test 3", jurisdiction3.getName());
+            assertEquals("Test Jurisdiction 3", jurisdiction3.getDescription());
+        });
     }
 }

--- a/src/test/java/uk/gov/hmcts/ccd/endpoint/ui/UserProfileEndpointTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/endpoint/ui/UserProfileEndpointTest.java
@@ -1,9 +1,16 @@
 package uk.gov.hmcts.ccd.endpoint.ui;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.type.TypeFactory;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import javax.inject.Inject;
+
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -14,18 +21,6 @@ import uk.gov.hmcts.ccd.domain.model.aggregated.IDAMProperties;
 import uk.gov.hmcts.ccd.domain.model.aggregated.JurisdictionDisplayProperties;
 import uk.gov.hmcts.ccd.domain.model.aggregated.UserProfile;
 import uk.gov.hmcts.ccd.domain.model.aggregated.WorkbasketDefault;
-
-import javax.inject.Inject;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.util.concurrent.Future;
 
 public class UserProfileEndpointTest extends WireMockBaseTest {
     private static final String URL = "/caseworkers/user1/profile";

--- a/src/test/java/uk/gov/hmcts/ccd/endpoint/ui/UserProfileEndpointTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/endpoint/ui/UserProfileEndpointTest.java
@@ -1,16 +1,7 @@
 package uk.gov.hmcts.ccd.endpoint.ui;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import javax.inject.Inject;
-
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -21,6 +12,14 @@ import uk.gov.hmcts.ccd.domain.model.aggregated.IDAMProperties;
 import uk.gov.hmcts.ccd.domain.model.aggregated.JurisdictionDisplayProperties;
 import uk.gov.hmcts.ccd.domain.model.aggregated.UserProfile;
 import uk.gov.hmcts.ccd.domain.model.aggregated.WorkbasketDefault;
+
+import javax.inject.Inject;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class UserProfileEndpointTest extends WireMockBaseTest {
     private static final String URL = "/caseworkers/user1/profile";
@@ -39,43 +38,41 @@ public class UserProfileEndpointTest extends WireMockBaseTest {
     public void validUser() throws Exception {
         final MvcResult result = mockMvc.perform(get(URL)
             .header(AUTHORIZATION, "Bearer user1"))
-            .andExpect(request().asyncStarted())
+            .andExpect(status().is(200))
             .andReturn();
 
-        mockMvc.perform(asyncDispatch(result)).andExpect(status().is(200)).andDo(res -> {
-            final UserProfile userProfile = mapper.readValue(res.getResponse().getContentAsString(), UserProfile.class);
+        final UserProfile userProfile = mapper.readValue(result.getResponse().getContentAsString(), UserProfile.class);
 
-            final IDAMProperties idamProperties = userProfile.getUser().getIdamProperties();
-            assertEquals("123", idamProperties.getId());
-            assertEquals("Cloud.Strife@test.com", idamProperties.getEmail());
-            assertEquals("Cloud", idamProperties.getForename());
-            assertEquals("Strife", idamProperties.getSurname());
-            assertEquals("caseworker", idamProperties.getRoles()[0]);
+        final IDAMProperties idamProperties = userProfile.getUser().getIdamProperties();
+        assertEquals("123", idamProperties.getId());
+        assertEquals("Cloud.Strife@test.com", idamProperties.getEmail());
+        assertEquals("Cloud", idamProperties.getForename());
+        assertEquals("Strife", idamProperties.getSurname());
+        assertEquals("caseworker", idamProperties.getRoles()[0]);
 
-            assertNull(userProfile.getChannels());
+        assertNull(userProfile.getChannels());
 
-            final JurisdictionDisplayProperties[] jurisdictions = userProfile.getJurisdictions();
-            assertEquals(3, jurisdictions.length);
+        final JurisdictionDisplayProperties[] jurisdictions = userProfile.getJurisdictions();
+        assertEquals(3, jurisdictions.length);
 
-            final JurisdictionDisplayProperties jurisdiction = jurisdictions[0];
-            assertEquals("PROBATE", jurisdiction.getId());
-            assertEquals("Test", jurisdiction.getName());
-            assertEquals("Test Jurisdiction", jurisdiction.getDescription());
+        final JurisdictionDisplayProperties jurisdiction = jurisdictions[0];
+        assertEquals("PROBATE", jurisdiction.getId());
+        assertEquals("Test", jurisdiction.getName());
+        assertEquals("Test Jurisdiction", jurisdiction.getDescription());
 
-            final WorkbasketDefault workbasketDefault = userProfile.getDefaultSettings().getWorkbasketDefault();
-            assertEquals("PROBATE", workbasketDefault.getJurisdictionId());
-            assertEquals("TestAddressBookCase", workbasketDefault.getCaseTypeId());
-            assertEquals("CaseCreated", workbasketDefault.getStateId());
+        final WorkbasketDefault workbasketDefault = userProfile.getDefaultSettings().getWorkbasketDefault();
+        assertEquals("PROBATE", workbasketDefault.getJurisdictionId());
+        assertEquals("TestAddressBookCase", workbasketDefault.getCaseTypeId());
+        assertEquals("CaseCreated", workbasketDefault.getStateId());
 
-            final JurisdictionDisplayProperties jurisdiction2 = jurisdictions[1];
-            assertEquals("DIVORCE", jurisdiction2.getId());
-            assertEquals("Test 2", jurisdiction2.getName());
-            assertEquals("Test Jurisdiction 2", jurisdiction2.getDescription());
+        final JurisdictionDisplayProperties jurisdiction2 = jurisdictions[1];
+        assertEquals("DIVORCE", jurisdiction2.getId());
+        assertEquals("Test 2", jurisdiction2.getName());
+        assertEquals("Test Jurisdiction 2", jurisdiction2.getDescription());
 
-            final JurisdictionDisplayProperties jurisdiction3 = jurisdictions[2];
-            assertEquals("SSCS", jurisdiction3.getId());
-            assertEquals("Test 3", jurisdiction3.getName());
-            assertEquals("Test Jurisdiction 3", jurisdiction3.getDescription());
-        });
+        final JurisdictionDisplayProperties jurisdiction3 = jurisdictions[2];
+        assertEquals("SSCS", jurisdiction3.getId());
+        assertEquals("Test 3", jurisdiction3.getName());
+        assertEquals("Test Jurisdiction 3", jurisdiction3.getDescription());
     }
 }

--- a/src/test/resources/mappings/case-type-version.json
+++ b/src/test/resources/mappings/case-type-version.json
@@ -1,0 +1,15 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPattern": "/api/data/case-type/.*/version"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "version": "33"
+    }
+  }
+}

--- a/src/test/resources/mappings/jurisdictions.json
+++ b/src/test/resources/mappings/jurisdictions.json
@@ -10,16 +10,23 @@
     },
     "jsonBody": [
       {
-        "id": "123",
-        "name" : "JUR1",
-        "description" : "desc 1",
+        "id": "PROBATE",
+        "name" : "Test",
+        "description" : "Test Jurisdiction",
         "live_from": "2017-01-01",
         "live_until": "2017-01-01"
       },
       {
-        "id": "333",
-        "name" : "JUR2",
-        "description" : "desc 2",
+        "id": "DIVORCE",
+        "name" : "Test 2",
+        "description" : "Test Jurisdiction 2",
+        "live_from": "2017-01-01",
+        "live_until": "2017-01-01"
+      },
+      {
+        "id": "SSCS",
+        "name" : "Test 3",
+        "description" : "Test Jurisdiction 3",
         "live_from": "2017-01-01",
         "live_until": "2017-01-01"
       }

--- a/src/test/resources/mappings/jurisdictions.json
+++ b/src/test/resources/mappings/jurisdictions.json
@@ -1,0 +1,28 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "/api/data/jurisdictions"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": [
+      {
+        "id": "123",
+        "name" : "JUR1",
+        "description" : "desc 1",
+        "live_from": "2017-01-01",
+        "live_until": "2017-01-01"
+      },
+      {
+        "id": "333",
+        "name" : "JUR2",
+        "description" : "desc 2",
+        "live_from": "2017-01-01",
+        "live_until": "2017-01-01"
+      }
+    ]
+  }
+}

--- a/src/test/resources/mappings/wizard-page.json
+++ b/src/test/resources/mappings/wizard-page.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPattern": "/api/display/wizard-page-structure.*"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "wizard_pages": [
+        {
+          "id": "createCaseInfoPage",
+          "label" : "Required Information1",
+          "order": 1,
+          "wizard_page_fields" : [
+            {
+              "case_field_id" : "PersonFirstName",
+              "order": 1
+            },
+            {
+              "case_field_id" : "PersonLastNameWithValidation",
+              "order": 2
+            }
+          ],
+          "defaultService" : "ccd"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-1433

### Change description ###

- Updated Data Store to support async tasks
- Improved performance of /getUserProfile endpoint by parallelising external calls 
- Improved performance of /getUserProfile endpoint by retrieving only definition of jurisdicitions instead of all cases for all jurisdictions
- Simplified existing WireMockTests

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
⚠️ Asynchronous tasks for the moment are not compatible with request scoped beans, so for the moment can't be used together with cached repositories