### PR TITLE
RDM-1982 Timeout configuration applied to RestTemplate object

### DIFF
--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/callbacks/CallbackService.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/callbacks/CallbackService.java
@@ -119,6 +119,7 @@ public class CallbackService {
             requestFactory.setConnectionRequestTimeout(secondsToMilliseconds(timeout));
             requestFactory.setReadTimeout(secondsToMilliseconds(timeout));
             requestFactory.setConnectTimeout(secondsToMilliseconds(timeout));
+            restTemplate.setRequestFactory(requestFactory);
             return Optional.ofNullable(
                 restTemplate.exchange(url, HttpMethod.POST, requestEntity, clazz));
         } catch (RestClientException e) {

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/callbacks/CallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/callbacks/CallbackServiceTest.java
@@ -105,7 +105,8 @@ public class CallbackServiceTest {
 
         long duration = (endTime - startTime);
         final CallbackResponse response = result.orElseThrow(() -> new AssertionError("Missing result"));
-        assertTrue(duration/1000000 > 2500);
+        verify(exactly(2), postRequestedFor(urlMatching("/test-callback.*")));
+        assertTrue(duration/1_000_000 > 2500);
         assertTrue(response.getErrors().isEmpty());
     }
 

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/callbacks/CallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/callbacks/CallbackServiceTest.java
@@ -99,14 +99,10 @@ public class CallbackServiceTest {
         mockCallbackServer.stubFor(post(urlMatching("/test-callback.*"))
             .willReturn(okJson(mapper.writeValueAsString(callbackResponse)).withStatus(200).withFixedDelay(1500)));
 
-        long startTime = System.nanoTime();
         final Optional<CallbackResponse> result = callbackService.send(testUrl, null, caseEvent, caseDetails);
-        long endTime = System.nanoTime();
 
-        long duration = (endTime - startTime);
         final CallbackResponse response = result.orElseThrow(() -> new AssertionError("Missing result"));
         verify(exactly(2), postRequestedFor(urlMatching("/test-callback.*")));
-        assertTrue(duration/1_000_000 > 2500);
         assertTrue(response.getErrors().isEmpty());
     }
 


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RDM-1982

Timeout for callbacks were not applied. Added a fix for this and added a timeout test

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```