### PR TITLE
RDM-1448: Enforce user access at DB level

### DIFF
--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CachedCaseDetailsRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CachedCaseDetailsRepository.java
@@ -28,7 +28,7 @@ public class CachedCaseDetailsRepository implements CaseDetailsRepository {
     private static final String META_AND_FIELD_DATA_HASH_FORMAT = "%s%s";
 
     private final CaseDetailsRepository caseDetailsRepository;
-    private final Map<Long, CaseDetails> idToCaseDetails = newHashMap();
+    private final Map<Long, Optional<CaseDetails>> idToCaseDetails = newHashMap();
     private final Map<String, CaseDetails> referenceToCaseDetails = newHashMap();
     private final Map<String, CaseDetails> findHashToCaseDetails = newHashMap();
     private final Map<String, List<CaseDetails>> metaAndFieldDataHashToCaseDetails = newHashMap();
@@ -46,15 +46,13 @@ public class CachedCaseDetailsRepository implements CaseDetailsRepository {
 
     @Override
     public Optional<CaseDetails> findById(String jurisdiction, Long id) {
-        final Function<Long, CaseDetails> findCase = (key) -> caseDetailsRepository.findById(jurisdiction, id)
-                                                                                   .orElse(null);
-        return Optional.ofNullable(idToCaseDetails.computeIfAbsent(id, findCase))
-                       .filter(caseDetails -> jurisdiction.equals(caseDetails.getJurisdiction()));
+        return idToCaseDetails.computeIfAbsent(id, (key) -> caseDetailsRepository.findById(jurisdiction, id));
     }
 
     @Override
     public CaseDetails findById(final Long id) {
-        return idToCaseDetails.computeIfAbsent(id, caseDetailsRepository::findById);
+        return idToCaseDetails.computeIfAbsent(id, (key) -> Optional.ofNullable(caseDetailsRepository.findById(id)))
+                              .orElse(null);
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CachedCaseDetailsRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CachedCaseDetailsRepository.java
@@ -73,7 +73,9 @@ public class CachedCaseDetailsRepository implements CaseDetailsRepository {
         } else {
             final Optional<CaseDetails> optionalCaseDetails = caseDetailsRepository.findByReference(jurisdiction,
                                                                                                     reference);
-            referenceToCaseDetails.put(reference, optionalCaseDetails.orElse(null));
+
+            optionalCaseDetails.ifPresent(caseDetails -> referenceToCaseDetails.put(reference, caseDetails));
+
             return optionalCaseDetails;
         }
     }

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CaseDetailsRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CaseDetailsRepository.java
@@ -11,11 +11,21 @@ import java.util.Optional;
 public interface CaseDetailsRepository {
     CaseDetails set(CaseDetails caseDetails);
 
+    Optional<CaseDetails> findById(String jurisdiction, Long id);
+
+    Optional<CaseDetails> findByReference(String jurisdiction, Long caseReference);
+
+    Optional<CaseDetails> findByReference(String jurisdiction, String reference);
+
+    Optional<CaseDetails> lockByReference(String jurisdiction, Long reference);
+
+    Optional<CaseDetails> lockByReference(String jurisdiction, String reference);
+
     /**
      *
      * @param id Internal case ID
      * @return Case details
-     * @deprecated Case retrieval should be done by reference. Use {@link CaseDetailsRepository#findByReference(String, Long)} instead.
+     * @deprecated Use {@link CaseDetailsRepository#findByReference(String, Long)} instead.
      */
     @Deprecated
     CaseDetails findById(Long id);
@@ -24,13 +34,18 @@ public interface CaseDetailsRepository {
      *
      * @param caseReference Public case reference
      * @return Case details
-     * @deprecated Case retrieval should be done by reference. Use {@link CaseDetailsRepository#findByReference(String, Long)} instead.
+     * @deprecated Use {@link CaseDetailsRepository#findByReference(String, Long)} instead.
      */
     @Deprecated
     CaseDetails findByReference(Long caseReference);
 
-    Optional<CaseDetails> findByReference(String jurisdictionId, Long caseReference);
-
+    /**
+     *
+     * @param caseReference Public case reference
+     * @return Case details
+     * @deprecated Use {@link CaseDetailsRepository#lockByReference(String, Long)} instead.
+     */
+    @Deprecated
     CaseDetails lockCase(Long caseReference);
 
     /**
@@ -39,7 +54,7 @@ public interface CaseDetailsRepository {
      * @param caseTypeId Case's type ID
      * @param caseReference Public case reference
      * @return Case details
-     * @deprecated Case retrieval should be done by reference. Use {@link CaseDetailsRepository#findByReference(String, Long)} instead.
+     * @deprecated Use {@link CaseDetailsRepository#findByReference(String, String)} instead.
      */
     @Deprecated
     CaseDetails findUniqueCase(String jurisdictionId,

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/DefaultCaseDetailsRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/DefaultCaseDetailsRepository.java
@@ -5,6 +5,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import uk.gov.hmcts.ccd.ApplicationParams;
+import uk.gov.hmcts.ccd.data.casedetails.query.CaseDetailsQueryBuilder;
+import uk.gov.hmcts.ccd.data.casedetails.query.CaseDetailsQueryBuilderFactory;
 import uk.gov.hmcts.ccd.data.casedetails.search.MetaData;
 import uk.gov.hmcts.ccd.data.casedetails.search.PaginatedSearchMetadata;
 import uk.gov.hmcts.ccd.data.casedetails.search.SearchQueryFactoryOperation;
@@ -49,15 +51,18 @@ public class DefaultCaseDetailsRepository implements CaseDetailsRepository {
     private EntityManager em;
 
     private final SearchQueryFactoryOperation queryBuilder;
+    private final CaseDetailsQueryBuilderFactory queryBuilderFactory;
     private final ApplicationParams applicationParams;
 
     @Inject
     public DefaultCaseDetailsRepository(
             final CaseDetailsMapper caseDetailsMapper,
             final SearchQueryFactoryOperation queryBuilder,
+            final CaseDetailsQueryBuilderFactory queryBuilderFactory,
             final ApplicationParams applicationParams) {
         this.caseDetailsMapper = caseDetailsMapper;
         this.queryBuilder = queryBuilder;
+        this.queryBuilderFactory = queryBuilderFactory;
         this.applicationParams = applicationParams;
     }
 
@@ -78,65 +83,83 @@ public class DefaultCaseDetailsRepository implements CaseDetailsRepository {
     }
 
     @Override
+    public Optional<CaseDetails> findById(String jurisdiction, Long id) {
+        return find(jurisdiction, id, null).map(this.caseDetailsMapper::entityToModel);
+    }
+
+    @Override
+    public Optional<CaseDetails> findByReference(String jurisdiction, Long caseReference) {
+        return findByReference(jurisdiction, caseReference.toString());
+    }
+
+    @Override
+    public Optional<CaseDetails> findByReference(String jurisdiction, String reference) {
+        return find(jurisdiction, null, reference).map(this.caseDetailsMapper::entityToModel);
+    }
+
+    @Override
+    public Optional<CaseDetails> lockByReference(String jurisdiction, Long reference) {
+        return lockByReference(jurisdiction, reference.toString());
+    }
+
+    @Override
+    public Optional<CaseDetails> lockByReference(String jurisdiction, String reference) {
+        return find(jurisdiction, null, reference).map(entity -> {
+            em.lock(entity, LockModeType.PESSIMISTIC_WRITE);
+            return this.caseDetailsMapper.entityToModel(entity);
+        });
+    }
+
+    /**
+     *
+     * @param id Internal case ID
+     * @return Case details if found; null otherwise
+     * @deprecated Use {@link DefaultCaseDetailsRepository#findByReference(String, Long)} instead
+     */
+    @Override
+    @Deprecated
     public CaseDetails findById(final Long id) {
-        return caseDetailsMapper.entityToModel(em.find(CaseDetailsEntity.class, id));
+        return findById(null, id).orElse(null);
     }
 
+    /**
+     *
+     * @param caseReference Public case reference
+     * @return Case details if found; null otherwise.
+     * @deprecated Use {@link DefaultCaseDetailsRepository#findByReference(String, Long)} instead
+     */
     @Override
+    @Deprecated
     public CaseDetails findByReference(final Long caseReference) {
-        final CaseDetailsEntity caseDetailsEntity = findByReference(caseReference, Optional.empty());
-        return caseDetailsMapper.entityToModel(caseDetailsEntity);
+        return findByReference(null, caseReference).orElseThrow(() -> new ResourceNotFoundException("No case found"));
     }
 
+    /**
+     *
+     * @param jurisdiction Jurisdiction's ID
+     * @param caseTypeId Case's type ID
+     * @param reference Case unique 16-digit reference
+     * @return Case details if found; null otherwise
+     * @deprecated Use {@link DefaultCaseDetailsRepository#findByReference(String, String)} instead
+     */
     @Override
-    public CaseDetails lockCase(final Long caseReference) {
-        final CaseDetailsEntity caseDetailsEntity = findByReference(caseReference, Optional.of(LockModeType.PESSIMISTIC_WRITE));
-        return caseDetailsMapper.entityToModel(caseDetailsEntity);
-    }
-
-    private CaseDetailsEntity findByReference(final Long caseReference, Optional<LockModeType> lockModeType) {
-        final TypedQuery<CaseDetailsEntity> query = em.createNamedQuery(CaseDetailsEntity.FIND_BY_REFERENCE, CaseDetailsEntity.class);
-        query.setParameter(CaseDetailsEntity.CASE_REFERENCE_PARAM, valueOf(caseReference));
-        CaseDetailsEntity caseDetailsEntity = null;
-        try {
-            caseDetailsEntity = query.getSingleResult();
-        } catch (NoResultException e) {
-            throw new ResourceNotFoundException("No case found");
-        }
-        if (caseDetailsEntity == null || caseDetailsEntity.getCaseType() == null)
-            throw new ResourceNotFoundException("No case found");
-        if (lockModeType.isPresent()) {
-            em.lock(caseDetailsEntity, lockModeType.get());
-        }
-        return caseDetailsEntity;
-    }
-
-    public Optional<CaseDetails> findByReference(String jurisdictionId, Long caseReference) {
-        final TypedQuery<CaseDetailsEntity> query = em.createNamedQuery(CaseDetailsEntity.FIND_BY_REF_AND_JURISDICTION,
-                                                                        CaseDetailsEntity.class);
-        query.setParameter(CaseDetailsEntity.JURISDICTION_ID_PARAM, jurisdictionId);
-        query.setParameter(CaseDetailsEntity.CASE_REFERENCE_PARAM, caseReference);
-
-        try {
-            final CaseDetailsEntity caseEntity = query.getSingleResult();
-            return Optional.of(caseDetailsMapper.entityToModel(caseEntity));
-        } catch (NoResultException ex) {
-            LOG.debug("Case not found for jurisdiction '{}' and reference '{}", jurisdictionId, caseReference);
-        }
-
-        return Optional.empty();
-    }
-
-    @Override
-    public CaseDetails findUniqueCase(final String jurisdictionId,
+    @Deprecated
+    public CaseDetails findUniqueCase(final String jurisdiction,
                                       final String caseTypeId,
-                                      final String caseReference) {
-        final TypedQuery<CaseDetailsEntity> query = em.createNamedQuery(CaseDetailsEntity.FIND_CASE, CaseDetailsEntity.class);
-        query.setParameter(CaseDetailsEntity.JURISDICTION_ID_PARAM, jurisdictionId);
-        query.setParameter(CaseDetailsEntity.CASE_TYPE_PARAM, caseTypeId);
-        query.setParameter(CaseDetailsEntity.CASE_REFERENCE_PARAM, valueOf(caseReference));
-        final List<CaseDetailsEntity> result = query.getResultList();
-        return result.isEmpty() ? null : caseDetailsMapper.entityToModel(result.get(0));
+                                      final String reference) {
+        return findByReference(jurisdiction, reference).orElse(null);
+    }
+
+    /**
+     *
+     * @param reference Case unique 16-digit reference
+     * @return Case details if found; throw NotFound exception otherwise
+     * @deprecated Use {@link DefaultCaseDetailsRepository#lockByReference(String, Long)} instead
+     */
+    @Override
+    @Deprecated
+    public CaseDetails lockCase(final Long reference) {
+        return lockByReference(null, reference).orElseThrow(() -> new ResourceNotFoundException("No case found"));
     }
 
     @Override
@@ -155,6 +178,27 @@ public class DefaultCaseDetailsRepository implements CaseDetailsRepository {
         sr.setTotalResultsCount(totalResults);
         sr.setTotalPagesCount((int) Math.ceil((double) sr.getTotalResultsCount()/pageSize));
         return sr;
+    }
+
+    // TODO This accepts null values for backward compatibility. Once deprecated methods are removed, parameters should
+    // be annotated with @NotNull
+    private Optional<CaseDetailsEntity> find(String jurisdiction, Long id, String reference) {
+        final CaseDetailsQueryBuilder qb = queryBuilderFactory.create(em);
+
+        if (null != jurisdiction) {
+            qb.whereJurisdiction(jurisdiction);
+        }
+
+        if (null != reference) {
+            qb.whereReference(reference);
+        } else {
+            qb.whereId(id);
+        }
+
+        final TypedQuery<CaseDetailsEntity> query = qb.build();
+        return query.getResultList()
+                    .stream()
+                    .findFirst();
     }
 
     private Query getQuery(MetaData metadata, Map<String, String> dataSearchParams, boolean isCountQuery) {

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/DefaultCaseDetailsRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/DefaultCaseDetailsRepository.java
@@ -189,10 +189,10 @@ public class DefaultCaseDetailsRepository implements CaseDetailsRepository {
             qb.whereId(id);
         }
 
-        final TypedQuery<CaseDetailsEntity> query = qb.build();
-        return query.getResultList()
-                    .stream()
-                    .findFirst();
+        return qb.build()
+                 .getResultList()
+                 .stream()
+                 .findFirst();
     }
 
     private Query getQuery(MetaData metadata, Map<String, String> dataSearchParams, boolean isCountQuery) {

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/DefaultCaseDetailsRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/DefaultCaseDetailsRepository.java
@@ -189,10 +189,7 @@ public class DefaultCaseDetailsRepository implements CaseDetailsRepository {
             qb.whereId(id);
         }
 
-        return qb.build()
-                 .getResultList()
-                 .stream()
-                 .findFirst();
+        return qb.getSingleResult();
     }
 
     private Query getQuery(MetaData metadata, Map<String, String> dataSearchParams, boolean isCountQuery) {

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/DefaultCaseDetailsRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/DefaultCaseDetailsRepository.java
@@ -177,7 +177,7 @@ public class DefaultCaseDetailsRepository implements CaseDetailsRepository {
     // TODO This accepts null values for backward compatibility. Once deprecated methods are removed, parameters should
     // be annotated with @NotNull
     private Optional<CaseDetailsEntity> find(String jurisdiction, Long id, String reference) {
-        final CaseDetailsQueryBuilder qb = queryBuilderFactory.select(em);
+        final CaseDetailsQueryBuilder<CaseDetailsEntity> qb = queryBuilderFactory.select(em);
 
         if (null != jurisdiction) {
             qb.whereJurisdiction(jurisdiction);

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/query/CaseDetailsQueryBuilder.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/query/CaseDetailsQueryBuilder.java
@@ -12,6 +12,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public abstract class CaseDetailsQueryBuilder<T> {
 
@@ -112,6 +113,12 @@ public abstract class CaseDetailsQueryBuilder<T> {
     }
 
     public abstract TypedQuery<T> build();
+
+    public Optional<T> getSingleResult() {
+        return build().getResultList()
+                      .stream()
+                      .findFirst();
+    }
 
     protected abstract CriteriaQuery<T> createQuery();
 

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/query/CaseDetailsQueryBuilder.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/query/CaseDetailsQueryBuilder.java
@@ -95,11 +95,11 @@ public abstract class CaseDetailsQueryBuilder<T> {
         whereJurisdiction(metadata.getJurisdiction());
         whereCaseType(metadata.getCaseTypeId());
 
-        metadata.getState().map(this::whereState);
-        metadata.getCaseReference().map(this::whereReference);
-        metadata.getCreatedDate().map(this::whereCreatedDate);
-        metadata.getLastModified().map(this::whereLastModified);
-        metadata.getSecurityClassification().map(this::whereSecurityClassification);
+        metadata.getState().ifPresent(this::whereState);
+        metadata.getCaseReference().ifPresent(this::whereReference);
+        metadata.getCreatedDate().ifPresent(this::whereCreatedDate);
+        metadata.getLastModified().ifPresent(this::whereLastModified);
+        metadata.getSecurityClassification().ifPresent(this::whereSecurityClassification);
 
         return this;
     }

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/query/CaseDetailsQueryBuilder.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/query/CaseDetailsQueryBuilder.java
@@ -11,6 +11,7 @@ import javax.persistence.criteria.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.List;
 
 public abstract class CaseDetailsQueryBuilder<T> {
 
@@ -18,8 +19,8 @@ public abstract class CaseDetailsQueryBuilder<T> {
     protected final CriteriaBuilder cb;
     protected final CriteriaQuery<T> query;
     protected final Root<CaseDetailsEntity> root;
-    protected final ArrayList<Predicate> predicates;
-    protected final ArrayList<Order> orders;
+    protected final List<Predicate> predicates;
+    protected final List<Order> orders;
 
     CaseDetailsQueryBuilder(EntityManager em) {
         this.em = em;

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/query/CaseDetailsQueryBuilder.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/query/CaseDetailsQueryBuilder.java
@@ -1,0 +1,60 @@
+package uk.gov.hmcts.ccd.data.casedetails.query;
+
+import uk.gov.hmcts.ccd.data.caseaccess.CaseUserEntity;
+import uk.gov.hmcts.ccd.data.casedetails.CaseDetailsEntity;
+
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
+import javax.persistence.criteria.*;
+import java.util.ArrayList;
+
+public class CaseDetailsQueryBuilder {
+
+    private final EntityManager em;
+    private final CriteriaBuilder cb;
+    private final CriteriaQuery<CaseDetailsEntity> query;
+    private final Root<CaseDetailsEntity> root;
+    private final ArrayList<Predicate> predicates;
+
+    CaseDetailsQueryBuilder(EntityManager em) {
+        this.em = em;
+        cb = em.getCriteriaBuilder();
+        query = cb.createQuery(CaseDetailsEntity.class);
+        root = query.from(CaseDetailsEntity.class);
+        predicates = new ArrayList<>();
+    }
+
+    public CaseDetailsQueryBuilder whereGrantedAccessOnly(String userId) {
+        final Subquery<CaseUserEntity> cuQuery = query.subquery(CaseUserEntity.class);
+        final Root<CaseUserEntity> cu = cuQuery.from(CaseUserEntity.class);
+        cuQuery.select(cu.get("casePrimaryKey").get("caseDataId"))
+               .where(cb.equal(cu.get("casePrimaryKey").get("userId"), userId));
+
+        predicates.add(cb.in(root.get("id")).value(cuQuery));
+
+        return this;
+    }
+
+    public CaseDetailsQueryBuilder whereJurisdiction(String jurisdiction) {
+        predicates.add(cb.equal(root.get("jurisdiction"), jurisdiction));
+
+        return this;
+    }
+
+    public CaseDetailsQueryBuilder whereReference(String reference) {
+        predicates.add(cb.equal(root.get("reference"), reference));
+
+        return this;
+    }
+
+    public CaseDetailsQueryBuilder whereId(Long id) {
+        predicates.add(cb.equal(root.get("id"), id));
+
+        return this;
+    }
+
+    public TypedQuery<CaseDetailsEntity> build() {
+        return em.createQuery(query.select(root)
+                                   .where(predicates.toArray(new Predicate[]{})));
+    }
+}

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/query/CaseDetailsQueryBuilderFactory.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/query/CaseDetailsQueryBuilderFactory.java
@@ -1,0 +1,21 @@
+package uk.gov.hmcts.ccd.data.casedetails.query;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import javax.persistence.EntityManager;
+
+@Component
+public class CaseDetailsQueryBuilderFactory {
+
+    private final UserAuthorisationSecurity userAuthorisationSecurity;
+
+    @Autowired
+    public CaseDetailsQueryBuilderFactory(UserAuthorisationSecurity userAuthorisationSecurity) {
+        this.userAuthorisationSecurity = userAuthorisationSecurity;
+    }
+
+    public CaseDetailsQueryBuilder create(EntityManager em) {
+        return userAuthorisationSecurity.secure(new CaseDetailsQueryBuilder(em));
+    }
+}

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/query/CaseDetailsQueryBuilderFactory.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/query/CaseDetailsQueryBuilderFactory.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.ccd.data.casedetails.query;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.data.casedetails.CaseDetailsEntity;
 
 import javax.persistence.EntityManager;
 
@@ -15,7 +16,11 @@ public class CaseDetailsQueryBuilderFactory {
         this.userAuthorisationSecurity = userAuthorisationSecurity;
     }
 
-    public CaseDetailsQueryBuilder create(EntityManager em) {
-        return userAuthorisationSecurity.secure(new CaseDetailsQueryBuilder(em));
+    public CaseDetailsQueryBuilder<CaseDetailsEntity> select(EntityManager em) {
+        return userAuthorisationSecurity.secure(new SelectCaseDetailsQueryBuilder(em));
+    }
+
+    public CaseDetailsQueryBuilder<Long> count(EntityManager em) {
+        return userAuthorisationSecurity.secure(new CountCaseDetailsQueryBuilder(em));
     }
 }

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/query/CountCaseDetailsQueryBuilder.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/query/CountCaseDetailsQueryBuilder.java
@@ -1,0 +1,25 @@
+package uk.gov.hmcts.ccd.data.casedetails.query;
+
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Predicate;
+
+public class CountCaseDetailsQueryBuilder extends CaseDetailsQueryBuilder<Long> {
+
+    CountCaseDetailsQueryBuilder(EntityManager em) {
+        super(em);
+    }
+
+    @Override
+    public TypedQuery<Long> build() {
+        return em.createQuery(query.select(cb.count(root))
+                                   .orderBy(orders)
+                                   .where(predicates.toArray(new Predicate[]{})));
+    }
+
+    @Override
+    protected CriteriaQuery<Long> createQuery() {
+        return cb.createQuery(Long.class);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/query/SelectCaseDetailsQueryBuilder.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/query/SelectCaseDetailsQueryBuilder.java
@@ -1,0 +1,27 @@
+package uk.gov.hmcts.ccd.data.casedetails.query;
+
+import uk.gov.hmcts.ccd.data.casedetails.CaseDetailsEntity;
+
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Predicate;
+
+public class SelectCaseDetailsQueryBuilder extends CaseDetailsQueryBuilder<CaseDetailsEntity> {
+
+    SelectCaseDetailsQueryBuilder(EntityManager em) {
+        super(em);
+    }
+
+    @Override
+    public TypedQuery<CaseDetailsEntity> build() {
+        return em.createQuery(query.select(root)
+                                   .orderBy(orders)
+                                   .where(predicates.toArray(new Predicate[]{})));
+    }
+
+    @Override
+    protected CriteriaQuery<CaseDetailsEntity> createQuery() {
+        return cb.createQuery(CaseDetailsEntity.class);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/query/UserAuthorisationSecurity.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/query/UserAuthorisationSecurity.java
@@ -15,7 +15,7 @@ class UserAuthorisationSecurity {
         this.userAuthorisation = userAuthorisation;
     }
 
-    CaseDetailsQueryBuilder secure(CaseDetailsQueryBuilder builder) {
+    <T> CaseDetailsQueryBuilder<T> secure(CaseDetailsQueryBuilder<T> builder) {
         if (AccessLevel.GRANTED.equals(userAuthorisation.getAccessLevel())) {
             builder.whereGrantedAccessOnly(userAuthorisation.getUserId());
         }

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/query/UserAuthorisationSecurity.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/query/UserAuthorisationSecurity.java
@@ -1,0 +1,24 @@
+package uk.gov.hmcts.ccd.data.casedetails.query;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.infrastructure.user.UserAuthorisation;
+import uk.gov.hmcts.ccd.infrastructure.user.UserAuthorisation.AccessLevel;
+
+@Component
+class UserAuthorisationSecurity {
+
+    private final UserAuthorisation userAuthorisation;
+
+    @Autowired
+    UserAuthorisationSecurity(UserAuthorisation userAuthorisation) {
+        this.userAuthorisation = userAuthorisation;
+    }
+
+    CaseDetailsQueryBuilder secure(CaseDetailsQueryBuilder builder) {
+        if (AccessLevel.GRANTED.equals(userAuthorisation.getAccessLevel())) {
+            builder.whereGrantedAccessOnly(userAuthorisation.getUserId());
+        }
+        return builder;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/search/SearchQueryFactoryOperation.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/search/SearchQueryFactoryOperation.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.ccd.data.casedetails.search;
 
 import uk.gov.hmcts.ccd.ApplicationParams;
 import uk.gov.hmcts.ccd.data.casedetails.CaseDetailsEntity;
+import uk.gov.hmcts.ccd.infrastructure.user.UserAuthorisation;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -28,21 +29,22 @@ public class SearchQueryFactoryOperation {
     private static final String MAIN_COUNT_QUERY = "SELECT count(*) FROM case_data WHERE %s";
 
     private final CriterionFactory criteraFactory;
-
     private final ApplicationParams applicationParam;
+    private final UserAuthorisation userAuthorisation;
 
     public SearchQueryFactoryOperation(CriterionFactory criteraFactory,
-            FieldMapSanitizeOperation fieldMapSanitizeOperation,
-            final EntityManager entityManager,
-            ApplicationParams applicationParam) {
+                                       EntityManager entityManager,
+                                       ApplicationParams applicationParam,
+                                       UserAuthorisation userAuthorisation) {
         this.criteraFactory = criteraFactory;
         this.entityManager = entityManager;
         this.applicationParam = applicationParam;
+        this.userAuthorisation = userAuthorisation;
     }
 
     public Query build(MetaData metadata, Map<String, String> params, boolean isCountQuery) {
         final List<Criterion> criteria = criteraFactory.build(metadata, params);
-        String queryString = String.format(isCountQuery ? MAIN_COUNT_QUERY : MAINQUERY, toClauses(criteria));
+        String queryString = String.format(isCountQuery ? MAIN_COUNT_QUERY : MAINQUERY, secure(toClauses(criteria)));
         Query query;
         if (isCountQuery) {
             query = entityManager.createNativeQuery(queryString);
@@ -51,6 +53,16 @@ public class SearchQueryFactoryOperation {
         }
         addParameters(query, criteria);
         return query;
+    }
+
+    private String secure(String clauses) {
+        if (UserAuthorisation.AccessLevel.GRANTED.equals(userAuthorisation.getAccessLevel())) {
+            clauses += String.format(
+                " AND id IN (SELECT cu.case_data_id FROM case_users AS cu WHERE user_id = '%s')",
+                userAuthorisation.getUserId()
+            );
+        }
+        return clauses;
     }
 
     private void addParameters(final Query query, List<Criterion> critereon) {

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/search/SearchQueryFactoryOperation.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/search/SearchQueryFactoryOperation.java
@@ -25,7 +25,7 @@ public class SearchQueryFactoryOperation {
     @PersistenceContext
     private EntityManager entityManager;
 
-    private static final String MAINQUERY = "SELECT * FROM case_data WHERE %s ORDER BY created_date ASC";
+    private static final String MAIN_QUERY = "SELECT * FROM case_data WHERE %s ORDER BY created_date ASC";
     private static final String MAIN_COUNT_QUERY = "SELECT count(*) FROM case_data WHERE %s";
 
     private final CriterionFactory criteraFactory;
@@ -44,7 +44,7 @@ public class SearchQueryFactoryOperation {
 
     public Query build(MetaData metadata, Map<String, String> params, boolean isCountQuery) {
         final List<Criterion> criteria = criteraFactory.build(metadata, params);
-        String queryString = String.format(isCountQuery ? MAIN_COUNT_QUERY : MAINQUERY, secure(toClauses(criteria)));
+        String queryString = String.format(isCountQuery ? MAIN_COUNT_QUERY : MAIN_QUERY, secure(toClauses(criteria)));
         Query query;
         if (isCountQuery) {
             query = entityManager.createNativeQuery(queryString);

--- a/src/main/java/uk/gov/hmcts/ccd/infrastructure/user/UserAuthorisation.java
+++ b/src/main/java/uk/gov/hmcts/ccd/infrastructure/user/UserAuthorisation.java
@@ -1,0 +1,24 @@
+package uk.gov.hmcts.ccd.infrastructure.user;
+
+public class UserAuthorisation {
+
+    private final String id;
+    private final AccessLevel accessLevel;
+
+    public UserAuthorisation(String id, AccessLevel accessLevel) {
+        this.id = id;
+        this.accessLevel = accessLevel;
+    }
+
+    public String getUserId() {
+        return id;
+    }
+
+    public AccessLevel getAccessLevel() {
+        return accessLevel;
+    }
+
+    public enum AccessLevel {
+        ALL, GRANTED
+    }
+}

--- a/src/main/java/uk/gov/hmcts/ccd/infrastructure/user/UserAuthorisationConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/ccd/infrastructure/user/UserAuthorisationConfiguration.java
@@ -10,12 +10,12 @@ import uk.gov.hmcts.ccd.infrastructure.user.UserAuthorisation.AccessLevel;
 import uk.gov.hmcts.reform.auth.checker.spring.serviceanduser.ServiceAndUserDetails;
 
 @Configuration
-public class UserAuthorisationFactory {
+public class UserAuthorisationConfiguration {
 
     private final CaseAccessService caseAccessService;
 
     @Autowired
-    public UserAuthorisationFactory(CaseAccessService caseAccessService) {
+    public UserAuthorisationConfiguration(CaseAccessService caseAccessService) {
         this.caseAccessService = caseAccessService;
     }
 

--- a/src/main/java/uk/gov/hmcts/ccd/infrastructure/user/UserAuthorisationFactory.java
+++ b/src/main/java/uk/gov/hmcts/ccd/infrastructure/user/UserAuthorisationFactory.java
@@ -1,0 +1,41 @@
+package uk.gov.hmcts.ccd.infrastructure.user;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.context.annotation.RequestScope;
+import uk.gov.hmcts.ccd.domain.service.common.CaseAccessService;
+import uk.gov.hmcts.ccd.infrastructure.user.UserAuthorisation.AccessLevel;
+import uk.gov.hmcts.reform.auth.checker.spring.serviceanduser.ServiceAndUserDetails;
+
+@Configuration
+public class UserAuthorisationFactory {
+
+    private final CaseAccessService caseAccessService;
+
+    @Autowired
+    public UserAuthorisationFactory(CaseAccessService caseAccessService) {
+        this.caseAccessService = caseAccessService;
+    }
+
+    @Bean
+    @RequestScope
+    public UserAuthorisation create() {
+        return new UserAuthorisation(getUserId(), getAccessLevel());
+    }
+
+    private ServiceAndUserDetails getServiceAndUserDetails() {
+        return (ServiceAndUserDetails) SecurityContextHolder.getContext()
+                                                            .getAuthentication()
+                                                            .getPrincipal();
+    }
+
+    private String getUserId() {
+        return getServiceAndUserDetails().getUsername();
+    }
+
+    private AccessLevel getAccessLevel() {
+        return caseAccessService.getAccessLevel(getServiceAndUserDetails());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/ccd/data/casedetails/CachedCaseDetailsRepositoryTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/data/casedetails/CachedCaseDetailsRepositoryTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import uk.gov.hmcts.ccd.data.casedetails.search.MetaData;
@@ -22,6 +23,7 @@ class CachedCaseDetailsRepositoryTest {
 
     private final static long CASE_ID = 100000L;
     private final static long CASE_REFERENCE = 999999L;
+    private final static String CASE_REFERENCE_STR = "1234123412341236";
     private final static String JURISDICTION_ID = "JeyOne";
     private final static String CASE_TYPE_ID = "CaseTypeOne";
 
@@ -35,7 +37,8 @@ class CachedCaseDetailsRepositoryTest {
     private Map<String, String> dataSearchParams;
     private PaginatedSearchMetadata paginatedSearchMetadata;
 
-    private CachedCaseDetailsRepository classUnderTest;
+    @InjectMocks
+    private CachedCaseDetailsRepository cachedRepository;
 
     @BeforeEach
     void setUp() {
@@ -56,8 +59,6 @@ class CachedCaseDetailsRepositoryTest {
         dataSearchParams = new HashMap<>();
 
         paginatedSearchMetadata = new PaginatedSearchMetadata();
-
-        classUnderTest = new CachedCaseDetailsRepository(caseDetailsRepository);
     }
 
     @Test
@@ -65,7 +66,7 @@ class CachedCaseDetailsRepositoryTest {
     void set() {
         doReturn(caseDetails).when(caseDetailsRepository).set(caseDetails);
 
-        CaseDetails returned = classUnderTest.set(caseDetails);
+        CaseDetails returned = cachedRepository.set(caseDetails);
 
         assertAll(
             () -> assertThat(returned, is(caseDetails)),
@@ -78,7 +79,7 @@ class CachedCaseDetailsRepositoryTest {
     void lockCase() {
         doReturn(caseDetails).when(caseDetailsRepository).lockCase(CASE_REFERENCE);
 
-        CaseDetails returned = classUnderTest.lockCase(CASE_REFERENCE);
+        CaseDetails returned = cachedRepository.lockCase(CASE_REFERENCE);
 
         assertAll(
             () -> assertThat(returned, is(caseDetails)),
@@ -94,9 +95,9 @@ class CachedCaseDetailsRepositoryTest {
         @DisplayName("should initially retrieve paginated search metadata from decorated repository")
         void getPaginatedSearchMetaData() {
             doReturn(paginatedSearchMetadata).when(caseDetailsRepository).getPaginatedSearchMetadata(metaData,
-                dataSearchParams);
+                                                                                                     dataSearchParams);
 
-            PaginatedSearchMetadata returned = classUnderTest.getPaginatedSearchMetadata(metaData, dataSearchParams);
+            PaginatedSearchMetadata returned = cachedRepository.getPaginatedSearchMetadata(metaData, dataSearchParams);
 
             assertAll(
                 () -> assertThat(returned, is(paginatedSearchMetadata)),
@@ -108,16 +109,16 @@ class CachedCaseDetailsRepositoryTest {
         @DisplayName("should cache paginated search metadata for subsequent calls")
         void getPaginatedSearchMetaDataAgain() {
             doReturn(paginatedSearchMetadata).when(caseDetailsRepository).getPaginatedSearchMetadata(metaData,
-                dataSearchParams);
+                                                                                                     dataSearchParams);
 
-            classUnderTest.getPaginatedSearchMetadata(metaData, dataSearchParams);
+            cachedRepository.getPaginatedSearchMetadata(metaData, dataSearchParams);
 
             verify(caseDetailsRepository, times(1)).getPaginatedSearchMetadata(metaData, dataSearchParams);
 
             PaginatedSearchMetadata newPaginatedSearchMetadata = new PaginatedSearchMetadata();
             doReturn(newPaginatedSearchMetadata).when(caseDetailsRepository).getPaginatedSearchMetadata(metaData,
-                dataSearchParams);
-            PaginatedSearchMetadata returned = classUnderTest.getPaginatedSearchMetadata(metaData, dataSearchParams);
+                                                                                                        dataSearchParams);
+            PaginatedSearchMetadata returned = cachedRepository.getPaginatedSearchMetadata(metaData, dataSearchParams);
 
             assertAll(
                 () -> assertThat(returned, is(paginatedSearchMetadata)),
@@ -133,9 +134,9 @@ class CachedCaseDetailsRepositoryTest {
         @DisplayName("should initially retrieve case details list from decorated repository")
         void findByMetaDataAndFieldData() {
             doReturn(caseDetailsList).when(caseDetailsRepository).findByMetaDataAndFieldData(metaData,
-                dataSearchParams);
+                                                                                             dataSearchParams);
 
-            List<CaseDetails> returned = classUnderTest.findByMetaDataAndFieldData(metaData, dataSearchParams);
+            List<CaseDetails> returned = cachedRepository.findByMetaDataAndFieldData(metaData, dataSearchParams);
 
             assertAll(
                 () -> assertThat(returned, is(caseDetailsList)),
@@ -147,16 +148,16 @@ class CachedCaseDetailsRepositoryTest {
         @DisplayName("should cache case details list for subsequent calls")
         void findByMetaDataAndFieldDataAgain() {
             doReturn(caseDetailsList).when(caseDetailsRepository).findByMetaDataAndFieldData(metaData,
-                dataSearchParams);
+                                                                                             dataSearchParams);
 
-            classUnderTest.findByMetaDataAndFieldData(metaData, dataSearchParams);
+            cachedRepository.findByMetaDataAndFieldData(metaData, dataSearchParams);
 
             verify(caseDetailsRepository, times(1)).findByMetaDataAndFieldData(metaData, dataSearchParams);
 
             List<CaseDetails> newCaseDetailsList = Arrays.asList(new CaseDetails(), new CaseDetails());
             doReturn(newCaseDetailsList).when(caseDetailsRepository).findByMetaDataAndFieldData(metaData,
-                dataSearchParams);
-            List<CaseDetails> returned = classUnderTest.findByMetaDataAndFieldData(metaData, dataSearchParams);
+                                                                                                dataSearchParams);
+            List<CaseDetails> returned = cachedRepository.findByMetaDataAndFieldData(metaData, dataSearchParams);
 
             assertAll(
                 () -> assertThat(returned, is(caseDetailsList)),
@@ -174,7 +175,7 @@ class CachedCaseDetailsRepositoryTest {
             doReturn(caseDetails).when(caseDetailsRepository).findUniqueCase(JURISDICTION_ID, CASE_TYPE_ID, valueOf
                 (CASE_REFERENCE));
 
-            CaseDetails returned = classUnderTest.findUniqueCase(JURISDICTION_ID, CASE_TYPE_ID, valueOf
+            CaseDetails returned = cachedRepository.findUniqueCase(JURISDICTION_ID, CASE_TYPE_ID, valueOf
                 (CASE_REFERENCE));
 
             assertAll(
@@ -190,15 +191,15 @@ class CachedCaseDetailsRepositoryTest {
             doReturn(caseDetails).when(caseDetailsRepository).findUniqueCase(JURISDICTION_ID, CASE_TYPE_ID, valueOf
                 (CASE_REFERENCE));
 
-            classUnderTest.findUniqueCase(JURISDICTION_ID, CASE_TYPE_ID, valueOf(CASE_REFERENCE));
+            cachedRepository.findUniqueCase(JURISDICTION_ID, CASE_TYPE_ID, valueOf(CASE_REFERENCE));
 
             verify(caseDetailsRepository, times(1)).findUniqueCase(JURISDICTION_ID, CASE_TYPE_ID, valueOf
                 (CASE_REFERENCE));
 
             doReturn(new CaseDetails()).when(caseDetailsRepository).findUniqueCase(JURISDICTION_ID, CASE_TYPE_ID,
-                valueOf
-                    (CASE_REFERENCE));
-            CaseDetails returned = classUnderTest.findUniqueCase(JURISDICTION_ID, CASE_TYPE_ID, valueOf
+                                                                                   valueOf
+                                                                                       (CASE_REFERENCE));
+            CaseDetails returned = cachedRepository.findUniqueCase(JURISDICTION_ID, CASE_TYPE_ID, valueOf
                 (CASE_REFERENCE));
 
             assertAll(
@@ -216,7 +217,7 @@ class CachedCaseDetailsRepositoryTest {
         void findByReference() {
             doReturn(caseDetails).when(caseDetailsRepository).findByReference(CASE_REFERENCE);
 
-            CaseDetails returned = classUnderTest.findByReference(CASE_REFERENCE);
+            CaseDetails returned = cachedRepository.findByReference(CASE_REFERENCE);
 
             assertAll(
                 () -> assertThat(returned, is(caseDetails)),
@@ -229,12 +230,12 @@ class CachedCaseDetailsRepositoryTest {
         void findByReferenceAgain() {
             doReturn(caseDetails).when(caseDetailsRepository).findByReference(CASE_REFERENCE);
 
-            classUnderTest.findByReference(CASE_REFERENCE);
+            cachedRepository.findByReference(CASE_REFERENCE);
 
             verify(caseDetailsRepository, times(1)).findByReference(CASE_REFERENCE);
 
             doReturn(new CaseDetails()).when(caseDetailsRepository).findByReference(CASE_REFERENCE);
-            CaseDetails returned = classUnderTest.findByReference(CASE_REFERENCE);
+            CaseDetails returned = cachedRepository.findByReference(CASE_REFERENCE);
 
             assertAll(
                 () -> assertThat(returned, is(caseDetails)),
@@ -252,7 +253,7 @@ class CachedCaseDetailsRepositoryTest {
         void findById() {
             doReturn(caseDetails).when(caseDetailsRepository).findById(CASE_ID);
 
-            CaseDetails returned = classUnderTest.findById(CASE_ID);
+            CaseDetails returned = cachedRepository.findById(CASE_ID);
 
             assertAll(
                 () -> assertThat(returned, is(caseDetails)),
@@ -265,16 +266,117 @@ class CachedCaseDetailsRepositoryTest {
         void findByIdAgain() {
             doReturn(caseDetails).when(caseDetailsRepository).findById(CASE_ID);
 
-            classUnderTest.findById(CASE_ID);
+            cachedRepository.findById(CASE_ID);
 
             verify(caseDetailsRepository, times(1)).findById(CASE_ID);
 
             doReturn(new CaseDetails()).when(caseDetailsRepository).findById(CASE_ID);
-            CaseDetails returned = classUnderTest.findById(CASE_ID);
+            CaseDetails returned = cachedRepository.findById(CASE_ID);
 
             assertAll(
                 () -> assertThat(returned, is(caseDetails)),
                 () -> verifyNoMoreInteractions(caseDetailsRepository)
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("findById(String, Long)")
+    class findByIdWithJurisdiction {
+        @Test
+        @DisplayName("should initially retrieve case details from decorated repository")
+        void findById() {
+            doReturn(Optional.of(caseDetails)).when(caseDetailsRepository)
+                                              .findById(JURISDICTION_ID, CASE_ID);
+
+            final CaseDetails returned = cachedRepository.findById(JURISDICTION_ID, CASE_ID)
+                                                         .orElseThrow(() -> new AssertionError("Not found"));
+
+            assertAll(
+                () -> assertThat(returned, is(caseDetails)),
+                () -> verify(caseDetailsRepository, times(1)).findById(JURISDICTION_ID, CASE_ID)
+            );
+        }
+
+        @Test
+        @DisplayName("should cache case details for subsequent calls")
+        void findByIdAgain() {
+            doReturn(Optional.of(caseDetails)).when(caseDetailsRepository)
+                                              .findById(JURISDICTION_ID, CASE_ID);
+
+            cachedRepository.findById(JURISDICTION_ID, CASE_ID);
+
+            verify(caseDetailsRepository, times(1)).findById(JURISDICTION_ID, CASE_ID);
+
+            doReturn(Optional.of(new CaseDetails())).when(caseDetailsRepository)
+                                                    .findById(JURISDICTION_ID, CASE_ID);
+
+            final CaseDetails returned = cachedRepository.findById(JURISDICTION_ID, CASE_ID)
+                                                         .orElseThrow(() -> new AssertionError("Not found"));
+
+            assertAll(
+                () -> assertThat(returned, is(caseDetails)),
+                () -> verifyNoMoreInteractions(caseDetailsRepository)
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("findByReference(String, String)")
+    class findByReferenceAsString {
+        @Test
+        @DisplayName("should initially retrieve case details from decorated repository")
+        void findByReference() {
+            doReturn(Optional.of(caseDetails)).when(caseDetailsRepository)
+                                              .findByReference(JURISDICTION_ID, CASE_REFERENCE_STR);
+
+            final CaseDetails returned = cachedRepository.findByReference(JURISDICTION_ID, CASE_REFERENCE_STR)
+                                                         .orElseThrow(() -> new AssertionError("Not found"));
+
+            assertAll(
+                () -> assertThat(returned, is(caseDetails)),
+                () -> verify(caseDetailsRepository, times(1)).findByReference(JURISDICTION_ID, CASE_REFERENCE_STR)
+            );
+        }
+
+        @Test
+        @DisplayName("should cache case details for subsequent calls")
+        void findByReferenceAgain() {
+            doReturn(Optional.of(caseDetails)).when(caseDetailsRepository)
+                                              .findByReference(JURISDICTION_ID, CASE_REFERENCE_STR);
+
+            cachedRepository.findByReference(JURISDICTION_ID, CASE_REFERENCE_STR);
+
+            verify(caseDetailsRepository, times(1)).findByReference(JURISDICTION_ID, CASE_REFERENCE_STR);
+
+            doReturn(Optional.of(new CaseDetails())).when(caseDetailsRepository)
+                                                    .findByReference(JURISDICTION_ID, CASE_REFERENCE_STR);
+
+            final CaseDetails returned = cachedRepository.findByReference(JURISDICTION_ID, CASE_REFERENCE_STR)
+                                                         .orElseThrow(() -> new AssertionError("Not found"));
+
+            assertAll(
+                () -> assertThat(returned, is(caseDetails)),
+                () -> verifyNoMoreInteractions(caseDetailsRepository)
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("lockByReference(String, String)")
+    class lockByReferenceAsString {
+        @Test
+        @DisplayName("should delegate to decorated repository")
+        void findByReference() {
+            doReturn(Optional.of(caseDetails)).when(caseDetailsRepository)
+                                              .lockByReference(JURISDICTION_ID, CASE_REFERENCE_STR);
+
+            final CaseDetails returned = cachedRepository.lockByReference(JURISDICTION_ID, CASE_REFERENCE_STR)
+                                                         .orElseThrow(() -> new AssertionError("Not found"));
+
+            assertAll(
+                () -> assertThat(returned, is(caseDetails)),
+                () -> verify(caseDetailsRepository, times(1)).lockByReference(JURISDICTION_ID, CASE_REFERENCE_STR)
             );
         }
     }

--- a/src/test/java/uk/gov/hmcts/ccd/data/casedetails/DefaultCaseDetailsRepositoryTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/data/casedetails/DefaultCaseDetailsRepositoryTest.java
@@ -3,7 +3,9 @@ package uk.gov.hmcts.ccd.data.casedetails;
 import org.hamcrest.MatcherAssert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,6 +13,8 @@ import uk.gov.hmcts.ccd.BaseTest;
 import uk.gov.hmcts.ccd.data.casedetails.search.MetaData;
 import uk.gov.hmcts.ccd.data.casedetails.search.PaginatedSearchMetadata;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseDetails;
+import uk.gov.hmcts.ccd.infrastructure.user.UserAuthorisation;
+import uk.gov.hmcts.ccd.infrastructure.user.UserAuthorisation.AccessLevel;
 
 import javax.inject.Inject;
 import java.io.IOException;
@@ -24,6 +28,7 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.when;
 
 @Transactional
 public class DefaultCaseDetailsRepositoryTest extends BaseTest {
@@ -38,6 +43,9 @@ public class DefaultCaseDetailsRepositoryTest extends BaseTest {
 
     private JdbcTemplate template;
 
+    @MockBean
+    private UserAuthorisation userAuthorisation;
+
     @Inject
     @Qualifier(DefaultCaseDetailsRepository.QUALIFIER)
     private CaseDetailsRepository caseDetailsRepository;
@@ -45,6 +53,8 @@ public class DefaultCaseDetailsRepositoryTest extends BaseTest {
     @Before
     public void setUp() {
         template = new JdbcTemplate(db);
+
+        when(userAuthorisation.getAccessLevel()).thenReturn(AccessLevel.ALL);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/ccd/data/casedetails/query/CaseDetailsQueryBuilderFactoryTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/data/casedetails/query/CaseDetailsQueryBuilderFactoryTest.java
@@ -1,0 +1,76 @@
+package uk.gov.hmcts.ccd.data.casedetails.query;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import uk.gov.hmcts.ccd.data.casedetails.CaseDetailsEntity;
+
+import javax.persistence.EntityManager;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.any;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@DisplayName("CaseDetailsQueryBuilderFactory")
+class CaseDetailsQueryBuilderFactoryTest {
+
+    @Mock
+    private UserAuthorisationSecurity security;
+
+    @Mock
+    private EntityManager em;
+
+    @Mock
+    private CriteriaBuilder criteriaBuilder;
+
+    @Mock
+    private CriteriaQuery<CaseDetailsEntity> query;
+
+    @Mock
+    private Root<CaseDetailsEntity> root;
+
+    @InjectMocks
+    private CaseDetailsQueryBuilderFactory factory;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        when(em.getCriteriaBuilder()).thenReturn(criteriaBuilder);
+        when(criteriaBuilder.createQuery(CaseDetailsEntity.class)).thenReturn(query);
+        when(query.from(CaseDetailsEntity.class)).thenReturn(root);
+
+        // Return argument as is
+        when(security.secure(Matchers.any(CaseDetailsQueryBuilder.class)))
+            .then((Answer<CaseDetailsQueryBuilder>) invocation -> (CaseDetailsQueryBuilder) invocation.getArguments()[0]);
+    }
+
+    @Nested
+    @DisplayName("create()")
+    class Create {
+        @Test
+        @DisplayName("should secure new builder instance with user authorisation")
+        void secureNewInstance() {
+            final CaseDetailsQueryBuilder queryBuilder = factory.create(em);
+
+            assertAll(
+                () -> assertThat(queryBuilder, is(notNullValue())),
+                () -> verify(security).secure(queryBuilder)
+            );
+        }
+    }
+}

--- a/src/test/java/uk/gov/hmcts/ccd/data/casedetails/query/CaseDetailsQueryBuilderFactoryTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/data/casedetails/query/CaseDetailsQueryBuilderFactoryTest.java
@@ -8,7 +8,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import uk.gov.hmcts.ccd.data.casedetails.CaseDetailsEntity;
 
@@ -18,7 +17,6 @@ import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.any;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -65,7 +63,7 @@ class CaseDetailsQueryBuilderFactoryTest {
         @Test
         @DisplayName("should secure new builder instance with user authorisation")
         void secureNewInstance() {
-            final CaseDetailsQueryBuilder queryBuilder = factory.create(em);
+            final CaseDetailsQueryBuilder queryBuilder = factory.select(em);
 
             assertAll(
                 () -> assertThat(queryBuilder, is(notNullValue())),

--- a/src/test/java/uk/gov/hmcts/ccd/data/casedetails/query/UserAuthorisationSecurityTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/data/casedetails/query/UserAuthorisationSecurityTest.java
@@ -1,0 +1,70 @@
+package uk.gov.hmcts.ccd.data.casedetails.query;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import uk.gov.hmcts.ccd.infrastructure.user.UserAuthorisation;
+import uk.gov.hmcts.ccd.infrastructure.user.UserAuthorisation.AccessLevel;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
+
+@DisplayName("UserAuthorisationSecurity")
+class UserAuthorisationSecurityTest {
+
+    private static final String USER_ID = "123";
+    @Mock
+    private UserAuthorisation userAuthorisation;
+
+    @Mock
+    private CaseDetailsQueryBuilder builder;
+
+    @InjectMocks
+    private UserAuthorisationSecurity security;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        when(userAuthorisation.getUserId()).thenReturn(USER_ID);
+    }
+
+    @Nested
+    @DisplayName("secure()")
+    class Secure {
+
+        @Test
+        @DisplayName("should not secure when user access level is ALL")
+        void accessLevelAll () {
+            when(userAuthorisation.getAccessLevel()).thenReturn(AccessLevel.ALL);
+
+            final CaseDetailsQueryBuilder securedBuilder = security.secure(builder);
+
+            assertAll(
+                () -> assertThat(securedBuilder, sameInstance(builder)),
+                () -> verify(builder, never()).whereGrantedAccessOnly(anyString())
+            );
+        }
+
+        @Test
+        @DisplayName("should secure for user ID when user access level is GRANTED")
+        void accessLevelGranted () {
+            when(userAuthorisation.getAccessLevel()).thenReturn(AccessLevel.GRANTED);
+
+            final CaseDetailsQueryBuilder securedBuilder = security.secure(builder);
+
+            assertAll(
+                () -> assertThat(securedBuilder, sameInstance(builder)),
+                () -> verify(builder).whereGrantedAccessOnly(USER_ID)
+            );
+        }
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/ccd/data/casedetails/search/SQLBuilderForSearchTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/data/casedetails/search/SQLBuilderForSearchTest.java
@@ -8,6 +8,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import uk.gov.hmcts.ccd.ApplicationParams;
 import uk.gov.hmcts.ccd.data.casedetails.CaseDetailsEntity;
+import uk.gov.hmcts.ccd.infrastructure.user.UserAuthorisation;
 
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
@@ -34,6 +35,10 @@ public class SQLBuilderForSearchTest {
 
     @Mock
     private ApplicationParams mockApp;
+
+    @Mock
+    private UserAuthorisation userAuthorisation;
+
     private Map<String, String> params;
 
     public SQLBuilderForSearchTest() {
@@ -45,11 +50,11 @@ public class SQLBuilderForSearchTest {
         MockitoAnnotations.initMocks(this);
         subject = new SearchQueryFactoryOperation(
                 criterionFactory,
-                new FieldMapSanitizeOperation(),
                 em,
-                mockApp);
+                mockApp,
+                userAuthorisation);
 
-        params = new HashMap<String, String>();
+        params = new HashMap<>();
 
     }
 

--- a/src/test/java/uk/gov/hmcts/ccd/endpoint/std/CaseDetailsEndpointIT.java
+++ b/src/test/java/uk/gov/hmcts/ccd/endpoint/std/CaseDetailsEndpointIT.java
@@ -1215,7 +1215,7 @@ public class CaseDetailsEndpointIT extends WireMockBaseTest {
             mapper.readTree(mvcResult.getResponse().getContentAsString()).get("case_data").toString());
 
         final List<CaseDetails> caseDetailsList = template.query("SELECT * FROM case_data", this::mapCaseData);
-        assertEquals("Incorrect number of cases: No case should be created", 15, caseDetailsList.size());
+        assertEquals("Incorrect number of cases: No case should be created", 16, caseDetailsList.size());
 
         final CaseDetails savedCaseDetails = caseDetailsList.stream()
             .filter(c -> CASE_REFERENCE.equals(c.getReference().toString()))
@@ -1298,7 +1298,7 @@ public class CaseDetailsEndpointIT extends WireMockBaseTest {
             mapper.readTree(mvcResult.getResponse().getContentAsString()).get("case_data").toString());
 
         final List<CaseDetails> caseDetailsList = template.query("SELECT * FROM case_data", this::mapCaseData);
-        assertEquals("Incorrect number of cases: No case should be created", 15, caseDetailsList.size());
+        assertEquals("Incorrect number of cases: No case should be created", 16, caseDetailsList.size());
 
         final CaseDetails savedCaseDetails = caseDetailsList.stream()
             .filter(c -> CASE_REFERENCE.equals(c.getReference().toString()))
@@ -1395,7 +1395,7 @@ public class CaseDetailsEndpointIT extends WireMockBaseTest {
             mapper.readTree(mvcResult.getResponse().getContentAsString()).get("case_data").toString());
 
         final List<CaseDetails> caseDetailsList = template.query("SELECT * FROM case_data", this::mapCaseData);
-        assertEquals("Incorrect number of cases: No case should be created", 15, caseDetailsList.size());
+        assertEquals("Incorrect number of cases: No case should be created", 16, caseDetailsList.size());
 
         final CaseDetails savedCaseDetails = caseDetailsList.stream()
             .filter(c -> caseReference.equals(c.getReference().toString()))
@@ -1468,7 +1468,7 @@ public class CaseDetailsEndpointIT extends WireMockBaseTest {
             mapper.readTree(mvcResult.getResponse().getContentAsString()).get("case_data").toString());
 
         final List<CaseDetails> caseDetailsList = template.query("SELECT * FROM case_data", this::mapCaseData);
-        assertEquals("Incorrect number of cases: No case should be created", 15, caseDetailsList.size());
+        assertEquals("Incorrect number of cases: No case should be created", 16, caseDetailsList.size());
 
         final CaseDetails savedCaseDetails = caseDetailsList.stream()
             .filter(c -> caseReference.equals(c.getReference().toString()))
@@ -1542,7 +1542,7 @@ public class CaseDetailsEndpointIT extends WireMockBaseTest {
             mapper.readTree(mvcResult.getResponse().getContentAsString()).get("case_data").toString());
 
         final List<CaseDetails> caseDetailsList = template.query("SELECT * FROM case_data", this::mapCaseData);
-        assertEquals("Incorrect number of cases: No case should be created", 15, caseDetailsList.size());
+        assertEquals("Incorrect number of cases: No case should be created", 16, caseDetailsList.size());
 
         final CaseDetails savedCaseDetails = caseDetailsList.stream()
             .filter(c -> caseReference.equals(c.getReference().toString()))
@@ -1616,7 +1616,7 @@ public class CaseDetailsEndpointIT extends WireMockBaseTest {
             mapper.readTree(mvcResult.getResponse().getContentAsString()).get("case_data").toString());
 
         final List<CaseDetails> caseDetailsList = template.query("SELECT * FROM case_data", this::mapCaseData);
-        assertEquals("Incorrect number of cases: No case should be created", 15, caseDetailsList.size());
+        assertEquals("Incorrect number of cases: No case should be created", 16, caseDetailsList.size());
 
         final CaseDetails savedCaseDetails = caseDetailsList.stream()
             .filter(c -> caseReference.equals(c.getReference().toString()))
@@ -1760,7 +1760,7 @@ public class CaseDetailsEndpointIT extends WireMockBaseTest {
         });
 
         final List<CaseDetails> caseDetailsList = template.query("SELECT * FROM case_data", this::mapCaseData);
-        assertEquals("Incorrect number of cases: No case should be created", 15, caseDetailsList.size());
+        assertEquals("Incorrect number of cases: No case should be created", 16, caseDetailsList.size());
 
         final CaseDetails savedCaseDetails = caseDetailsList.stream()
             .filter(c -> CASE_REFERENCE.equals(c.getReference().toString()))
@@ -1799,7 +1799,7 @@ public class CaseDetailsEndpointIT extends WireMockBaseTest {
         });
 
         final List<CaseDetails> caseDetailsList = template.query("SELECT * FROM case_data", this::mapCaseData);
-        assertEquals("Incorrect number of cases: No case should be created", 15, caseDetailsList.size());
+        assertEquals("Incorrect number of cases: No case should be created", 16, caseDetailsList.size());
 
         final CaseDetails savedCaseDetails = caseDetailsList.stream()
             .filter(c -> CASE_REFERENCE.equals(c.getReference().toString()))
@@ -1837,7 +1837,7 @@ public class CaseDetailsEndpointIT extends WireMockBaseTest {
         });
 
         final List<CaseDetails> caseDetailsList = template.query("SELECT * FROM case_data", this::mapCaseData);
-        assertEquals("Incorrect number of cases: No case should be created", 15, caseDetailsList.size());
+        assertEquals("Incorrect number of cases: No case should be created", 16, caseDetailsList.size());
 
         final CaseDetails savedCaseDetails = caseDetailsList.stream()
             .filter(c -> CASE_REFERENCE.equals(c.getReference().toString()))
@@ -1874,7 +1874,7 @@ public class CaseDetailsEndpointIT extends WireMockBaseTest {
         });
 
         final List<CaseDetails> caseDetailsList = template.query("SELECT * FROM case_data", this::mapCaseData);
-        assertEquals("Incorrect number of cases: No case should be created", 15, caseDetailsList.size());
+        assertEquals("Incorrect number of cases: No case should be created", 16, caseDetailsList.size());
 
         final CaseDetails savedCaseDetails = caseDetailsList.stream()
             .filter(c -> CASE_REFERENCE.equals(c.getReference().toString()))
@@ -1914,7 +1914,7 @@ public class CaseDetailsEndpointIT extends WireMockBaseTest {
         });
 
         final List<CaseDetails> caseDetailsList = template.query("SELECT * FROM case_data", this::mapCaseData);
-        assertEquals("Incorrect number of cases: No case should be created", 15, caseDetailsList.size());
+        assertEquals("Incorrect number of cases: No case should be created", 16, caseDetailsList.size());
 
         final CaseDetails savedCaseDetails = caseDetailsList.stream()
             .filter(c -> CASE_REFERENCE.equals(c.getReference().toString()))
@@ -1954,7 +1954,7 @@ public class CaseDetailsEndpointIT extends WireMockBaseTest {
         });
 
         final List<CaseDetails> caseDetailsList = template.query("SELECT * FROM case_data", this::mapCaseData);
-        assertEquals("Incorrect number of cases: No case should be created", 15, caseDetailsList.size());
+        assertEquals("Incorrect number of cases: No case should be created", 16, caseDetailsList.size());
 
         final CaseDetails savedCaseDetails = caseDetailsList.stream()
             .filter(c -> CASE_REFERENCE.equals(c.getReference().toString()))
@@ -1994,7 +1994,7 @@ public class CaseDetailsEndpointIT extends WireMockBaseTest {
         });
 
         final List<CaseDetails> caseDetailsList = template.query("SELECT * FROM case_data", this::mapCaseData);
-        assertEquals("Incorrect number of cases: No case should be created", 15, caseDetailsList.size());
+        assertEquals("Incorrect number of cases: No case should be created", 16, caseDetailsList.size());
 
         final CaseDetails savedCaseDetails = caseDetailsList.stream()
             .filter(c -> CASE_REFERENCE.equals(c.getReference().toString()))
@@ -2034,7 +2034,7 @@ public class CaseDetailsEndpointIT extends WireMockBaseTest {
         });
 
         final List<CaseDetails> caseDetailsList = template.query("SELECT * FROM case_data", this::mapCaseData);
-        assertEquals("Incorrect number of cases: No case should be created", 15, caseDetailsList.size());
+        assertEquals("Incorrect number of cases: No case should be created", 16, caseDetailsList.size());
 
         final CaseDetails savedCaseDetails = caseDetailsList.stream()
             .filter(c -> CASE_REFERENCE.equals(c.getReference().toString()))
@@ -2074,7 +2074,7 @@ public class CaseDetailsEndpointIT extends WireMockBaseTest {
         });
 
         final List<CaseDetails> caseDetailsList = template.query("SELECT * FROM case_data", this::mapCaseData);
-        assertEquals("Incorrect number of cases: No case should be created", 15, caseDetailsList.size());
+        assertEquals("Incorrect number of cases: No case should be created", 16, caseDetailsList.size());
 
         final CaseDetails savedCaseDetails = caseDetailsList.stream()
             .filter(c -> CASE_REFERENCE.equals(c.getReference().toString()))
@@ -2114,7 +2114,7 @@ public class CaseDetailsEndpointIT extends WireMockBaseTest {
         });
 
         final List<CaseDetails> caseDetailsList = template.query("SELECT * FROM case_data", this::mapCaseData);
-        assertEquals("Incorrect number of cases: No case should be created", 15, caseDetailsList.size());
+        assertEquals("Incorrect number of cases: No case should be created", 16, caseDetailsList.size());
 
         final CaseDetails savedCaseDetails = caseDetailsList.stream()
             .filter(c -> CASE_REFERENCE.equals(c.getReference().toString()))
@@ -2147,7 +2147,7 @@ public class CaseDetailsEndpointIT extends WireMockBaseTest {
         });
 
         final List<CaseDetails> caseDetailsList = template.query("SELECT * FROM case_data", this::mapCaseData);
-        assertEquals("Incorrect number of cases: No case should be created", 15, caseDetailsList.size());
+        assertEquals("Incorrect number of cases: No case should be created", 16, caseDetailsList.size());
 
         final CaseDetails savedCaseDetails = caseDetailsList.stream()
             .filter(c -> CASE_REFERENCE.equals(c.getReference().toString()))
@@ -2180,7 +2180,7 @@ public class CaseDetailsEndpointIT extends WireMockBaseTest {
         });
 
         final List<CaseDetails> caseDetailsList = template.query("SELECT * FROM case_data", this::mapCaseData);
-        assertEquals("Incorrect number of cases: No case should be created", 15, caseDetailsList.size());
+        assertEquals("Incorrect number of cases: No case should be created", 16, caseDetailsList.size());
 
         final CaseDetails savedCaseDetails = caseDetailsList.stream()
             .filter(c -> CASE_REFERENCE.equals(c.getReference().toString()))
@@ -2347,7 +2347,7 @@ public class CaseDetailsEndpointIT extends WireMockBaseTest {
             .andReturn();
 
         final List<CaseDetails> caseDetailsList = template.query("SELECT * FROM case_data", this::mapCaseData);
-        assertEquals("Incorrect number of cases: No case should be created", 15, caseDetailsList.size());
+        assertEquals("Incorrect number of cases: No case should be created", 16, caseDetailsList.size());
 
         final CaseDetails savedCaseDetails = caseDetailsList.stream()
             .filter(c -> CASE_REFERENCE.equals(c.getReference().toString()))
@@ -2404,7 +2404,7 @@ public class CaseDetailsEndpointIT extends WireMockBaseTest {
             .andReturn();
 
         final List<CaseDetails> caseDetailsList = template.query("SELECT * FROM case_data", this::mapCaseData);
-        assertEquals("Incorrect number of cases: No case should be created", 15, caseDetailsList.size());
+        assertEquals("Incorrect number of cases: No case should be created", 16, caseDetailsList.size());
 
         final CaseDetails savedCaseDetails = caseDetailsList.stream()
             .filter(c -> CASE_REFERENCE.equals(c.getReference().toString()))
@@ -3228,7 +3228,7 @@ public class CaseDetailsEndpointIT extends WireMockBaseTest {
             mapper.readTree(mvcResult.getResponse().getContentAsString()).get("case_data").toString());
 
         final List<CaseDetails> caseDetailsList = template.query("SELECT * FROM case_data", this::mapCaseData);
-        assertEquals("Incorrect number of cases: No case should be created", 15, caseDetailsList.size());
+        assertEquals("Incorrect number of cases: No case should be created", 16, caseDetailsList.size());
 
         final CaseDetails savedCaseDetails = caseDetailsList.stream()
             .filter(c -> CASE_REFERENCE.equals(c.getReference().toString()))
@@ -3315,7 +3315,7 @@ public class CaseDetailsEndpointIT extends WireMockBaseTest {
             mapper.readTree(mvcResult.getResponse().getContentAsString()).get("case_data").toString());
 
         final List<CaseDetails> caseDetailsList = template.query("SELECT * FROM case_data", this::mapCaseData);
-        assertEquals("Incorrect number of cases: No case should be created", 15, caseDetailsList.size());
+        assertEquals("Incorrect number of cases: No case should be created", 16, caseDetailsList.size());
 
         final CaseDetails savedCaseDetails = caseDetailsList.stream()
             .filter(c -> CASE_REFERENCE.equals(c.getReference().toString()))
@@ -3545,7 +3545,7 @@ public class CaseDetailsEndpointIT extends WireMockBaseTest {
         String responseAsString = result.getResponse().getContentAsString();
         List<CaseDetails> caseDetails = Arrays.asList(mapper.readValue(responseAsString, CaseDetails[].class));
 
-        assertThat(caseDetails, hasSize(1));
+        assertThat(caseDetails, hasSize(2));
         assertThat(result.getResponse().getContentAsString(), containsString(TEST_JURISDICTION));
         assertThat(result.getResponse().getContentAsString(), containsString(TEST_CASE_TYPE));
         assertThat(result.getResponse().getContentAsString(), containsString(TEST_STATE));
@@ -3899,7 +3899,7 @@ public class CaseDetailsEndpointIT extends WireMockBaseTest {
 
         responseAsString = result.getResponse().getContentAsString();
         List<CaseDetails> caseDetailsPage4 = Arrays.asList(mapper.readValue(responseAsString, CaseDetails[].class));
-        assertThat(caseDetailsPage4, hasSize(0));
+        assertThat(caseDetailsPage4, hasSize(1));
 
         Set<Long> references = allPages.stream().map(cd -> cd.getReference()).collect(Collectors.toSet());
         assertThat(references, hasSize(5)); //TODO RDM-1455 due to filtering being applied after pagination, to be fixed after EL implementation
@@ -3922,8 +3922,8 @@ public class CaseDetailsEndpointIT extends WireMockBaseTest {
         String responseAsString = result.getResponse().getContentAsString();
         PaginatedSearchMetadata metadata = mapper.readValue(responseAsString, PaginatedSearchMetadata.class);
 
-        assertThat(metadata.getTotalPagesCount(), is(3));
-        assertThat(metadata.getTotalResultsCount(), is(6));
+        assertThat(metadata.getTotalPagesCount(), is(4));
+        assertThat(metadata.getTotalResultsCount(), is(7));
 
         result = mockMvc.perform(get(GET_PAGINATED_SEARCH_METADATA)
                 .contentType(JSON_CONTENT_TYPE)
@@ -4011,7 +4011,7 @@ public class CaseDetailsEndpointIT extends WireMockBaseTest {
      */
     private void assertCaseDataResultSetSize() {
         final int count = template.queryForObject("SELECT count(1) as n FROM case_data",Integer.class);
-        assertEquals("Incorrect case data size", 15, count);
+        assertEquals("Incorrect case data size", 16, count);
     }
 
     private JsonNode getTextNode(String value) {

--- a/src/test/java/uk/gov/hmcts/ccd/endpoint/ui/QueryEndpointIT.java
+++ b/src/test/java/uk/gov/hmcts/ccd/endpoint/ui/QueryEndpointIT.java
@@ -114,7 +114,7 @@ public class QueryEndpointIT extends WireMockBaseTest {
         // Check that we have the expected test data set size, this is to ensure
         // that state filtering is correct
         final List<CaseDetails> resultList = template.query("SELECT * FROM case_data", this::mapCaseData);
-        assertEquals("Incorrect data initiation", 15, resultList.size());
+        assertEquals("Incorrect data initiation", 16, resultList.size());
 
         final String TEST_STATE = "CaseCreated";
 
@@ -176,7 +176,7 @@ public class QueryEndpointIT extends WireMockBaseTest {
         // Check that we have the expected test data set size, this is to ensure
         // that state filtering is correct
         final List<CaseDetails> resultList = template.query("SELECT * FROM case_data", this::mapCaseData);
-        assertEquals("Incorrect data initiation", 15, resultList.size());
+        assertEquals("Incorrect data initiation", 16, resultList.size());
 
         final MvcResult result = mockMvc.perform(get(GET_CASES_NO_READ_CASE_FIELD_ACCESS)
             .contentType(JSON_CONTENT_TYPE)
@@ -215,7 +215,7 @@ public class QueryEndpointIT extends WireMockBaseTest {
         // Check that we have the expected test data set size, this is to ensure
         // that state filtering is correct
         final List<CaseDetails> resultList = template.query("SELECT * FROM case_data", this::mapCaseData);
-        assertEquals("Incorrect data initiation", 15, resultList.size());
+        assertEquals("Incorrect data initiation", 16, resultList.size());
 
         final MvcResult result = mockMvc.perform(get(GET_CASES_NO_READ_CASE_TYPE_ACCESS)
             .contentType(JSON_CONTENT_TYPE)
@@ -237,7 +237,7 @@ public class QueryEndpointIT extends WireMockBaseTest {
         // Check that we have the expected test data set size, this is to ensure
         // that state filtering is correct
         final List<CaseDetails> resultList = template.query("SELECT * FROM case_data", this::mapCaseData);
-        assertEquals("Incorrect data initiation", 15, resultList.size());
+        assertEquals("Incorrect data initiation", 16, resultList.size());
 
         final MvcResult result = mockMvc.perform(get(GET_CASES)
             .contentType(JSON_CONTENT_TYPE)
@@ -265,7 +265,7 @@ public class QueryEndpointIT extends WireMockBaseTest {
         assertEquals("Address", searchResultViewColumns[2].getLabel());
         assertEquals(1, searchResultViewColumns[2].getOrder().intValue());
 
-        assertEquals("Incorrect view items count", 1, searchResultViewItems.length);
+        assertEquals("Incorrect view items count", 2, searchResultViewItems.length);
 
         assertNotNull(searchResultViewItems[0].getCaseId());
         assertEquals("Janet", searchResultViewItems[0].getCaseFields().get("PersonFirstName").asText());
@@ -284,7 +284,7 @@ public class QueryEndpointIT extends WireMockBaseTest {
         // Check that we have the expected test data set size, this is to ensure
         // that state filtering is correct
         final List<CaseDetails> resultList = template.query("SELECT * FROM case_data", this::mapCaseData);
-        assertEquals("Incorrect data initiation", 15, resultList.size());
+        assertEquals("Incorrect data initiation", 16, resultList.size());
 
         final MvcResult result = mockMvc.perform(get(GET_CASES)
             .contentType(JSON_CONTENT_TYPE)
@@ -324,7 +324,7 @@ public class QueryEndpointIT extends WireMockBaseTest {
         // Check that we have the expected test data set size, this is to ensure
         // that state filtering is correct
         final List<CaseDetails> resultList = template.query("SELECT * FROM case_data", this::mapCaseData);
-        assertEquals("Incorrect data initiation", 15, resultList.size());
+        assertEquals("Incorrect data initiation", 16, resultList.size());
 
         final MvcResult result = mockMvc.perform(get(GET_CASES)
             .contentType(JSON_CONTENT_TYPE)
@@ -343,7 +343,7 @@ public class QueryEndpointIT extends WireMockBaseTest {
         // Check that we have the expected test data set size, this is to ensure
         // that state filtering is correct
         final List<CaseDetails> resultList = template.query("SELECT * FROM case_data", this::mapCaseData);
-        assertEquals("Incorrect data initiation", 15, resultList.size());
+        assertEquals("Incorrect data initiation", 16, resultList.size());
 
         final MvcResult result = mockMvc.perform(get(GET_CASES)
             .contentType(JSON_CONTENT_TYPE)
@@ -388,7 +388,7 @@ public class QueryEndpointIT extends WireMockBaseTest {
         // Check that we have the expected test data set size, this is to ensure
         // that state filtering is correct
         final List<CaseDetails> resultList = template.query("SELECT * FROM case_data", this::mapCaseData);
-        assertEquals("Incorrect data initiation", 15, resultList.size());
+        assertEquals("Incorrect data initiation", 16, resultList.size());
 
         final MvcResult result = mockMvc.perform(get(GET_CASES)
             .contentType(JSON_CONTENT_TYPE)
@@ -431,7 +431,7 @@ public class QueryEndpointIT extends WireMockBaseTest {
         // Check that we have the expected test data set size, this is to ensure
         // that state filtering is correct
         final List<CaseDetails> resultList = template.query("SELECT * FROM case_data", this::mapCaseData);
-        assertEquals("Incorrect data initiation", 15, resultList.size());
+        assertEquals("Incorrect data initiation", 16, resultList.size());
 
         final MvcResult result = mockMvc.perform(get(GET_CASES)
             .contentType(JSON_CONTENT_TYPE)
@@ -487,7 +487,7 @@ public class QueryEndpointIT extends WireMockBaseTest {
         // Check that we have the expected test data set size, this is to ensure
         // that state filtering is correct
         final List<CaseDetails> resultList = template.query("SELECT * FROM case_data", this::mapCaseData);
-        assertEquals("Incorrect data initiation", 15, resultList.size());
+        assertEquals("Incorrect data initiation", 16, resultList.size());
 
         final MvcResult result = mockMvc.perform(get(GET_CASES)
             .contentType(JSON_CONTENT_TYPE)
@@ -572,7 +572,7 @@ public class QueryEndpointIT extends WireMockBaseTest {
 
         // Check that we have the expected test data set size
         final List<CaseDetails> resultList = template.query("SELECT * FROM case_data", this::mapCaseData);
-        assertEquals("Incorrect data initiation", 15, resultList.size());
+        assertEquals("Incorrect data initiation", 16, resultList.size());
 
         final MvcResult result = mockMvc.perform(get(GET_CASE)
             .contentType(JSON_CONTENT_TYPE)
@@ -737,7 +737,7 @@ public class QueryEndpointIT extends WireMockBaseTest {
 
         // Check that we have the expected test data set size
         final List<CaseDetails> resultList = template.query("SELECT * FROM case_data", this::mapCaseData);
-        assertEquals("Incorrect data initiation", 15, resultList.size());
+        assertEquals("Incorrect data initiation", 16, resultList.size());
 
         // set the state to a state where this user has no update access
         template.execute("UPDATE case_data SET state='some-state' WHERE reference='1504259907353529'");
@@ -762,7 +762,7 @@ public class QueryEndpointIT extends WireMockBaseTest {
 
         // Check that we have the expected test data set size
         final List<CaseDetails> resultList = template.query("SELECT * FROM case_data", this::mapCaseData);
-        assertEquals("Incorrect data initiation", 15, resultList.size());
+        assertEquals("Incorrect data initiation", 16, resultList.size());
 
         final MvcResult result = mockMvc.perform(get(GET_CASE_NO_EVENT_READ_ACCESS)
             .contentType(JSON_CONTENT_TYPE)
@@ -808,7 +808,7 @@ public class QueryEndpointIT extends WireMockBaseTest {
 
         // Check that we have the expected test data set size
         List<CaseDetails> resultList = template.query("SELECT * FROM case_data", this::mapCaseData);
-        assertEquals("Incorrect data initiation", 15, resultList.size());
+        assertEquals("Incorrect data initiation", 16, resultList.size());
 
         final MvcResult result = mockMvc.perform(get(GET_CASE_INVALID_REFERENCE)
             .contentType(JSON_CONTENT_TYPE)
@@ -817,7 +817,7 @@ public class QueryEndpointIT extends WireMockBaseTest {
             .andReturn();
 
         resultList = template.query("SELECT * FROM case_data", this::mapCaseData);
-        assertEquals("Incorrect data initiation", 15, resultList.size());
+        assertEquals("Incorrect data initiation", 16, resultList.size());
     }
 
     @Test
@@ -976,7 +976,7 @@ public class QueryEndpointIT extends WireMockBaseTest {
     public void getEventTriggerForCaseType_valid() throws Exception {
         // Check that we have the expected test data set size
         final List<CaseDetails> resultList = template.query("SELECT * FROM case_data", this::mapCaseData);
-        assertEquals("Incorrect data initiation", 15, resultList.size());
+        assertEquals("Incorrect data initiation", 16, resultList.size());
 
         final MvcResult result = mockMvc.perform(get(GET_EVENT_TRIGGER_FOR_CASE_TYPE_VALID)
             .contentType(JSON_CONTENT_TYPE)
@@ -1038,7 +1038,7 @@ public class QueryEndpointIT extends WireMockBaseTest {
 
         // Check that we have the expected test data set size
         final List<CaseDetails> resultList = template.query("SELECT * FROM case_data", this::mapCaseData);
-        assertEquals("Incorrect data initiation", 15, resultList.size());
+        assertEquals("Incorrect data initiation", 16, resultList.size());
 
         final MvcResult result = mockMvc.perform(get(GET_EVENT_TRIGGER_FOR_CASE_VALID)
             .contentType(JSON_CONTENT_TYPE)

--- a/src/test/java/uk/gov/hmcts/ccd/infrastructure/user/UserAuthorisationConfigurationTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/infrastructure/user/UserAuthorisationConfigurationTest.java
@@ -17,7 +17,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.when;
 
 @DisplayName("UserAuthorisationFactory")
-class UserAuthorisationFactoryTest {
+class UserAuthorisationConfigurationTest {
 
     private static final String USER_ID = "123";
     private static final UserAuthorisation.AccessLevel ACCESS_LEVEL = UserAuthorisation.AccessLevel.GRANTED;
@@ -35,7 +35,7 @@ class UserAuthorisationFactoryTest {
     private CaseAccessService caseAccessService;
 
     @InjectMocks
-    private UserAuthorisationFactory factory;
+    private UserAuthorisationConfiguration factory;
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/uk/gov/hmcts/ccd/infrastructure/user/UserAuthorisationFactoryTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/infrastructure/user/UserAuthorisationFactoryTest.java
@@ -1,0 +1,69 @@
+package uk.gov.hmcts.ccd.infrastructure.user;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import uk.gov.hmcts.ccd.domain.service.common.CaseAccessService;
+import uk.gov.hmcts.reform.auth.checker.spring.serviceanduser.ServiceAndUserDetails;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.when;
+
+@DisplayName("UserAuthorisationFactory")
+class UserAuthorisationFactoryTest {
+
+    private static final String USER_ID = "123";
+    private static final UserAuthorisation.AccessLevel ACCESS_LEVEL = UserAuthorisation.AccessLevel.GRANTED;
+
+    @Mock
+    private SecurityContext securityContext;
+
+    @Mock
+    private Authentication authentication;
+
+    @Mock
+    private ServiceAndUserDetails serviceAndUser;
+
+    @Mock
+    private CaseAccessService caseAccessService;
+
+    @InjectMocks
+    private UserAuthorisationFactory factory;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        SecurityContextHolder.setContext(securityContext);
+
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        when(authentication.getPrincipal()).thenReturn(serviceAndUser);
+
+        when(serviceAndUser.getUsername()).thenReturn(USER_ID);
+        when(caseAccessService.getAccessLevel(serviceAndUser)).thenReturn(ACCESS_LEVEL);
+    }
+
+    @Test
+    @DisplayName("should create user authorisation with ID")
+    void shouldCreateAuthorisationForUserID() {
+        final UserAuthorisation userAuthorisation = factory.create();
+
+        assertThat(userAuthorisation.getUserId(), equalTo(USER_ID));
+    }
+
+    @Test
+    @DisplayName("should create user authorisation with access level")
+    void shouldCreateAuthorisationWithAccessLevel() {
+        final UserAuthorisation userAuthorisation = factory.create();
+
+        assertThat(userAuthorisation.getAccessLevel(), equalTo(ACCESS_LEVEL));
+    }
+
+}

--- a/src/test/resources/sql/insert_case_users.sql
+++ b/src/test/resources/sql/insert_case_users.sql
@@ -1,0 +1,4 @@
+delete from case_users;
+
+insert into case_users (case_data_id, user_id)
+  values (16, 1);

--- a/src/test/resources/sql/insert_cases.sql
+++ b/src/test/resources/sql/insert_cases.sql
@@ -566,6 +566,19 @@ VALUES (13, 'TestAddressBookCaseNoReadFieldAccess', 'PROBATE', 'CaseCreated', 'P
        '1504259907353651'
 );
 
+INSERT INTO case_data (id, case_type_id, jurisdiction, state, security_classification, data, data_classification, reference)
+VALUES (16, 'TestAddressBookCase', 'PROBATE', 'CaseCreated', 'PUBLIC',
+        '{
+          "PersonFirstName": "Janet",
+          "PersonLastName": "Doe"
+        }',
+        '{
+          "PersonFirstName": "PUBLIC",
+          "PersonLastName": "PUBLIC"
+        }',
+        '1504254784737847'
+);
+
 INSERT INTO case_event (
         case_data_id,
         case_type_id,


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDM-1448

### Change description ###

Enforce user access constraints as part of the SQL queries. This allows pagination on search to stay accurate when cases are filtered out by this constraint.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
