### PR TITLE
Defaults to test for CNP sandbox

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -40,15 +40,15 @@ variable "database-name" {
 }
 
 variable "vault_section" {
-  default = "preprod"
+  default = "test"
 }
 
 variable "idam_api_url" {
-  default = "https://preprod-idamapi.reform.hmcts.net:3511"
+  default = "http://betaDevBccidamAppLB.reform.hmcts.net"
 }
 
 variable "s2s_url" {
-  default = "https://preprod-s2s-api.reform.hmcts.net:3511"
+  default = "http://betaDevBccidamS2SLB.reform.hmcts.net"
 }
 
 variable "authorised-services" {
@@ -57,7 +57,7 @@ variable "authorised-services" {
 }
 
 variable "document_management_valid_domain" {
-  default = "https://api-gateway.preprod.dm.reform.hmcts.net"
+  default = "https://api-gateway.test.dm.reform.hmcts.net"
 }
 
 variable "default_print_url" {


### PR DESCRIPTION
Use tactical test by default to support sandbox, saat and sprod envs.