### PR TITLE
Do not sanitise null document

### DIFF
--- a/src/main/java/uk/gov/hmcts/ccd/domain/types/sanitiser/DocumentSanitiser.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/types/sanitiser/DocumentSanitiser.java
@@ -44,8 +44,9 @@ public class DocumentSanitiser implements Sanitiser {
     public JsonNode sanitise(FieldType fieldType, JsonNode fieldData) {
         final ObjectNode sanitisedData = JSON_NODE_FACTORY.objectNode();
 
-        if (fieldData.has(DOCUMENT_BINARY_URL)
-            && fieldData.has(DOCUMENT_FILENAME)) {
+        if ((fieldData.has(DOCUMENT_BINARY_URL)
+            && fieldData.has(DOCUMENT_FILENAME))
+            || fieldData.isNull()) {
             return fieldData;
         } else {
             final String documentUrl = fieldData.get(DOCUMENT_URL).textValue();

--- a/src/test/java/uk/gov/hmcts/ccd/domain/types/sanitiser/DocumentSanitiserTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/types/sanitiser/DocumentSanitiserTest.java
@@ -2,7 +2,9 @@ package uk.gov.hmcts.ccd.domain.types.sanitiser;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,6 +23,7 @@ import uk.gov.hmcts.ccd.endpoint.exceptions.ValidationException;
 import java.util.Collections;
 
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -171,6 +174,16 @@ class DocumentSanitiserTest {
         assertThrows(ValidationException.class, () -> {
             documentSanitiser.sanitise(DOCUMENT_FIELD_TYPE, DOCUMENT_VALUE_INITIAL);
         });
+    }
+
+    @Test
+    @DisplayName("should not sanitise document when null node")
+    void shouldNotSanitizeIfDocumentIsNullNode() {
+        final NullNode initialValue = JSON_FACTORY.nullNode();
+
+        final JsonNode saneValue = documentSanitiser.sanitise(DOCUMENT_FIELD_TYPE, initialValue);
+
+        assertThat(saneValue, sameInstance(initialValue));
     }
 
     private Document buildDocument() {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDM-1985

### Change description ###

Attempt to sanitise null document throws NPE. This add checks to only sanitise documents that are not null nodes.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
