### PR TITLE
RDM-2230: Support event ID max length 70 chars

### DIFF
--- a/src/main/resources/db/changelog/db.changelog-RDM-2230.xml
+++ b/src/main/resources/db/changelog/db.changelog-RDM-2230.xml
@@ -1,0 +1,12 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="19" author="vlaurin">
+        <modifyDataType tableName="case_event"
+                        columnName="event_id"
+                        newDataType="varchar(70)"
+        />
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -12,4 +12,5 @@
     <include file="db/changelog/db.changelog-1.2-1.xml"/>
     <include file="db/changelog/db.changelog-RDM-1462.xml"/>
     <include file="db/changelog/db.changelog-RDM-1565.xml"/>
+    <include file="db/changelog/db.changelog-RDM-2230.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDM-2230

### Change description ###

Definition store dictates that event IDs have a max length of 70 chars. However, data store only support max length of 40 chars. This is updating the column to be `varchar(70)`.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```