### PR TITLE
Rdm 1149

### DIFF
--- a/src/main/java/uk/gov/hmcts/ccd/domain/types/DateTimeValidator.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/types/DateTimeValidator.java
@@ -1,0 +1,96 @@
+package uk.gov.hmcts.ccd.domain.types;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import uk.gov.hmcts.ccd.domain.model.definition.CaseField;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.Collections;
+import java.util.List;
+
+import static java.time.format.DateTimeFormatter.ISO_DATE_TIME;
+import static uk.gov.hmcts.ccd.domain.types.TextValidator.checkRegex;
+
+/**
+ * Max and Min is expressed as EPOCH
+ */
+@Named
+@Singleton
+public class DateTimeValidator implements BaseTypeValidator {
+    private static final String TYPE_ID = "DateTime";
+
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ISO_DATE_TIME;
+
+    public BaseType getType() {
+        return BaseType.get(TYPE_ID);
+    }
+
+    @Override
+    public List<ValidationResult> validate(final String dataFieldId,
+                                           final JsonNode dataValue,
+                                           final CaseField caseFieldDefinition) {
+        if (isNullOrEmpty(dataValue)) {
+            return Collections.emptyList();
+        }
+
+        final LocalDateTime dateTimeValue;
+        try {
+            dateTimeValue = LocalDateTime.parse(dataValue.asText(), ISO_DATE_TIME);
+        } catch (DateTimeParseException e) {
+            return Collections.singletonList(new ValidationResult(dataValue + " is not a valid ISO 8601 date time", dataFieldId));
+        }
+
+        if (!checkMax(caseFieldDefinition.getFieldType().getMax(), dateTimeValue)) {
+            return Collections.singletonList(new ValidationResult("The date time should be earlier than "
+                + DATE_TIME_FORMATTER.format(epochTimeStampToLocalDate(caseFieldDefinition.getFieldType().getMax())), dataFieldId));
+        }
+
+        if (!checkMin(caseFieldDefinition.getFieldType().getMin(), dateTimeValue)) {
+            return Collections.singletonList(new ValidationResult("The date time should be later than "
+                + DATE_TIME_FORMATTER.format(epochTimeStampToLocalDate(caseFieldDefinition.getFieldType().getMin())), dataFieldId));
+        }
+
+        if (!checkRegex(caseFieldDefinition.getFieldType().getRegularExpression(), dataValue.asText())) {
+            return Collections.singletonList(new ValidationResult(dataValue.asText() + " Field Type Regex Failed:" + caseFieldDefinition.getFieldType().getRegularExpression(), dataFieldId));
+        }
+
+        if (!checkRegex(getType().getRegularExpression(), dataValue.asText())) {
+            return Collections.singletonList(new ValidationResult(dataValue.asText() + " Date Time Type Regex Failed:" + getType().getRegularExpression(), dataFieldId));
+        }
+
+        return Collections.emptyList();
+    }
+
+    private Boolean checkMax(final BigDecimal max, final LocalDateTime dateTimeValue) {
+        if (max == null) {
+            return true;
+        }
+
+        final Instant maxDate = Instant.ofEpochMilli(max.longValue());
+        final Instant testDate = dateTimeValue.toInstant(ZoneOffset.UTC);
+        return maxDate.isAfter(testDate) || maxDate.equals(testDate);
+    }
+
+    private Boolean checkMin(final BigDecimal min, final LocalDateTime dateTimeValue) {
+        if (min == null) {
+            return true;
+        }
+
+        final Instant minDate = Instant.ofEpochMilli(min.longValue());
+        final Instant testDate = dateTimeValue.toInstant(ZoneOffset.UTC);
+        return minDate.isBefore(testDate) || minDate.equals(testDate);
+    }
+
+    private LocalDateTime epochTimeStampToLocalDate(final BigDecimal timestamp) {
+        return Instant
+            .ofEpochMilli(timestamp.longValue())
+            .atZone(ZoneOffset.UTC)
+            .toLocalDateTime();
+    }
+}

--- a/src/test/java/uk/gov/hmcts/ccd/TestConfiguration.java
+++ b/src/test/java/uk/gov/hmcts/ccd/TestConfiguration.java
@@ -59,6 +59,9 @@ class TestConfiguration extends ContextCleanupListener {
             "    \"type\": \"Date\"\n" +
             "  },\n" +
             "  {\n" +
+            "    \"type\": \"DateTime\"\n" +
+            "  },\n" +
+            "  {\n" +
             "    \"type\": \"FixedList\"\n" +
             "  },\n" +
             "  {\n" +

--- a/src/test/java/uk/gov/hmcts/ccd/data/definition/DefaultCaseDefinitionRepositoryIT.java
+++ b/src/test/java/uk/gov/hmcts/ccd/data/definition/DefaultCaseDefinitionRepositoryIT.java
@@ -44,11 +44,12 @@ public class DefaultCaseDefinitionRepositoryIT extends WireMockBaseTest {
 
         assertAll(
             "Assert All of these",
-            () -> assertThat(baseTypes, IsCollectionWithSize.hasSize(14)),
+            () -> assertThat(baseTypes, IsCollectionWithSize.hasSize(15)),
             () -> assertThat(baseTypes, hasItem(hasProperty("type", is("Text")))),
             () -> assertThat(baseTypes, hasItem(hasProperty("type", is("Number")))),
             () -> assertThat(baseTypes, hasItem(hasProperty("type", is("Email")))),
             () -> assertThat(baseTypes, hasItem(hasProperty("type", is("YesOrNo")))),
+            () -> assertThat(baseTypes, hasItem(hasProperty("type", is("Date")))),
             () -> assertThat(baseTypes, hasItem(hasProperty("type", is("Date")))),
             () -> assertThat(baseTypes, hasItem(hasProperty("type", is("FixedList")))),
             () -> assertThat(baseTypes, hasItem(hasProperty("type", is("PostCode")))),

--- a/src/test/java/uk/gov/hmcts/ccd/domain/types/DateTimeValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/types/DateTimeValidatorTest.java
@@ -1,0 +1,309 @@
+package uk.gov.hmcts.ccd.domain.types;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.gov.hmcts.ccd.BaseTest;
+import uk.gov.hmcts.ccd.domain.model.definition.CaseField;
+
+import javax.inject.Inject;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import static java.time.format.DateTimeFormatter.ISO_DATE_TIME;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.core.StringEndsWith.endsWith;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+public class DateTimeValidatorTest extends BaseTest implements IVallidatorTest {
+    private static final String CASE_FIELD_STRING =
+        "{\n" +
+        "  \"id\": \"TEST_FIELD_ID\",\n" +
+        "  \"field_type\": {\n" +
+        "    \"type\": \"DATETIME\"\n" +
+        "  }\n" +
+        "}";
+
+    @Inject
+    private DateTimeValidator validator;
+    private CaseField caseField;
+
+    @Before
+    public void setUp() throws Exception {
+        caseField = MAPPER.readValue(CASE_FIELD_STRING, CaseField.class);
+        ReflectionTestUtils.setField(validator.getType(), "regularExpression",
+            "^(\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|" +
+                "(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)" +
+                "([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$");
+    }
+
+    @Test
+    public void validDate() {
+        final List<ValidationResult> result01 = validator.validate("TEST_FIELD_ID",
+            NODE_FACTORY.textNode("2012-04-21T00:00:00.000"), caseField);
+        assertEquals(0, result01.size());
+
+        final List<ValidationResult> result02 = validator.validate("TEST_FIELD_ID",
+            NODE_FACTORY.textNode("2012-04-21T00:00:00.000Z"), caseField);
+        assertEquals(0, result02.size());
+
+        final List<ValidationResult> result03 = validator.validate("TEST_FIELD_ID",
+            NODE_FACTORY.textNode("2012-04-21T00:00:00+01:00"), caseField);
+        assertEquals(0, result03.size());
+    }
+
+    @Test
+    public void invalidDate() {
+        final List<ValidationResult> result01 = validator.validate("TEST_FIELD_ID",
+            NODE_FACTORY.textNode("3321M1 1AA"), caseField);
+        assertEquals("Did not catch invalid date 3321M1 1AA", 1, result01.size());
+        assertEquals("\"3321M1 1AA\" is not a valid ISO 8601 date time", result01.get(0).getErrorMessage());
+
+        final List<ValidationResult> result02 = validator.validate("TEST_FIELD_ID",
+            NODE_FACTORY.textNode("1800-14-14T00:00:00"), caseField);
+        assertEquals("Did not catch invalid date 1800-14-14 ", 1, result02.size());
+        assertEquals("\"1800-14-14T00:00:00\" is not a valid ISO 8601 date time", result02.get(0).getErrorMessage());
+
+        final List<ValidationResult> result03 = validator.validate("TEST_FIELD_ID",
+            NODE_FACTORY.textNode("2001-11-31T00:00:00"), caseField);
+        assertEquals("Did not catch invalid date time 2001-11-31", 1, result03.size());
+        assertEquals("\"2001-11-31T00:00:00\" is not a valid ISO 8601 date time", result03.get(0).getErrorMessage());
+
+        // checks that ISO DATE is not accepted by DateTimeValidator
+        final List<ValidationResult> result04 = validator.validate("TEST_FIELD_ID",
+            NODE_FACTORY.textNode("2001-01-01"), caseField);
+        assertEquals("Did not catch invalid date time 2001-01-01", 1, result04.size());
+        assertEquals("\"2001-01-01\" is not a valid ISO 8601 date time", result04.get(0).getErrorMessage());
+
+        final List<ValidationResult> result05 = validator.validate("TEST_FIELD_ID",
+            NODE_FACTORY.textNode("2000-02-29T00:00:00Z"), caseField);
+        assertEquals("Year 2000 is a leap year", 0, result05.size());
+
+        final List<ValidationResult> result06 = validator.validate("TEST_FIELD_ID",
+            NODE_FACTORY.textNode("2100-02-29T00:00:00Z"), caseField);
+        assertEquals("Did not catch invalid date 2100-02-29Z", 1, result06.size());
+        assertEquals("\"2100-02-29T00:00:00Z\" is not a valid ISO 8601 date time", result06.get(0).getErrorMessage());
+    }
+
+    @Test
+    public void getType() {
+        assertEquals("Type is incorrect", validator.getType(), BaseType.get("DATETIME"));
+    }
+
+    @Test
+    public void nullValue() {
+        assertEquals("Did not catch NULL", 0, validator.validate("TEST_FIELD_ID", null, null).size());
+    }
+
+    @Test
+    public void checkMax() throws Exception {
+        final String validDateTime = "2001-01-01T00:00:00Z";
+        final String invalidDateTime = "2002-01-01T00:00:00Z";
+        final String maxDate = "2001-12-31T00:00:00+01:00";
+        final Long maxDateTime = convertToLongTime(maxDate);
+        final CaseField caseField = MAPPER.readValue(
+            "{\n" +
+            "  \"id\": \"DATE_TEST\",\n" +
+            "  \"field_type\": {\n" +
+            "    \"type\": \"DATETIME\",\n" +
+            "    \"max\": \"" + maxDateTime + "\"\n" +
+            "  }\n" +
+            "}", CaseField.class);
+
+        final List<ValidationResult> result01 = validator.validate("TEST_FIELD_ID",
+            NODE_FACTORY.textNode(validDateTime), caseField);
+        assertEquals(result01.toString(), 0, result01.size());
+
+        final List<ValidationResult> result02 = validator.validate("TEST_FIELD_ID",
+            NODE_FACTORY.textNode(maxDate), caseField);
+        assertEquals(result02.toString(), 0, result02.size());
+
+        final List<ValidationResult> result03 = validator.validate("TEST_FIELD_ID",
+            NODE_FACTORY.textNode(invalidDateTime), caseField);
+        assertEquals("Did not catch invalid max-date", 1, result03.size());
+        assertEquals("Validation message", "The date time should be earlier than 2001-12-31T00:00:00",
+            result03.get(0).getErrorMessage());
+    }
+
+    @Test
+    public void checkMin() throws Exception {
+        final String validDateTime = "2001-12-31T00:00:00Z";
+        final String invalidDateTime = "2000-01-01T00:00:00Z";
+        final String minDate = "2001-01-01T00:00:00Z";
+        final Long minDateTime = convertToLongTime(minDate);
+        final CaseField caseField = MAPPER.readValue(
+            "{\n" +
+            "  \"id\": \"DATE_TEST\",\n" +
+            "  \"field_type\": {\n" +
+            "    \"type\": \"DATETIME\",\n" +
+            "    \"min\": \"" + minDateTime + "\"\n" +
+            "  }\n" +
+            "}", CaseField.class);
+
+        final List<ValidationResult> result01 = validator.validate("TEST_FIELD_ID",
+            NODE_FACTORY.textNode(validDateTime), caseField);
+        assertEquals(result01.toString(), 0, result01.size());
+
+        final List<ValidationResult> result02 = validator.validate("TEST_FIELD_ID",
+            NODE_FACTORY.textNode(minDate), caseField);
+        assertEquals(result02.toString(), 0, result02.size());
+
+        final List<ValidationResult> result03 = validator.validate("TEST_FIELD_ID",
+            NODE_FACTORY.textNode(invalidDateTime), caseField);
+        assertEquals("Did not catch invalid max-date", 1, result03.size());
+        assertEquals("Validation message", "The date time should be later than 2001-01-01T00:00:00",
+            result03.get(0).getErrorMessage());
+    }
+
+    @Test
+    public void checkMaxMinWithoutRegEx() throws Exception {
+        final String validDateTime = "2001-12-10T00:00:00Z";
+        final String invalidMinDateTime = "1999-12-31T00:00:00Z";
+        final String invalidMaxDateTime = "2002-01-01T00:00:00Z";
+        final String minDate = "2001-01-01T00:00:00Z";
+        final Long minDateTime = convertToLongTime(minDate);
+        final String maxDate = "2001-12-31T00:00:00Z";
+        final Long maxDateTime = convertToLongTime(maxDate);
+        final CaseField caseField = MAPPER.readValue(
+            "{\n" +
+                "  \"id\": \"DATE_TEST\",\n" +
+                "  \"field_type\": {\n" +
+                "    \"type\": \"DATETIME\",\n" +
+                "    \"max\": \"" + maxDateTime + "\",\n" +
+                "    \"min\": \"" + minDateTime + "\"\n" +
+                "  }\n" +
+                "}", CaseField.class);
+
+        final List<ValidationResult> result01 = validator.validate("TEST_FIELD_ID",
+            NODE_FACTORY.textNode(validDateTime), caseField);
+        assertEquals(result01.toString(), 0, result01.size());
+
+        final List<ValidationResult> result02 = validator.validate("TEST_FIELD_ID",
+            NODE_FACTORY.textNode(minDate), caseField);
+        assertEquals(result02.toString(), 0, result02.size());
+
+        final List<ValidationResult> result03 = validator.validate("TEST_FIELD_ID",
+            NODE_FACTORY.textNode(maxDate), caseField);
+        assertEquals(result03.toString(), 0, result03.size());
+
+        final List<ValidationResult> result04 = validator.validate("TEST_FIELD_ID",
+            NODE_FACTORY.textNode(invalidMinDateTime), caseField);
+        assertEquals("Did not catch invalid min-date", 1, result04.size());
+
+        final List<ValidationResult> result05 = validator.validate("TEST_FIELD_ID",
+            NODE_FACTORY.textNode(invalidMaxDateTime), caseField);
+        assertEquals("Did not catch invalid max-date", 1, result05.size());
+    }
+
+    @Test
+    public void invalidFieldTypeRegEx() throws Exception {
+        final Long minDateTime = convertToLongTime("2001-01-01T00:00:00");
+        final Long maxDateTime = convertToLongTime("2001-12-31T00:00:00");
+        final String validDateTime = "2001-12-10T00:00:00Z";
+
+        final CaseField caseField = MAPPER.readValue(
+            "{\n" +
+                "  \"id\": \"DATE_TEST\",\n" +
+                "  \"field_type\": {\n" +
+                "    \"type\": \"DATETIME\",\n" +
+                "    \"max\": \"" + maxDateTime + "\",\n" +
+                "    \"min\": \"" + minDateTime + "\",\n" +
+                "    \"regular_expression\": \"" + "InvalidRegEx" + "\"\n" +
+                "  }\n" +
+                "}", CaseField.class);
+        final List<ValidationResult> result = validator.validate("TEST_FIELD_ID",
+            NODE_FACTORY.textNode(validDateTime), caseField);
+        assertEquals("RegEx validation failed", 1, result.size());
+        assertEquals("2001-12-10T00:00:00Z Field Type Regex Failed:InvalidRegEx", result.get(0).getErrorMessage());
+        assertEquals("TEST_FIELD_ID", result.get(0).getFieldId());
+    }
+
+    @Test
+    public void invalidBaseTypeRegEx() throws Exception {
+        ReflectionTestUtils.setField(validator.getType(), "regularExpression", "InvalidRegEx");
+
+        final CaseField caseField = MAPPER.readValue(
+            "{\n" +
+                "  \"id\": \"DATE_TEST\",\n" +
+                "  \"field_type\": {\n" +
+                "    \"type\": \"DATETIME\"\n" +
+                "  }\n" +
+                "}", CaseField.class);
+        final List<ValidationResult> result = validator.validate("TEST_FIELD_ID",
+            NODE_FACTORY.textNode("2001-12-10T00:00:00"), caseField);
+        assertEquals("RegEx validation failed", 1, result.size());
+        assertEquals("2001-12-10T00:00:00 Date Time Type Regex Failed:InvalidRegEx", result.get(0).getErrorMessage());
+        assertEquals("TEST_FIELD_ID", result.get(0).getFieldId());
+    }
+
+
+    @Test
+    public void validRegEx() throws Exception {
+        final String validDateTime = "2001-12-10T00:00:00";
+        String LIMITED_REGEX = "^\\\\d{4}-\\\\d{2}-\\\\d{2}[T\\\\s]\\\\d{2}:\\\\d{2}:\\\\d{2}$";
+        final CaseField caseField = MAPPER.readValue(
+            "{\n" +
+                "  \"id\": \"DATE_TEST\",\n" +
+                "  \"field_type\": {\n" +
+                "    \"type\": \"DATETIME\",\n" +
+                "    \"regular_expression\": \"" + LIMITED_REGEX + "\"\n" +
+                "  }\n" +
+                "}", CaseField.class);
+
+        final List<ValidationResult> result = validator.validate("TEST_FIELD_ID",
+            NODE_FACTORY.textNode(validDateTime), caseField);
+        assertEquals("RegEx validation failed", 0, result.size());
+    }
+
+    @Test
+    public void shouldFail_whenValidatingBooleanNode() {
+        final List<ValidationResult>
+            result =
+            validator.validate("TEST_FIELD_ID", NODE_FACTORY.booleanNode(true), caseField);
+        assertThat(result, hasSize(1));
+        assertThat(result.get(0).getErrorMessage(), is("true is not a valid ISO 8601 date time"));
+    }
+
+    @Test
+    public void shouldFail_whenDataValueIsBinary() {
+        final List<ValidationResult>
+            result =
+            validator.validate("TEST_FIELD_ID", NODE_FACTORY.binaryNode("Ngitb".getBytes()), caseField);
+        assertThat(result, hasSize(1));
+        assertThat(result.get(0).getErrorMessage(), endsWith(" is not a valid ISO 8601 date time"));
+    }
+
+    @Test
+    public void shouldFail_whenValidatingArrayNode() {
+        final List<ValidationResult>
+            result =
+            validator.validate("TEST_FIELD_ID", NODE_FACTORY.arrayNode(), caseField);
+        assertThat(result, hasSize(1));
+        assertThat(result.get(0).getErrorMessage(), is("[] is not a valid ISO 8601 date time"));
+    }
+
+    @Test
+    public void shouldPass_whenValidatingObjectNode() {
+        final List<ValidationResult>
+            result = validator.validate("TEST_FIELD_ID", NODE_FACTORY.objectNode(), caseField);
+        assertThat(result, empty());
+    }
+
+    @Test
+    public void shouldFail_whenValidatingPojoNode() {
+        final List<ValidationResult>
+            result =
+            validator.validate("TEST_FIELD_ID", NODE_FACTORY.pojoNode(true), caseField);
+        assertThat(result, hasSize(1));
+        assertThat(result.get(0).getErrorMessage(), is("true is not a valid ISO 8601 date time"));
+    }
+
+    private Long convertToLongTime(final String dateString) {
+        final LocalDateTime dateTimeValue = LocalDateTime.parse(dateString, ISO_DATE_TIME);
+        return dateTimeValue.toEpochSecond(ZoneOffset.UTC) * 1000;
+    }
+}

--- a/src/test/resources/mappings/base-types.json
+++ b/src/test/resources/mappings/base-types.json
@@ -25,6 +25,9 @@
         "type": "Date"
       },
       {
+        "type": "DateTime"
+      },
+      {
         "type": "FixedList"
       },
       {


### PR DESCRIPTION
Part of DateTime support task: https://tools.hmcts.net/jira/browse/RDM-1149

Support new field type called "DateTime" (import domain). Added a DateTime Validator for this purpose. BaseTypes updated and added a new Type DateTime.

This depends on following PRs
- https://github.com/hmcts/ccd-definition-store-api/pull/28

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```