### PR TITLE
fix for functional tests & sIdam Integration

### DIFF
--- a/src/aat/java/uk/gov/hmcts/ccd/datastore/tests/helper/idam/IdamApi.java
+++ b/src/aat/java/uk/gov/hmcts/ccd/datastore/tests/helper/idam/IdamApi.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.ccd.datastore.tests.helper.idam;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import feign.Body;
 import feign.Headers;
 import feign.Param;
 import feign.RequestLine;
@@ -9,23 +10,17 @@ import java.util.List;
 
 public interface IdamApi {
 
-    @RequestLine("POST /oauth2/authorize"
-        + "?response_type={response_type}"
-        + "&client_id={client_id}"
-        + "&redirect_uri={redirect_uri}")
-    @Headers("Authorization: {authorization}")
+    @RequestLine("POST /oauth2/authorize")
+    @Headers({"Authorization: {authorization}", "Content-Type: application/x-www-form-urlencoded"})
+    @Body("response_type={response_type}&redirect_uri={redirect_uri}&client_id={client_id}")
     AuthenticateUserResponse authenticateUser(@Param("authorization") String authorization,
                                               @Param("response_type") String responseType,
                                               @Param("client_id") String clientId,
                                               @Param("redirect_uri") String redirectUri);
 
-    @RequestLine("POST /oauth2/token"
-        + "?code={code}"
-        + "&grant_type={grant_type}"
-        + "&client_id={client_id}"
-        + "&client_secret={client_secret}"
-        + "&redirect_uri={redirect_uri}")
+    @RequestLine("POST /oauth2/token")
     @Headers("Content-Type: application/x-www-form-urlencoded")
+    @Body("code={code}&grant_type={grant_type}&client_id={client_id}&client_secret={client_secret}&redirect_uri={redirect_uri}")
     TokenExchangeResponse exchangeCode(@Param("code") String code,
                                        @Param("grant_type") String grantType,
                                        @Param("client_id") String clientId,


### PR DESCRIPTION
This PR is for fixing the functional tests of sIdam.

Same solution applied in ccd-definition-store-api

The idam requests are altered to send the content in body instead of the query string.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```