### PR TITLE
Correct default Print Service URL

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -49,7 +49,7 @@ idam.s2s-auth.url=${IDAM_S2S_URL:http://localhost:4502}
 
 casedatastore.authorised.services=${DATA_STORE_S2S_AUTHORISED_SERVICES:ccd_gw,ccd_data,ccd_ps}
 
-ccd.defaultPrintUrl=${CCD_DEFAULTPRINTURL:http://localhost:3100/jurisdictions/:jid/case-types/:ctid/cases/:cid}
+ccd.defaultPrintUrl=${CCD_DEFAULTPRINTURL:http://localhost:3453/print/jurisdictions/:jid/case-types/:ctid/cases/:cid}
 ccd.defaultPrintName=CCD Print
 ccd.defaultPrintDescription=Printing for CCD
 ccd.defaultPrintType=CCD Print Type


### PR DESCRIPTION
Correct URL to access the Print Service via the API Gateway (to ensure correct setting of authentication header), instead of directly.

### JIRA link (if applicable) ###
None.

### Change description ###
Sets the default Print Service URL to access the service via the API Gateway, not directly.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
