### PR TITLE
[WIP] Refactor unit tests to not depend on Spring or Wiremock

### DIFF
--- a/src/main/java/uk/gov/hmcts/ccd/domain/types/DateValidator.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/types/DateValidator.java
@@ -23,7 +23,7 @@ import static uk.gov.hmcts.ccd.domain.types.TextValidator.checkRegex;
 @Named
 @Singleton
 public class DateValidator implements BaseTypeValidator {
-    private static final String TYPE_ID = "Date";
+    static final String TYPE_ID = "Date";
 
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("dd-MM-yyyy");
 

--- a/src/main/java/uk/gov/hmcts/ccd/domain/types/EmailValidator.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/types/EmailValidator.java
@@ -17,7 +17,7 @@ import static uk.gov.hmcts.ccd.domain.types.TextValidator.checkRegex;
 @Named
 @Singleton
 public class EmailValidator implements BaseTypeValidator {
-    private static final String TYPE_ID = "Email";
+    static final String TYPE_ID = "Email";
 
     @Override
     public BaseType getType() {

--- a/src/main/java/uk/gov/hmcts/ccd/domain/types/FixedListValidator.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/types/FixedListValidator.java
@@ -14,7 +14,7 @@ import static uk.gov.hmcts.ccd.domain.types.TextValidator.checkRegex;
 @Named
 @Singleton
 public class FixedListValidator implements BaseTypeValidator {
-    private static final String TYPE_ID = "FixedList";
+    static final String TYPE_ID = "FixedList";
 
     @Override
     public BaseType getType() {

--- a/src/main/java/uk/gov/hmcts/ccd/domain/types/MultiSelectListValidator.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/types/MultiSelectListValidator.java
@@ -15,7 +15,7 @@ import java.util.List;
 @Named
 @Singleton
 public class MultiSelectListValidator implements BaseTypeValidator {
-    private static final String TYPE_ID = "MultiSelectList";
+    static final String TYPE_ID = "MultiSelectList";
 
     @Override
     public BaseType getType() {

--- a/src/main/java/uk/gov/hmcts/ccd/domain/types/NumberValidator.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/types/NumberValidator.java
@@ -14,7 +14,7 @@ import static uk.gov.hmcts.ccd.domain.types.TextValidator.checkRegex;
 @Named
 @Singleton
 public class NumberValidator implements BaseTypeValidator {
-    private static final String TYPE_ID = "Number";
+    static final String TYPE_ID = "Number";
 
     public BaseType getType() {
         return BaseType.get(TYPE_ID);

--- a/src/test/java/uk/gov/hmcts/ccd/domain/types/DateValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/types/DateValidatorTest.java
@@ -1,89 +1,104 @@
 package uk.gov.hmcts.ccd.domain.types;
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.springframework.test.util.ReflectionTestUtils;
-import uk.gov.hmcts.ccd.BaseTest;
+import uk.gov.hmcts.ccd.data.definition.CaseDefinitionRepository;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseField;
+import uk.gov.hmcts.ccd.domain.model.definition.FieldType;
+import uk.gov.hmcts.ccd.test.CaseFieldBuilder;
 
-import javax.inject.Inject;
+import java.math.BigDecimal;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Collections;
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import static org.hamcrest.core.StringEndsWith.endsWith;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doReturn;
 
-public class DateValidatorTest extends BaseTest implements IVallidatorTest {
-    private static final String CASE_FIELD_STRING =
-        "{\n" +
-        "  \"id\": \"TEST_FIELD_ID\",\n" +
-        "  \"field_type\": {\n" +
-        "    \"type\": \"DATE\"\n" +
-        "  }\n" +
-        "}";
-    private final String LIMITED_REGEX = "^\\\\d{4}-\\\\d{2}-\\\\d{2}$";
+public class DateValidatorTest {
+    private static final JsonNodeFactory NODE_FACTORY = JsonNodeFactory.instance;
+    private static final String DATE_REGEX = "^(\\d{4})\\D?(0[1-9]|1[0-2])\\D?([12]\\d|0[1-9]|3[01])([zZ]|([\\+-])([01]\\d|2[0-3])\\D?([0-5]\\d)?)?$";
+    private static final String LIMITED_REGEX = "^\\d{4}-\\d{2}-\\d{2}$";
+    private static final String FIELD_ID = "TEST_FIELD_ID";
 
-    @Inject
+    @Mock
+    private FieldType dateFieldType;
+
+    @Mock
+    private CaseDefinitionRepository definitionRepository;
+
     private DateValidator validator;
     private CaseField caseField;
 
     @Before
-    public void setUp() throws Exception {
-        caseField = MAPPER.readValue(CASE_FIELD_STRING, CaseField.class);
-        ReflectionTestUtils.setField(validator.getType(), "regularExpression",
-            "^(\\d{4})\\D?(0[1-9]|1[0-2])\\D?([12]\\d|0[1-9]|3[01])([zZ]|([\\+-])([01]\\d|2[0-3])\\D?([0-5]\\d)?)?$");
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        doReturn(Collections.emptyList()).when(definitionRepository).getBaseTypes();
+        BaseType.setCaseDefinitionRepository(definitionRepository);
+        BaseType.initialise();
+
+        doReturn(DateValidator.TYPE_ID).when(dateFieldType).getType();
+        doReturn(DATE_REGEX).when(dateFieldType).getRegularExpression();
+        BaseType.register(new BaseType(dateFieldType));
+
+        validator = new DateValidator();
+
+        caseField = caseField().build();
     }
 
     @Test
     public void validDate() {
-        final List<ValidationResult> result01 = validator.validate("TEST_FIELD_ID",
-            NODE_FACTORY.textNode("2012-04-21"), caseField);
+        final List<ValidationResult> result01 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode("2012-04-21"), caseField);
         assertEquals(0, result01.size());
 
-        final List<ValidationResult> result02 = validator.validate("TEST_FIELD_ID",
-            NODE_FACTORY.textNode("2012-04-21Z"), caseField);
+        final List<ValidationResult> result02 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode("2012-04-21Z"), caseField);
         assertEquals(0, result02.size());
 
-        final List<ValidationResult> result03 = validator.validate("TEST_FIELD_ID",
-            NODE_FACTORY.textNode("2012-04-21+01:00"), caseField);
+        final List<ValidationResult> result03 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode("2012-04-21+01:00"),
+                                                                   caseField);
         assertEquals(0, result03.size());
     }
 
     @Test
     public void invalidDate() {
-        final List<ValidationResult> result01 = validator.validate("TEST_FIELD_ID",
-            NODE_FACTORY.textNode("3321M1 1AA"), caseField);
+        final List<ValidationResult> result01 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode("3321M1 1AA"), caseField);
         assertEquals("Did not catch invalid date 3321M1 1AA", 1, result01.size());
         assertEquals("\"3321M1 1AA\" is not a valid ISO 8601 date", result01.get(0).getErrorMessage());
 
-        final List<ValidationResult> result02 = validator.validate("TEST_FIELD_ID",
-            NODE_FACTORY.textNode("1800-14-14"), caseField);
+        final List<ValidationResult> result02 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode("1800-14-14"), caseField);
         assertEquals("Did not catch invalid date 1800-14-14 ", 1, result02.size());
         assertEquals("\"1800-14-14\" is not a valid ISO 8601 date", result02.get(0).getErrorMessage());
 
-        final List<ValidationResult> result03 = validator.validate("TEST_FIELD_ID",
-            NODE_FACTORY.textNode("2001-11-31"), caseField);
+        final List<ValidationResult> result03 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode("2001-11-31"), caseField);
         assertEquals("Did not catch invalid date 2001-11-31", 1, result03.size());
         assertEquals("\"2001-11-31\" is not a valid ISO 8601 date", result03.get(0).getErrorMessage());
 
         // checks that ISO DATE TIME is not accepted by DateValidator
-        final List<ValidationResult> result04 = validator.validate("TEST_FIELD_ID",
-            NODE_FACTORY.textNode("2001-01-01T00:00:00.000Z"), caseField);
+        final List<ValidationResult> result04 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode("2001-01-01T00:00:00.000Z"),
+                                                                   caseField);
         assertEquals("Did not catch invalid date 2001-01-01T00:00:00.000Z", 1, result04.size());
         assertEquals("\"2001-01-01T00:00:00.000Z\" is not a valid ISO 8601 date", result04.get(0).getErrorMessage());
 
-        final List<ValidationResult> result05 = validator.validate("TEST_FIELD_ID",
-            NODE_FACTORY.textNode("2000-02-29Z"), caseField);
+        final List<ValidationResult> result05 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode("2000-02-29Z"), caseField);
         assertEquals("Year 2000 is a leap year", 0, result05.size());
 
-        final List<ValidationResult> result06 = validator.validate("TEST_FIELD_ID",
-            NODE_FACTORY.textNode("2100-02-29Z"), caseField);
+        final List<ValidationResult> result06 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode("2100-02-29Z"), caseField);
         assertEquals("Did not catch invalid date 2100-02-29Z", 1, result06.size());
         assertEquals("\"2100-02-29Z\" is not a valid ISO 8601 date", result06.get(0).getErrorMessage());
     }
@@ -95,214 +110,132 @@ public class DateValidatorTest extends BaseTest implements IVallidatorTest {
 
     @Test
     public void nullValue() {
-        assertEquals("Did not catch NULL", 0, validator.validate("TEST_FIELD_ID", null, null).size());
+        assertEquals("Did not catch NULL", 0, validator.validate(FIELD_ID, null, null).size());
     }
 
     @Test
-    public void checkMax() throws Exception {
+    public void checkMax() {
         final String validDate = "2001-01-01Z";
         final String invalidDate = "2002-01-01Z";
         final String maxDate = "2001-12-31+01:00";
-        final Long maxDateTime = convertToTime(maxDate);
-        final CaseField caseField = MAPPER.readValue(
-            "{\n" +
-            "  \"id\": \"DATE_TEST\",\n" +
-            "  \"field_type\": {\n" +
-            "    \"type\": \"DATE\",\n" +
-            "    \"max\": \"" + maxDateTime + "\"\n" +
-            "  }\n" +
-            "}", CaseField.class);
+        final CaseField caseField = caseField().withMax(date(maxDate)).build();
 
-        final List<ValidationResult> result01 = validator.validate("TEST_FIELD_ID",
-            NODE_FACTORY.textNode(validDate), caseField);
+        final List<ValidationResult> result01 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode(validDate), caseField);
         assertEquals(result01.toString(), 0, result01.size());
 
-        final List<ValidationResult> result02 = validator.validate("TEST_FIELD_ID",
-            NODE_FACTORY.textNode(maxDate), caseField);
+        final List<ValidationResult> result02 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode(maxDate), caseField);
         assertEquals(result02.toString(), 0, result02.size());
 
-        final List<ValidationResult> result03 = validator.validate("TEST_FIELD_ID",
-            NODE_FACTORY.textNode(invalidDate), caseField);
+        final List<ValidationResult> result03 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode(invalidDate), caseField);
         assertEquals("Did not catch invalid max-date", 1, result03.size());
         assertEquals("Validation message", "The date should be earlier than 31-12-2001",
-            result03.get(0).getErrorMessage());
+                     result03.get(0).getErrorMessage());
     }
 
     @Test
-    public void checkMin() throws Exception {
+    public void checkMin() {
         final String validDate = "2001-12-31Z";
         final String invalidDate = "2000-01-01Z";
         final String minDate = "2001-01-01Z";
-        final Long minDateTime = convertToTime(minDate);
-        final CaseField caseField = MAPPER.readValue(
-            "{\n" +
-            "  \"id\": \"DATE_TEST\",\n" +
-            "  \"field_type\": {\n" +
-            "    \"type\": \"DATE\",\n" +
-            "    \"min\": \"" + minDateTime + "\"\n" +
-            "  }\n" +
-            "}", CaseField.class);
+        final CaseField caseField = caseField().withMin(date(minDate)).build();
 
-        final List<ValidationResult> result01 = validator.validate("TEST_FIELD_ID",
-            NODE_FACTORY.textNode(validDate), caseField);
+        final List<ValidationResult> result01 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode(validDate), caseField);
         assertEquals(result01.toString(), 0, result01.size());
 
-        final List<ValidationResult> result02 = validator.validate("TEST_FIELD_ID",
-            NODE_FACTORY.textNode(minDate), caseField);
+        final List<ValidationResult> result02 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode(minDate), caseField);
         assertEquals(result02.toString(), 0, result02.size());
 
-        final List<ValidationResult> result03 = validator.validate("TEST_FIELD_ID",
-            NODE_FACTORY.textNode(invalidDate), caseField);
+        final List<ValidationResult> result03 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode(invalidDate), caseField);
         assertEquals("Did not catch invalid max-date", 1, result03.size());
         assertEquals("Validation message", "The date should be later than 01-01-2001",
-            result03.get(0).getErrorMessage());
+                     result03.get(0).getErrorMessage());
     }
 
     @Test
-    public void checkMaxMinWithoutRegEx() throws Exception {
+    public void checkMaxMinWithoutRegEx() {
         final String validDate = "2001-12-10Z";
         final String invalidMinDate = "1999-12-31Z";
         final String invalidMaxDate = "2002-01-01Z";
         final String minDate = "2001-01-01Z";
-        final Long minDateTime = convertToTime(minDate);
         final String maxDate = "2001-12-31Z";
-        final Long maxDateTime = convertToTime(maxDate);
-        final CaseField caseField = MAPPER.readValue(
-            "{\n" +
-                "  \"id\": \"DATE_TEST\",\n" +
-                "  \"field_type\": {\n" +
-                "    \"type\": \"DATE\",\n" +
-                "    \"max\": \"" + maxDateTime + "\",\n" +
-                "    \"min\": \"" + minDateTime + "\"\n" +
-                "  }\n" +
-                "}", CaseField.class);
+        final CaseField caseField = caseField().withMin(date(minDate))
+                                               .withMax(date(maxDate))
+                                               .build();
 
-        final List<ValidationResult> result01 = validator.validate("TEST_FIELD_ID",
-            NODE_FACTORY.textNode(validDate), caseField);
+        final List<ValidationResult> result01 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode(validDate), caseField);
         assertEquals(result01.toString(), 0, result01.size());
 
-        final List<ValidationResult> result02 = validator.validate("TEST_FIELD_ID",
-            NODE_FACTORY.textNode(minDate), caseField);
+        final List<ValidationResult> result02 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode(minDate), caseField);
         assertEquals(result02.toString(), 0, result02.size());
 
-        final List<ValidationResult> result03 = validator.validate("TEST_FIELD_ID",
-            NODE_FACTORY.textNode(maxDate), caseField);
+        final List<ValidationResult> result03 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode(maxDate), caseField);
         assertEquals(result03.toString(), 0, result03.size());
 
-        final List<ValidationResult> result04 = validator.validate("TEST_FIELD_ID",
-            NODE_FACTORY.textNode(invalidMinDate), caseField);
+        final List<ValidationResult> result04 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode(invalidMinDate), caseField);
         assertEquals("Did not catch invalid min-date", 1, result04.size());
 
-        final List<ValidationResult> result05 = validator.validate("TEST_FIELD_ID",
-            NODE_FACTORY.textNode(invalidMaxDate), caseField);
+        final List<ValidationResult> result05 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode(invalidMaxDate), caseField);
         assertEquals("Did not catch invalid max-date", 1, result05.size());
     }
 
     @Test
-    public void invalidFieldTypeRegEx() throws Exception {
-        final Long minDateTime = convertToTime("2001-01-01");
-        final Long maxDateTime = convertToTime("2001-12-31");
+    public void invalidFieldTypeRegEx() {
         final String validDate = "2001-12-10Z";
 
-        final CaseField caseField = MAPPER.readValue(
-            "{\n" +
-                "  \"id\": \"DATE_TEST\",\n" +
-                "  \"field_type\": {\n" +
-                "    \"type\": \"DATE\",\n" +
-                "    \"max\": \"" + maxDateTime + "\",\n" +
-                "    \"min\": \"" + minDateTime + "\",\n" +
-                "    \"regular_expression\": \"" + "InvalidRegEx" + "\"\n" +
-                "  }\n" +
-                "}", CaseField.class);
-        final List<ValidationResult> result = validator.validate("TEST_FIELD_ID",
-            NODE_FACTORY.textNode(validDate), caseField);
+        final CaseField caseField = caseField().withMin(date("2001-01-01"))
+                                               .withMax(date("2001-12-10Z"))
+                                               .withRegExp("InvalidRegEx")
+                                               .build();
+        final List<ValidationResult> result = validator.validate(FIELD_ID,
+                                                                 NODE_FACTORY.textNode(validDate), caseField);
         assertEquals("RegEx validation failed", 1, result.size());
         assertEquals("2001-12-10Z Field Type Regex Failed:InvalidRegEx", result.get(0).getErrorMessage());
-        assertEquals("TEST_FIELD_ID", result.get(0).getFieldId());
+        assertEquals(FIELD_ID, result.get(0).getFieldId());
     }
 
     @Test
-    public void invalidBaseTypeRegEx() throws Exception {
+    public void invalidBaseTypeRegEx() {
         ReflectionTestUtils.setField(validator.getType(), "regularExpression", "InvalidRegEx");
 
-        final CaseField caseField = MAPPER.readValue(
-            "{\n" +
-                "  \"id\": \"DATE_TEST\",\n" +
-                "  \"field_type\": {\n" +
-                "    \"type\": \"DATE\"\n" +
-                "  }\n" +
-                "}", CaseField.class);
-        final List<ValidationResult> result = validator.validate("TEST_FIELD_ID",
-            NODE_FACTORY.textNode("2001-12-10"), caseField);
+        final CaseField caseField = caseField().build();
+        final List<ValidationResult> result = validator.validate(FIELD_ID,
+                                                                 NODE_FACTORY.textNode("2001-12-10"), caseField);
         assertEquals("RegEx validation failed", 1, result.size());
         assertEquals("2001-12-10 Date Type Regex Failed:InvalidRegEx", result.get(0).getErrorMessage());
-        assertEquals("TEST_FIELD_ID", result.get(0).getFieldId());
+        assertEquals(FIELD_ID, result.get(0).getFieldId());
     }
 
-
     @Test
-    public void validRegEx() throws Exception {
+    public void validRegEx() {
         final String validDate = "2001-12-10";
-        final CaseField caseField = MAPPER.readValue(
-            "{\n" +
-                "  \"id\": \"DATE_TEST\",\n" +
-                "  \"field_type\": {\n" +
-                "    \"type\": \"DATE\",\n" +
-                "    \"regular_expression\": \"" + LIMITED_REGEX + "\"\n" +
-                "  }\n" +
-                "}", CaseField.class);
+        final CaseField caseField = caseField().withRegExp(LIMITED_REGEX).build();
 
-        final List<ValidationResult> result = validator.validate("TEST_FIELD_ID",
-            NODE_FACTORY.textNode(validDate), caseField);
+        final List<ValidationResult> result = validator.validate(FIELD_ID,
+                                                                 NODE_FACTORY.textNode(validDate), caseField);
         assertEquals("RegEx validation failed", 0, result.size());
     }
 
-    @Test
-    public void shouldFail_whenValidatingBooleanNode() {
-        final List<ValidationResult>
-            result =
-            validator.validate("TEST_FIELD_ID", NODE_FACTORY.booleanNode(true), caseField);
-        assertThat(result, hasSize(1));
-        assertThat(result.get(0).getErrorMessage(), is("true is not a valid ISO 8601 date"));
-    }
-
-    @Test
-    public void shouldFail_whenDataValueIsBinary() {
-        final List<ValidationResult>
-            result =
-            validator.validate("TEST_FIELD_ID", NODE_FACTORY.binaryNode("Ngitb".getBytes()), caseField);
-        assertThat(result, hasSize(1));
-        assertThat(result.get(0).getErrorMessage(), endsWith(" is not a valid ISO 8601 date"));
-    }
-
-    @Test
-    public void shouldFail_whenValidatingArrayNode() {
-        final List<ValidationResult>
-            result =
-            validator.validate("TEST_FIELD_ID", NODE_FACTORY.arrayNode(), caseField);
-        assertThat(result, hasSize(1));
-        assertThat(result.get(0).getErrorMessage(), is("[] is not a valid ISO 8601 date"));
-    }
-
-    @Test
-    public void shouldPass_whenValidatingObjectNode() {
-        final List<ValidationResult>
-            result =
-            validator.validate("TEST_FIELD_ID", NODE_FACTORY.objectNode(), caseField);
-        assertThat(result, empty());
-    }
-
-    @Test
-    public void shouldFail_whenValidatingPojoNode() {
-        final List<ValidationResult>
-            result =
-            validator.validate("TEST_FIELD_ID", NODE_FACTORY.pojoNode(true), caseField);
-        assertThat(result, hasSize(1));
-        assertThat(result.get(0).getErrorMessage(), is("true is not a valid ISO 8601 date"));
-    }
-
-    private Long convertToTime(final String dateString) throws ParseException {
+    private BigDecimal date(final String dateString) {
         final DateFormat df = new SimpleDateFormat("yyyy-MM-dd");
-        return df.parse(dateString).getTime();
+        try {
+            return new BigDecimal(df.parse(dateString).getTime());
+        } catch (ParseException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private CaseFieldBuilder caseField() {
+        return new CaseFieldBuilder(FIELD_ID).withType(DateValidator.TYPE_ID);
     }
 }

--- a/src/test/java/uk/gov/hmcts/ccd/domain/types/EmailValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/types/EmailValidatorTest.java
@@ -1,211 +1,165 @@
 package uk.gov.hmcts.ccd.domain.types;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.test.util.ReflectionTestUtils;
-import uk.gov.hmcts.ccd.BaseTest;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import uk.gov.hmcts.ccd.data.definition.CaseDefinitionRepository;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseField;
+import uk.gov.hmcts.ccd.test.CaseFieldBuilder;
 
-import javax.inject.Inject;
-import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.List;
 
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.StringEndsWith.endsWith;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doReturn;
 
-public class EmailValidatorTest extends BaseTest {
-    private static final ObjectMapper MAPPER = new ObjectMapper();
-    private JsonNodeFactory NODE_FACTORY = JsonNodeFactory.instance;
-    private static final String CASE_FIELD_STRING =
-        "{\n" +
-        "  \"id\": \"TEST_FIELD_ID\",\n" +
-        "  \"field_type\": {\n" +
-        "    \"type\": \"Email\"\n" +
-        "  }\n" +
-        "}";
+public class EmailValidatorTest {
+    private static final JsonNodeFactory NODE_FACTORY = JsonNodeFactory.instance;
+    private static final String FIELD_ID = "TEST_FIELD_ID";
 
-    @Inject
+    @Mock
+    private BaseType emailBaseType;
+
+    @Mock
+    private CaseDefinitionRepository definitionRepository;
+
     private EmailValidator validator;
+
     private CaseField caseField;
 
     @Before
-    public void setUp() throws Exception {
-        caseField = MAPPER.readValue(CASE_FIELD_STRING, CaseField.class);
-        ReflectionTestUtils.setField(validator.getType(), "regularExpression", null);
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        doReturn(Collections.emptyList()).when(definitionRepository).getBaseTypes();
+        BaseType.setCaseDefinitionRepository(definitionRepository);
+        BaseType.initialise();
+
+        doReturn(EmailValidator.TYPE_ID).when(emailBaseType).getType();
+        doReturn(null).when(emailBaseType).getRegularExpression();
+        BaseType.register(emailBaseType);
+
+        validator = new EmailValidator();
+
+        caseField = caseField().build();
     }
 
     @Test
-    public void validEmail() throws Exception {
-        final List<ValidationResult> result01 = validator.validate("TEST_FIELD_ID", MAPPER.readTree("\"test@test.com\""), caseField);
+    public void validEmail() {
+        final List<ValidationResult> result01 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode("test@test.com"),
+                                                                   caseField);
         assertEquals(result01.toString(), 0, result01.size());
 
-        final List<ValidationResult> result02 = validator.validate("TEST_FIELD_ID", MAPPER.readTree("\"test@test\""), caseField);
+        final List<ValidationResult> result02 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode("test@test"),
+                                                                   caseField);
         assertEquals(result02.toString(), 0, result02.size());
 
-        final List<ValidationResult> result03 = validator.validate("TEST_FIELD_ID", MAPPER.readTree("\"test@test.org\""), caseField);
+        final List<ValidationResult> result03 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode("test@test.org"),
+                                                                   caseField);
         assertEquals(result01.toString(), 0, result03.size());
 
-        final List<ValidationResult> result04 = validator.validate("TEST_FIELD_ID", MAPPER.readTree("\"test@test.org.uk\""), caseField);
+        final List<ValidationResult> result04 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode("test@test.org.uk"),
+                                                                   caseField);
         assertEquals(result04.toString(), 0, result04.size());
 
-        final List<ValidationResult> result05 = validator.validate("TEST_FIELD_ID", MAPPER.readTree("\"test.test@test.com\""), caseField);
+        final List<ValidationResult> result05 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode("test.test@test.com"),
+                                                                   caseField);
         assertEquals(result05.toString(), 0, result05.size());
 
-        final List<ValidationResult> result06 = validator.validate("TEST_FIELD_ID", MAPPER.readTree("\"test_test@test.xxx\""), caseField);
+        final List<ValidationResult> result06 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode("test_test@test.xxx"),
+                                                                   caseField);
         assertEquals(result06.toString(), 0, result06.size());
     }
 
     @Test
-    public void invalidEmail() throws Exception {
-        final List<ValidationResult> result01 = validator.validate("TEST_FIELD_ID", MAPPER.readTree("\"test.test.com\""), caseField);
+    public void invalidEmail() {
+        final List<ValidationResult> result01 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode("test.test.com"),
+                                                                   caseField);
         assertEquals(result01.toString(), 1, result01.size());
 
-        final List<ValidationResult> result02 = validator.validate("TEST_FIELD_ID", MAPPER.readTree("\"test.com\""), caseField);
+        final List<ValidationResult> result02 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode("test.com"),
+                                                                   caseField);
         assertEquals(result02.toString(), 1, result01.size());
 
-        final List<ValidationResult> result03 = validator.validate("TEST_FIELD_ID", MAPPER.readTree("\"test@test@test\""), caseField);
+        final List<ValidationResult> result03 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode("test@test@test"),
+                                                                   caseField);
         assertEquals(result03.toString(), 1, result03.size());
     }
 
     @Test
-    public void fieldTypeRegEx() throws Exception {
-        final String caseFieldString =
-            "{\n" +
-                "  \"id\": \"TEST_FIELD_ID\",\n" +
-                "  \"field_type\": {\n" +
-                "    \"type\": \"Email\",\n" +
-                "    \"regular_expression\": \"^[a-z]\\\\w*@hmcts.net$\"\n" +
-                "  }\n" +
-                "}";
-        final CaseField regexCaseField = MAPPER.readValue(caseFieldString, CaseField.class);
+    public void fieldTypeRegEx() {
+        final CaseField regexCaseField = caseField().withRegExp("^[a-z]\\w*@hmcts.net$").build();
         final JsonNode validValue = NODE_FACTORY.textNode("k9@hmcts.net");
-        final List<ValidationResult> validResult = validator.validate("TEST_FIELD_ID", validValue, regexCaseField);
+        final List<ValidationResult> validResult = validator.validate(FIELD_ID, validValue, regexCaseField);
         assertEquals(validResult.toString(), 0, validResult.size());
 
         final JsonNode invalidValue = NODE_FACTORY.textNode("9k@hmcts.net");
-        final List<ValidationResult> invalidResult = validator.validate("TEST_FIELD_ID", invalidValue, regexCaseField);
+        final List<ValidationResult> invalidResult = validator.validate(FIELD_ID, invalidValue, regexCaseField);
         assertEquals(invalidResult.toString(), 1, invalidResult.size());
-        assertEquals("9k@hmcts.net field type Regex Failed: ^[a-z]\\w*@hmcts.net$", invalidResult.get(0).getErrorMessage());
+        assertEquals("9k@hmcts.net field type Regex Failed: ^[a-z]\\w*@hmcts.net$",
+                     invalidResult.get(0).getErrorMessage());
     }
 
     @Test
-    public void baseTypeRegEx() throws IOException {
-        ReflectionTestUtils.setField(validator.getType(), "regularExpression", "\\\\w*@hmcts.net");
-        final List<ValidationResult> result01 = validator.validate("TEST_FIELD_ID",
-            NODE_FACTORY.textNode("9k@hmcts.net"), caseField);
+    public void baseTypeRegEx() {
+        doReturn("\\\\w*@hmcts.net").when(emailBaseType).getRegularExpression();
+
+        final List<ValidationResult> result01 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode("9k@hmcts.net"), caseField);
         assertEquals(1, result01.size());
         assertEquals("9k@hmcts.net base type Regex Failed: \\\\w*@hmcts.net", result01.get(0).getErrorMessage());
     }
 
     @Test
-    public void checkMin() throws IOException {
-        final String caseFieldString =
-            "{\n" +
-                "  \"id\": \"TEST_FIELD_ID\",\n" +
-                "  \"field_type\": {\n" +
-                "    \"type\": \"Email\",\n" +
-                "    \"min\": 13\n" +
-                "  }\n" +
-                "}";
-        final CaseField caseField = MAPPER.readValue(caseFieldString, CaseField.class);
+    public void checkMin() {
+        final CaseField caseField = caseField().withMin(new BigDecimal(13)).build();
         final JsonNode validValue = NODE_FACTORY.textNode("k99@hmcts.net");
-        final List<ValidationResult> validResult = validator.validate("TEST_FIELD_ID", validValue, caseField);
+        final List<ValidationResult> validResult = validator.validate(FIELD_ID, validValue, caseField);
         assertEquals(validResult.toString(), 0, validResult.size());
 
         final JsonNode invalidValue = NODE_FACTORY.textNode("k9@hmcts.net");
-        final List<ValidationResult> invalidResult = validator.validate("TEST_FIELD_ID", invalidValue, caseField);
+        final List<ValidationResult> invalidResult = validator.validate(FIELD_ID, invalidValue, caseField);
         assertEquals(invalidResult.toString(), 1, invalidResult.size());
         assertEquals("Email 'k9@hmcts.net' requires minimum length 13", invalidResult.get(0).getErrorMessage());
     }
 
     @Test
-    public void checkMax() throws IOException {
-        final String caseFieldString =
-            "{\n" +
-                "  \"id\": \"TEST_FIELD_ID\",\n" +
-                "  \"field_type\": {\n" +
-                "    \"type\": \"Email\",\n" +
-                "    \"max\": 12\n" +
-                "  }\n" +
-                "}";
-        final CaseField caseField = MAPPER.readValue(caseFieldString, CaseField.class);
+    public void checkMax() {
+        final CaseField caseField = caseField().withMax(new BigDecimal(12)).build();
         final JsonNode validValue = NODE_FACTORY.textNode("k9@hmcts.net");
-        final List<ValidationResult> validResult = validator.validate("TEST_FIELD_ID", validValue, caseField);
+        final List<ValidationResult> validResult = validator.validate(FIELD_ID, validValue, caseField);
         assertEquals(validResult.toString(), 0, validResult.size());
 
         final JsonNode invalidValue = NODE_FACTORY.textNode("k99@hmcts.net");
-        final List<ValidationResult> invalidResult = validator.validate("TEST_FIELD_ID", invalidValue, caseField);
+        final List<ValidationResult> invalidResult = validator.validate(FIELD_ID, invalidValue, caseField);
         assertEquals(invalidResult.toString(), 1, invalidResult.size());
         assertEquals("Email 'k99@hmcts.net' exceeds maximum length 12", invalidResult.get(0).getErrorMessage());
     }
 
     @Test
-    public void shouldFail_whenValidatingBooleanNode() {
-        final List<ValidationResult>
-            result =
-            validator.validate("TEST_FIELD_ID", NODE_FACTORY.booleanNode(true), caseField);
-        assertThat(result, hasSize(1));
-        assertThat(result.get(0).getErrorMessage(), is("true is not a valid email"));
-    }
-
-    @Test
-    public void shouldFail_whenValidatingArrayNode() {
-        final List<ValidationResult>
-            result =
-            validator.validate("TEST_FIELD_ID", NODE_FACTORY.arrayNode(), caseField);
-        assertThat(result, hasSize(1));
-        assertThat(result.get(0).getErrorMessage(), is("[] is not a valid email"));
-    }
-
-    @Test
-    public void shouldFail_whenValidatingBinaryNode() {
-        final List<ValidationResult>
-            result =
-            validator.validate("TEST_FIELD_ID", NODE_FACTORY.binaryNode("STrinG".getBytes()), caseField);
-        assertThat(result, hasSize(1));
-        assertThat(result.get(0).getErrorMessage(), endsWith(" is not a valid email"));
-    }
-
-    @Test
-    public void shouldFail_whenValidatingNumericNode() {
-        final List<ValidationResult>
-            result =
-            validator.validate("TEST_FIELD_ID", NODE_FACTORY.numberNode(1), caseField);
-        assertThat(result, hasSize(1));
-        assertThat(result.get(0).getErrorMessage(), is("1 is not a valid email"));
-    }
-
-    @Test
-    public void shouldPass_whenValidatingObjectNode() {
-        final List<ValidationResult>
-            result =
-            validator.validate("TEST_FIELD_ID", NODE_FACTORY.objectNode(), caseField);
-        assertThat(result, empty());
-    }
-
-    @Test
-    public void shouldFail_whenValidatingPojoNode() {
-        final List<ValidationResult>
-            result =
-            validator.validate("TEST_FIELD_ID", NODE_FACTORY.pojoNode("sjobs@apple.com"), caseField);
-        assertThat(result, hasSize(1));
-        assertThat(result.get(0).getErrorMessage(), is("sjobs@apple.com is not a valid email"));
-    }
-
-    @Test
     public void nullValue() {
-        assertEquals("Did not catch NULL", 0, validator.validate("TEST_FIELD_ID", null, caseField).size());
+        assertEquals("Did not catch NULL", 0, validator.validate(FIELD_ID, null, caseField).size());
     }
 
     @Test
     public void getType() {
         assertEquals("Type is incorrect", validator.getType(), BaseType.get("Email"));
+    }
+
+    private CaseFieldBuilder caseField() {
+        return new CaseFieldBuilder(FIELD_ID).withType(EmailValidator.TYPE_ID);
     }
 }

--- a/src/test/java/uk/gov/hmcts/ccd/domain/types/FixedListValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/types/FixedListValidatorTest.java
@@ -1,53 +1,63 @@
 package uk.gov.hmcts.ccd.domain.types;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.test.util.ReflectionTestUtils;
-import uk.gov.hmcts.ccd.BaseTest;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import uk.gov.hmcts.ccd.data.definition.CaseDefinitionRepository;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseField;
+import uk.gov.hmcts.ccd.test.CaseFieldBuilder;
 
-import javax.inject.Inject;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
 
-public class FixedListValidatorTest extends BaseTest {
-    private static final ObjectMapper MAPPER = new ObjectMapper();
-    private static final String CASE_FIELD_STRING =
-        "{\n" +
-        "  \"id\": \"TEST_FIELD_ID\",\n" +
-        "  \"field_type\": {\n" +
-        "    \"type\": \"FixedList\",\n" +
-        "    \"fixed_list_items\": [\n" +
-        "      {\"code\" : \"AAAAAA\"},\n" +
-        "      {\"code\" : \"BBBBBB\"},\n" +
-        "      {\"code\" : \"CCCCCC\"}\n" +
-        "    ]\n" +
-        "  }\n" +
-        "}";
+public class FixedListValidatorTest {
+    private static final String FIELD_ID = "TEST_FIELD_ID";
     private static final JsonNodeFactory NODE_FACTORY = JsonNodeFactory.instance;
 
-    @Inject
+    @Mock
+    private BaseType fixedListBaseType;
+
+    @Mock
+    private CaseDefinitionRepository definitionRepository;
+
     private FixedListValidator validator;
     private CaseField caseField;
 
     @Before
-    public void setUp() throws Exception {
-        caseField = MAPPER.readValue(CASE_FIELD_STRING, CaseField.class);
-        ReflectionTestUtils.setField(validator.getType(), "regularExpression", null);
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        doReturn(Collections.emptyList()).when(definitionRepository).getBaseTypes();
+        BaseType.setCaseDefinitionRepository(definitionRepository);
+        BaseType.initialise();
+
+        doReturn(FixedListValidator.TYPE_ID).when(fixedListBaseType).getType();
+        doReturn(null).when(fixedListBaseType).getRegularExpression();
+        BaseType.register(fixedListBaseType);
+
+        validator = new FixedListValidator();
+
+        caseField = caseField().build();
     }
 
     @Test
-    public void validValue() throws Exception {
-        final List<ValidationResult> result01 = validator.validate("TEST_FIELD_ID", MAPPER.readTree("\"AAAAAA\""), caseField);
+    public void validValue() {
+        final List<ValidationResult> result01 = validator.validate("TEST_FIELD_ID",
+                                                                   NODE_FACTORY.textNode("AAAAAA"),
+                                                                   caseField);
         assertEquals(0, result01.size());
     }
 
     @Test
-    public void invalidValue() throws Exception {
-        final List<ValidationResult> result01 = validator.validate("TEST_FIELD_ID", MAPPER.readTree("\"DDDD\""), caseField);
+    public void invalidValue() {
+        final List<ValidationResult> result01 = validator.validate("TEST_FIELD_ID",
+                                                                   NODE_FACTORY.textNode("DDDD"),
+                                                                   caseField);
         assertEquals(result01.toString(), 1, result01.size());
     }
 
@@ -62,48 +72,33 @@ public class FixedListValidatorTest extends BaseTest {
     }
 
     @Test
-    public void fieldTypeRegEx() throws Exception {
-        final CaseField caseFieldWithRegEx = MAPPER.readValue(
-            "{\n" +
-                "  \"id\": \"TEST_FIELD_ID\",\n" +
-                "  \"field_type\": {\n" +
-                "    \"type\": \"FixedList\",\n" +
-                "    \"regular_expression\": \"AAAAAA\",\n" +
-                "    \"fixed_list_items\": [\n" +
-                "      {\"code\" : \"AAAAAA\"},\n" +
-                "      {\"code\" : \"BBBBBB\"},\n" +
-                "      {\"code\" : \"CCCCCC\"}\n" +
-                "    ]\n" +
-                "  }\n" +
-                "}",
-            CaseField.class);
-        final List<ValidationResult> result01 = validator.validate("TEST_FIELD_ID", MAPPER.readTree("\"AAAAAA\""),
-            caseFieldWithRegEx);
+    public void fieldTypeRegEx() {
+        final CaseField caseFieldWithRegEx = caseField().withRegExp("AAAAAA").build();
+        final List<ValidationResult> result01 = validator.validate("TEST_FIELD_ID", NODE_FACTORY.textNode("AAAAAA"),
+                                                                   caseFieldWithRegEx);
         assertEquals(0, result01.size());
 
-        final List<ValidationResult> result02 = validator.validate("TEST_FIELD_ID", MAPPER.readTree("\"BBBBBB\""),
-            caseFieldWithRegEx);
+        final List<ValidationResult> result02 = validator.validate("TEST_FIELD_ID", NODE_FACTORY.textNode("BBBBBB"),
+                                                                   caseFieldWithRegEx);
         assertEquals("BBBBBB failed regular expression check", 1, result02.size());
         assertEquals("BBBBBB fails regex: AAAAAA", result02.get(0).getErrorMessage());
         assertEquals("TEST_FIELD_ID", result02.get(0).getFieldId());
     }
 
     @Test
-    public void baseTypeRegEx() throws Exception {
-        ReflectionTestUtils.setField(validator.getType(), "regularExpression", "InvalidRegEx");
-
-        final CaseField caseField = MAPPER.readValue(
-            "{\n" +
-                "  \"id\": \"DATE_TEST\",\n" +
-                "  \"field_type\": {\n" +
-                "    \"type\": \"DATE\"\n" +
-                "  }\n" +
-                "}", CaseField.class);
+    public void baseTypeRegEx() {
+        doReturn("InvalidRegEx").when(fixedListBaseType).getRegularExpression();
         final List<ValidationResult> result = validator.validate("TEST_FIELD_ID",
-            NODE_FACTORY.textNode("AA"), caseField);
+                                                                 NODE_FACTORY.textNode("AA"), caseField);
         assertEquals("RegEx validation failed", 1, result.size());
         assertEquals("'AA' failed FixedList Type Regex check: InvalidRegEx", result.get(0).getErrorMessage());
         assertEquals("TEST_FIELD_ID", result.get(0).getFieldId());
     }
 
+    private CaseFieldBuilder caseField() {
+        return new CaseFieldBuilder(FIELD_ID).withType(FixedListValidator.TYPE_ID)
+                                             .withFixedListItem("AAAAAA")
+                                             .withFixedListItem("BBBBBB")
+                                             .withFixedListItem("CCCCCC");
+    }
 }

--- a/src/test/java/uk/gov/hmcts/ccd/domain/types/MoneyGBPValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/types/MoneyGBPValidatorTest.java
@@ -1,171 +1,139 @@
 package uk.gov.hmcts.ccd.domain.types;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import org.junit.Before;
 import org.junit.Test;
-import uk.gov.hmcts.ccd.BaseTest;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import uk.gov.hmcts.ccd.data.definition.CaseDefinitionRepository;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseField;
+import uk.gov.hmcts.ccd.test.CaseFieldBuilder;
 
-import javax.inject.Inject;
+import java.util.Collections;
 import java.util.List;
 
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.StringEndsWith.endsWith;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static uk.gov.hmcts.ccd.domain.types.MoneyGBPValidator.TYPE_ID;
+import static org.mockito.Mockito.doReturn;
 
-public class MoneyGBPValidatorTest extends BaseTest {
-    private JsonNodeFactory NODE_FACTORY = JsonNodeFactory.instance;
-    private static final ObjectMapper MAPPER = new ObjectMapper();
-    private static final String CASE_FIELD_STRING =
-        "{\n" +
-        "  \"id\": \"TEST_FIELD_ID\",\n" +
-        "  \"field_type\": {\n" +
-        "    \"type\": \"MoneyGBP\"\n" +
-        "  }\n" +
-        "}";
+public class MoneyGBPValidatorTest {
+    private static final String FIELD_ID = "TEST_FIELD_ID";
+    private static final JsonNodeFactory NODE_FACTORY = JsonNodeFactory.instance;
 
-    @Inject
+    @Mock
+    private BaseType moneyGbpBaseType;
+
+    @Mock
+    private CaseDefinitionRepository definitionRepository;
+
     private MoneyGBPValidator validator;
     private CaseField caseField;
 
     @Before
-    public void setUp() throws Exception {
-        caseField = MAPPER.readValue(CASE_FIELD_STRING, CaseField.class);
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        doReturn(Collections.emptyList()).when(definitionRepository).getBaseTypes();
+        BaseType.setCaseDefinitionRepository(definitionRepository);
+        BaseType.initialise();
+
+        doReturn(MoneyGBPValidator.TYPE_ID).when(moneyGbpBaseType).getType();
+        BaseType.register(moneyGbpBaseType);
+
+        validator = new MoneyGBPValidator();
+
+        caseField = caseField().build();
     }
 
     @Test
-    public void validMoney() throws Exception {
-        final List<ValidationResult> result01 = validator.validate("TEST_FIELD_ID", MAPPER.readTree("\"177978989700\""), caseField);
+    public void validMoney() {
+        final List<ValidationResult> result01 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode("177978989700"),
+                                                                   caseField);
         assertEquals(0, result01.size());
 
-        final List<ValidationResult> result02 = validator.validate("TEST_FIELD_ID", MAPPER.readTree("\"-100\""), caseField);
+        final List<ValidationResult> result02 = validator.validate(FIELD_ID, NODE_FACTORY.textNode("-100"), caseField);
         assertEquals(0, result02.size());
     }
 
     @Test
-    public void nullMoney() throws Exception {
-        final List<ValidationResult> result01 = validator.validate("TEST_FIELD_ID", null, caseField);
+    public void nullMoney() {
+        final List<ValidationResult> result01 = validator.validate(FIELD_ID, null, caseField);
         assertEquals("Did not catch null", 0, result01.size());
     }
 
     @Test
-    public void invalidMoney() throws Exception {
-        final List<ValidationResult> result01 = validator.validate("TEST_FIELD_ID", MAPPER.readTree("\"3321M1 1AA\""), caseField);
+    public void invalidMoney() {
+        final List<ValidationResult> result01 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode("3321M1 1AA"),
+                                                                   caseField);
         assertEquals(result01.toString(), 1, result01.size());
 
-        final List<ValidationResult> result02 = validator.validate("TEST_FIELD_ID", MAPPER.readTree("\"100.1\""), caseField);
+        final List<ValidationResult> result02 = validator.validate(FIELD_ID, NODE_FACTORY.textNode("100.1"), caseField);
         assertEquals(result02.toString(), 1, result01.size());
     }
 
     @Test
-    public void checkMaxMin_BothBelow1GBP() throws Exception {
-        final String caseFiledString =
-            "{\n" +
-            "  \"id\": \"TEST_FIELD_ID\",\n" +
-            "  \"field_type\": {\n" +
-            "    \"type\": \"MONEY_GBP\",\n" +
-            "    \"max\": 10,\n" +
-            "    \"min\": 5\n" +
-            "  }\n" +
-            "}";
-
-        final CaseField minMaxCaseField = MAPPER.readValue(caseFiledString, CaseField.class);
+    public void checkMaxMin_BothBelow1GBP() {
+        final CaseField minMaxCaseField = caseField().withMin(5)
+                                                     .withMax(10)
+                                                     .build();
 
         // Test valid max min
-        final List<ValidationResult> result01 = validator.validate("TEST_FIELD_ID", MAPPER.readTree("\"5\""), minMaxCaseField);
+        final List<ValidationResult> result01 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode("5"),
+                                                                   minMaxCaseField);
         assertEquals(0, result01.size());
 
-        final List<ValidationResult> result02 = validator.validate("TEST_FIELD_ID", MAPPER.readTree("\"10\""), minMaxCaseField);
+        final List<ValidationResult> result02 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode("10"),
+                                                                   minMaxCaseField);
         assertEquals(0, result02.size());
 
-        final List<ValidationResult> result03 = validator.validate("TEST_FIELD_ID", MAPPER.readTree("\"7\""), minMaxCaseField);
+        final List<ValidationResult> result03 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode("7"),
+                                                                   minMaxCaseField);
         assertEquals(0, result03.size());
 
         // Test invalid max min
-        final List<ValidationResult> result04 = validator.validate("TEST_FIELD_ID", MAPPER.readTree("\"4\""), minMaxCaseField);
+        final List<ValidationResult> result04 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode("4"),
+                                                                   minMaxCaseField);
         assertEquals(1, result04.size());
         assertEquals("Should be more than or equal to £0.05", result04.get(0).getErrorMessage());
 
-        final List<ValidationResult> result05 = validator.validate("TEST_FIELD_ID", MAPPER.readTree("\"11\""), minMaxCaseField);
+        final List<ValidationResult> result05 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode("11"),
+                                                                   minMaxCaseField);
         assertEquals(1, result05.size());
         assertEquals("Should be less than or equal to £0.10", result05.get(0).getErrorMessage());
     }
 
     @Test
-    public void checkMaxMin_BothAbove1GBP() throws Exception {
-        final String caseFiledString =
-            "{\n" +
-                "  \"id\": \"TEST_FIELD_ID\",\n" +
-                "  \"field_type\": {\n" +
-                "    \"type\": \"MONEY_GBP\",\n" +
-                "    \"max\": 123456,\n" +
-                "    \"min\": 123\n" +
-                "  }\n" +
-                "}";
-
-        final CaseField minMaxCaseField = MAPPER.readValue(caseFiledString, CaseField.class);
+    public void checkMaxMin_BothAbove1GBP() {
+        final CaseField minMaxCaseField = caseField().withMin(123)
+                                                     .withMax(123456)
+                                                     .build();
 
         // Test invalid max min
-        final List<ValidationResult> result01 = validator.validate("TEST_FIELD_ID", MAPPER.readTree("\"123457\""), minMaxCaseField);
+        final List<ValidationResult> result01 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode("123457"),
+                                                                   minMaxCaseField);
         assertEquals(1, result01.size());
         assertEquals("Should be less than or equal to £1,234.56", result01.get(0).getErrorMessage());
 
-        final List<ValidationResult> result02 = validator.validate("TEST_FIELD_ID", MAPPER.readTree("\"122\""), minMaxCaseField);
+        final List<ValidationResult> result02 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode("122"),
+                                                                   minMaxCaseField);
         assertEquals(1, result02.size());
         assertEquals("Should be more than or equal to £1.23", result02.get(0).getErrorMessage());
     }
 
     @Test
-    public void shouldFail_whenDataValidatingBooleanNode() {
-        final List<ValidationResult>
-            result =
-            validator.validate("TEST_FIELD_ID", NODE_FACTORY.booleanNode(true), caseField);
-        assertThat(result, hasSize(1));
-        assertThat(result.get(0).getErrorMessage(), is("true is not valid " + TYPE_ID));
-    }
-
-    @Test
-    public void shouldFail_whenDataValidatingBinaryNode() {
-        final List<ValidationResult>
-            result =
-            validator.validate("TEST_FIELD_ID", NODE_FACTORY.binaryNode("Ngitb".getBytes()), caseField);
-        assertThat(result, hasSize(1));
-        assertThat(result.get(0).getErrorMessage(), endsWith(" is not valid " + TYPE_ID));
-    }
-
-    @Test
-    public void shouldPass_whenDataValidatingObjectNode() {
-        final List<ValidationResult>
-            result =
-            validator.validate("TEST_FIELD_ID", NODE_FACTORY.objectNode(), caseField);
-        assertThat(result, empty());
-    }
-
-    @Test
-    public void shouldPass_whenDataValidatingPojoNode() {
-        final List<ValidationResult>
-            result =
-            validator.validate("TEST_FIELD_ID", NODE_FACTORY.pojoNode(1000), caseField);
-        assertThat(result, hasSize(1));
-        assertThat(result.get(0).getErrorMessage(), is("1000 is not valid " + TYPE_ID));
-    }
-
-    @Test
-    public void shouldPass_whenDataValidatingArrayNode() {
-        final List<ValidationResult>
-            result =
-            validator.validate("TEST_FIELD_ID", NODE_FACTORY.arrayNode(), caseField);
-        assertThat(result, hasSize(1));
-        assertThat(result.get(0).getErrorMessage(), is("[] is not valid " + TYPE_ID));
-    }
-
-    @Test
     public void getType() {
-        assertEquals("Type is incorrect", validator.getType(), BaseType.get(TYPE_ID));
+        assertEquals("Type is incorrect", validator.getType(), BaseType.get("MoneyGBP"));
+    }
+
+    private CaseFieldBuilder caseField() {
+        return new CaseFieldBuilder(FIELD_ID).withType(MoneyGBPValidator.TYPE_ID);
     }
 }

--- a/src/test/java/uk/gov/hmcts/ccd/domain/types/NumberValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/types/NumberValidatorTest.java
@@ -2,292 +2,196 @@ package uk.gov.hmcts.ccd.domain.types;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.util.RawValue;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.hmcts.ccd.BaseTest;
+import uk.gov.hmcts.ccd.data.definition.CaseDefinitionRepository;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseField;
+import uk.gov.hmcts.ccd.test.CaseFieldBuilder;
 
+import javax.inject.Inject;
+import java.util.Collections;
 import java.util.List;
 
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.StringEndsWith.endsWith;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doReturn;
 
-public class NumberValidatorTest extends BaseTest implements IVallidatorTest {
-    private static final String
-        SIMPLE_CASE_FIELD_STRING =
-        "{\n" +
-            "  \"id\": \"TEST_FIELD_ID\",\n" +
-            "  \"field_type\": {\n" +
-            "    \"type\": \"Number\"\n" +
-            "  }\n" +
-            "}";
+public class NumberValidatorTest {
+    private static final JsonNodeFactory NODE_FACTORY = JsonNodeFactory.instance;
+    private static final String FIELD_ID = "TEST_FIELD_ID";
 
-    private NumberValidator validator = new NumberValidator();
+    @Mock
+    private BaseType numberBaseType;
+
+    @Mock
+    private CaseDefinitionRepository definitionRepository;
+
+    private NumberValidator validator;
+    private CaseField caseField;
 
     @Before
     public void setup() {
-        ReflectionTestUtils.setField(validator.getType(), "regularExpression", null);
+        MockitoAnnotations.initMocks(this);
+
+        doReturn(Collections.emptyList()).when(definitionRepository).getBaseTypes();
+        BaseType.setCaseDefinitionRepository(definitionRepository);
+        BaseType.initialise();
+
+        doReturn(NumberValidator.TYPE_ID).when(numberBaseType).getType();
+        BaseType.register(numberBaseType);
+
+        validator = new NumberValidator();
+
+        caseField = caseField().build();
+    }
+
+    private CaseFieldBuilder caseField() {
+        return new CaseFieldBuilder(FIELD_ID).withType(NumberValidator.TYPE_ID);
     }
 
     @Test
-    public void noValueOrMaxOrMin() throws Exception {
-        final CaseField caseField = MAPPER.readValue(SIMPLE_CASE_FIELD_STRING, CaseField.class);
-
-        final JsonNode data = MAPPER.readTree("\"\"");
-        assertEquals(validator.validate("TEST_FIELD_ID", data, caseField).toString(), 0, validator.validate("TEST_FIELD_ID", data, caseField).size());
+    public void noValueOrMaxOrMin() {
+        final JsonNode data = NODE_FACTORY.textNode("");
+        assertEquals(validator.validate("TEST_FIELD_ID", data, caseField).toString(),
+                     0,
+                     validator.validate("TEST_FIELD_ID", data, caseField).size());
     }
 
     @Test
-    public void noValueWithMaxOrMin() throws Exception {
-        final String caseFieldString =
-            "{\n" +
-            "  \"id\": \"TEST_FIELD_ID\",\n" +
-            "  \"field_type\": {\n" +
-            "    \"type\": \"Number\",\n" +
-            "    \"max\": 10,\n" +
-            "    \"min\": 5\n" +
-            "  }\n" +
-            "}";
-        final CaseField caseField = MAPPER.readValue(caseFieldString, CaseField.class);
-        final JsonNode data = MAPPER.readTree("\"\"");
+    public void noValueWithMaxOrMin() {
+        final CaseField caseField = caseField().withMin(5)
+                                               .withMax(10)
+                                               .build();
+        final JsonNode data = NODE_FACTORY.textNode("");
         assertEquals(0, validator.validate("TEST_FIELD_ID", data, caseField).size());
     }
 
     @Test
-    public void valueWithMaxMin() throws Exception {
-        final String caseFieldString =
-            "{\n" +
-            "  \"id\": \"TEST_FIELD_ID\",\n" +
-            "  \"field_type\": {\n" +
-            "    \"type\": \"Number\",\n" +
-            "    \"max\": 10,\n" +
-            "    \"min\": 5\n" +
-            "  }\n" +
-            "}";
-        final CaseField caseField = MAPPER.readValue(caseFieldString, CaseField.class);
+    public void valueWithMaxMin() {
+        final CaseField caseField = caseField().withMin(5)
+                                               .withMax(10)
+                                               .build();
 
         assertEquals("5 should be with in range of between 5 and 10", 0,
-            validator.validate("TEST_FIELD_ID", NODE_FACTORY.textNode("5"), caseField).size());
+                     validator.validate("TEST_FIELD_ID", NODE_FACTORY.textNode("5"), caseField).size());
 
         assertEquals("5 should be with in range of between 5 and 10", 0,
-            validator.validate("TEST_FIELD_ID", NODE_FACTORY.numberNode(5), caseField).size());
+                     validator.validate("TEST_FIELD_ID", NODE_FACTORY.numberNode(5), caseField).size());
 
         assertEquals("5.001 should be with in range of between 5 and 10", 0,
-            validator.validate("TEST_FIELD_ID", NODE_FACTORY.textNode("5.001"), caseField).size());
+                     validator.validate("TEST_FIELD_ID", NODE_FACTORY.textNode("5.001"), caseField).size());
 
         assertEquals("5.001 should be with in range of between 5 and 10", 0,
-            validator.validate("TEST_FIELD_ID", NODE_FACTORY.numberNode(5.001), caseField).size());
+                     validator.validate("TEST_FIELD_ID", NODE_FACTORY.numberNode(5.001), caseField).size());
 
         assertEquals("9.999999 should be with in range of between 5 and 10", 0,
-            validator.validate("TEST_FIELD_ID", NODE_FACTORY.textNode("9.999999"), caseField).size());
+                     validator.validate("TEST_FIELD_ID", NODE_FACTORY.textNode("9.999999"), caseField).size());
 
         assertEquals("9.999999 should be with in range of between 5 and 10", 0,
-            validator.validate("TEST_FIELD_ID", NODE_FACTORY.numberNode(9.999999), caseField).size());
+                     validator.validate("TEST_FIELD_ID", NODE_FACTORY.numberNode(9.999999), caseField).size());
 
-        List<ValidationResult> textNodeBelowMin = validator.validate("TEST_FIELD_ID", NODE_FACTORY.textNode("4.9"), caseField);
+        List<ValidationResult> textNodeBelowMin = validator.validate("TEST_FIELD_ID",
+                                                                     NODE_FACTORY.textNode("4.9"),
+                                                                     caseField);
         assertEquals("4.9 should not be with in range of between 5 and 10", 1, textNodeBelowMin.size());
         assertEquals("Should be more than or equal to 5", textNodeBelowMin.get(0).getErrorMessage());
 
-        List<ValidationResult> numberNodeBelowMin = validator.validate("TEST_FIELD_ID", NODE_FACTORY.numberNode(4.9), caseField);
+        List<ValidationResult> numberNodeBelowMin = validator.validate("TEST_FIELD_ID",
+                                                                       NODE_FACTORY.numberNode(4.9),
+                                                                       caseField);
         assertEquals("4.9 should not be with in range of between 5 and 10", 1, numberNodeBelowMin.size());
         assertEquals("Should be more than or equal to 5", numberNodeBelowMin.get(0).getErrorMessage());
 
-        List<ValidationResult> textNodeAboveMin = validator.validate("TEST_FIELD_ID", NODE_FACTORY.textNode("10.1"), caseField);
+        List<ValidationResult> textNodeAboveMin = validator.validate("TEST_FIELD_ID",
+                                                                     NODE_FACTORY.textNode("10.1"),
+                                                                     caseField);
         assertEquals("10.1 should not be with in range of between 5 and 10", 1, textNodeAboveMin.size());
         assertEquals("Should be less than or equal to 10", textNodeAboveMin.get(0).getErrorMessage());
 
-        List<ValidationResult> numberNodeAboveMin = validator.validate("TEST_FIELD_ID", NODE_FACTORY.numberNode(10.1), caseField);
+        List<ValidationResult> numberNodeAboveMin = validator.validate("TEST_FIELD_ID",
+                                                                       NODE_FACTORY.numberNode(10.1),
+                                                                       caseField);
         assertEquals("10.1 should not be with in range of between 5 and 10", 1,
-            validator.validate("TEST_FIELD_ID", NODE_FACTORY.numberNode(10.1), caseField).size());
+                     validator.validate("TEST_FIELD_ID", NODE_FACTORY.numberNode(10.1), caseField).size());
         assertEquals("Should be less than or equal to 10", numberNodeAboveMin.get(0).getErrorMessage());
     }
 
     @Test
-    public void valueWithSameMaxMin() throws Exception {
-        final String caseFieldString =
-            "{\n" +
-            "  \"id\": \"TEST_FIELD_ID\",\n" +
-            "  \"field_type\": {\n" +
-            "    \"type\": \"Number\",\n" +
-            "    \"max\": 0,\n" +
-            "    \"min\": 0\n" +
-            "  }\n" +
-            "}";
-        final CaseField caseField = MAPPER.readValue(caseFieldString, CaseField.class);
+    public void valueWithSameMaxMin() {
+        final CaseField caseField = caseField().withMin(0)
+                                               .withMax(0)
+                                               .build();
 
         assertEquals("0 should be with in range of between 0 and 0", 0,
-            validator.validate("TEST_FIELD_ID", NODE_FACTORY.textNode("0"), caseField).size());
+                     validator.validate("TEST_FIELD_ID", NODE_FACTORY.textNode("0"), caseField).size());
 
         assertEquals("0 should be with in range of between 0 and 0", 0,
-            validator.validate("TEST_FIELD_ID", NODE_FACTORY.numberNode(0), caseField).size());
+                     validator.validate("TEST_FIELD_ID", NODE_FACTORY.numberNode(0), caseField).size());
 
         assertEquals("-1 should not be with in range of between 0 and 0", 1,
-            validator.validate("TEST_FIELD_ID", NODE_FACTORY.textNode("-1"), caseField).size());
+                     validator.validate("TEST_FIELD_ID", NODE_FACTORY.textNode("-1"), caseField).size());
 
         assertEquals("-1 should not be with in range of between 0 and 0", 1,
-            validator.validate("TEST_FIELD_ID", NODE_FACTORY.numberNode(-1), caseField).size());
+                     validator.validate("TEST_FIELD_ID", NODE_FACTORY.numberNode(-1), caseField).size());
 
         assertEquals("0.0000000000 should be with in range of between 0 and 0", 0,
-            validator.validate("TEST_FIELD_ID", NODE_FACTORY.textNode("0.0000000000"), caseField).size());
+                     validator.validate("TEST_FIELD_ID", NODE_FACTORY.textNode("0.0000000000"), caseField).size());
 
         assertEquals("0.0000000000 should be with in range of between 0 and 0", 0,
-            validator.validate("TEST_FIELD_ID", NODE_FACTORY.numberNode(0.0000000000), caseField).size());
+                     validator.validate("TEST_FIELD_ID", NODE_FACTORY.numberNode(0.0000000000), caseField).size());
     }
 
     @Test
-    public void valueWithSameDecimalMaxMin() throws Exception {
-        final String caseFieldString =
-            "{\n" +
-            "  \"id\": \"TEST_FIELD_ID\",\n" +
-            "  \"field_type\": {\n" +
-            "    \"type\": \"Number\",\n" +
-            "    \"max\": 0.00,\n" +
-            "    \"min\": 0.00\n" +
-            "  }\n" +
-            "}";
-        final CaseField caseField = MAPPER.readValue(caseFieldString, CaseField.class);
+    public void valueWithSameDecimalMaxMin() {
+        final CaseField caseField = caseField().withMin(0.0f)
+                                               .withMax(0.0f)
+                                               .build();
 
         assertEquals("0 should be with in range of between 0.00 and 0.00", 0,
-            validator.validate("TEST_FIELD_ID", NODE_FACTORY.textNode("0"), caseField).size());
+                     validator.validate("TEST_FIELD_ID", NODE_FACTORY.textNode("0"), caseField).size());
 
         assertEquals("0 should be with in range of between 0.00 and 0.00", 0,
-            validator.validate("TEST_FIELD_ID", NODE_FACTORY.numberNode(0), caseField).size());
+                     validator.validate("TEST_FIELD_ID", NODE_FACTORY.numberNode(0), caseField).size());
     }
 
     @Test
-    public void fieldTypeRegEx() throws Exception {
-        final String caseFieldString =
-            "{\n" +
-                "  \"id\": \"TEST_FIELD_ID\",\n" +
-                "  \"field_type\": {\n" +
-                "    \"type\": \"Number\",\n" +
-                "    \"regular_expression\": \"^\\\\d\\\\.\\\\d\\\\d$\"\n" +
-                "  }\n" +
-                "}";
-        final CaseField caseField = MAPPER.readValue(caseFieldString, CaseField.class);
+    public void fieldTypeRegEx() {
+        final CaseField caseField = caseField().withRegExp("^\\d\\.\\d\\d$").build();
 
         assertEquals("regular expression check", 0,
-            validator.validate("TEST_FIELD_ID", MAPPER.readTree("\"8.20\""), caseField).size());
+                     validator.validate("TEST_FIELD_ID", NODE_FACTORY.textNode("8.20"), caseField).size());
 
-        List<ValidationResult> results = validator.validate("TEST_FIELD_ID", MAPPER.readTree("\"8.2\""), caseField);
+        List<ValidationResult> results = validator.validate("TEST_FIELD_ID", NODE_FACTORY.textNode("8.2"), caseField);
         assertEquals("regular expression check", 1, results.size());
         assertEquals("8.2 fails regex: ^\\d\\.\\d\\d$", results.get(0).getErrorMessage());
     }
 
     @Test
-    public void invalidBaseTypeRegEx() throws Exception {
-        ReflectionTestUtils.setField(validator.getType(), "regularExpression", "\\d");
+    public void invalidBaseTypeRegEx() {
+        doReturn("\\d").when(numberBaseType).getRegularExpression();
 
-        final CaseField caseField = MAPPER.readValue(SIMPLE_CASE_FIELD_STRING, CaseField.class);
-        final List<ValidationResult>
-            result =
-            validator.validate("TEST_FIELD_ID", NODE_FACTORY.numberNode(12), caseField);
+        final List<ValidationResult> result = validator.validate("TEST_FIELD_ID",
+                                                                 NODE_FACTORY.numberNode(12), caseField);
         assertEquals("RegEx validation failed", 1, result.size());
         assertEquals("'12' failed number Type Regex check: \\d", result.get(0).getErrorMessage());
         assertEquals("TEST_FIELD_ID", result.get(0).getFieldId());
     }
 
     @Test
-    public void incorrectFormat() throws Exception {
-        final String caseFieldString =
-            "{\n" +
-            "  \"id\": \"TEST_FIELD_ID\",\n" +
-            "  \"field_type\": {\n" +
-            "    \"type\": \"Number\",\n" +
-            "    \"max\": \"10\",\n" +
-            "    \"min\": 5\n" +
-            "  }\n" +
-            "}";
-        final CaseField caseField = MAPPER.readValue(caseFieldString, CaseField.class);
+    public void incorrectFormat() {
+        final CaseField caseField = caseField().withMin(5)
+                                               .withMax(10)
+                                               .build();
 
         assertEquals("Did not catch invalid 10.1xxxx", 1,
-            validator.validate("TEST_FIELD_ID", MAPPER.readTree("\"10.1xxxx\""), caseField).size());
-    }
-
-    @Test(expected = JsonParseException.class)
-    public void incorrectFormatAsNumber() throws Exception {
-        final String caseFieldString =
-            "{\n" +
-                "  \"id\": \"TEST_FIELD_ID\",\n" +
-                "  \"field_type\": {\n" +
-                "    \"type\": \"Number\",\n" +
-                "    \"max\": \"10\",\n" +
-                "    \"min\": 5\n" +
-                "  }\n" +
-                "}";
-        final CaseField caseField = MAPPER.readValue(caseFieldString, CaseField.class);
-
-        validator.validate("TEST_FIELD_ID", MAPPER.readTree("10.1xxxx"), caseField);
-    }
-
-    @Test
-    public void shouldFailWhenValidatingAString() throws Exception {
-        final CaseField caseField = MAPPER.readValue(SIMPLE_CASE_FIELD_STRING, CaseField.class);
-
-        final List<ValidationResult>
-            validationResults =
-            validator.validate("TEST_FIELD_ID", NODE_FACTORY.textNode("PkJiTQ"), caseField);
-        assertThat(validationResults, hasSize(1));
-        assertThat(validationResults.get(0).getErrorMessage(), is("PkJiTQ is not a number"));
-    }
-
-    @Test
-    public void shouldFailWhenValidatingABoolean() throws Exception {
-        final CaseField caseField = MAPPER.readValue(SIMPLE_CASE_FIELD_STRING, CaseField.class);
-
-        final List<ValidationResult>
-            validationResults =
-            validator.validate("TEST_FIELD_ID", NODE_FACTORY.booleanNode(true), caseField);
-        assertThat(validationResults, hasSize(1));
-        assertThat(validationResults.get(0).getErrorMessage(), is("true is not a number"));
-    }
-
-    @Test
-    public void shouldFailWhenValidatingBinaryData() throws Exception {
-        final CaseField caseField = MAPPER.readValue(SIMPLE_CASE_FIELD_STRING, CaseField.class);
-
-        final List<ValidationResult>
-            validationResults =
-            validator.validate("TEST_FIELD_ID", NODE_FACTORY.binaryNode("ngitb".getBytes()), caseField);
-        assertThat(validationResults, hasSize(1));
-        assertThat(validationResults.get(0).getErrorMessage(), endsWith(" is not a number"));
-    }
-
-    @Test
-    public void shouldFailWhenValidatingArrayNode() throws Exception {
-        final CaseField caseField = MAPPER.readValue(SIMPLE_CASE_FIELD_STRING, CaseField.class);
-        final JsonNode node = NODE_FACTORY.arrayNode();
-        final List<ValidationResult>
-            validationResults =
-            validator.validate("TEST_FIELD_ID", node, caseField);
-        assertThat(validationResults, hasSize(1));
-        assertThat(validationResults.get(0).getErrorMessage(), endsWith(" is not a number"));
-    }
-
-    @Test
-    public void shouldPassWhenValidatingObjectNode() throws Exception {
-        final CaseField caseField = MAPPER.readValue(SIMPLE_CASE_FIELD_STRING, CaseField.class);
-        final JsonNode node = NODE_FACTORY.objectNode();
-        final List<ValidationResult>
-            validationResults =
-            validator.validate("TEST_FIELD_ID", node, caseField);
-        assertThat(validationResults, empty());
-    }
-
-    @Test
-    public void shouldFailWhenValidatingPoJoNode() throws Exception {
-        final CaseField caseField = MAPPER.readValue(SIMPLE_CASE_FIELD_STRING, CaseField.class);
-        final JsonNode node = NODE_FACTORY.pojoNode(1);
-        final List<ValidationResult>
-            validationResults =
-            validator.validate("TEST_FIELD_ID", node, caseField);
-        assertThat(validationResults, hasSize(1));
-        assertThat(validationResults.get(0).getErrorMessage(), is("1 is not a number"));
+                     validator.validate("TEST_FIELD_ID", NODE_FACTORY.textNode("10.1xxxx"), caseField).size());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/ccd/test/CaseFieldBuilder.java
+++ b/src/test/java/uk/gov/hmcts/ccd/test/CaseFieldBuilder.java
@@ -1,0 +1,73 @@
+package uk.gov.hmcts.ccd.test;
+
+import org.assertj.core.util.Lists;
+import uk.gov.hmcts.ccd.domain.model.definition.CaseField;
+import uk.gov.hmcts.ccd.domain.model.definition.FieldType;
+import uk.gov.hmcts.ccd.domain.model.definition.FixedListItem;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+
+public class CaseFieldBuilder {
+
+    final CaseField caseField = new CaseField();
+
+    public CaseFieldBuilder(final String fieldId) {
+        caseField.setId(fieldId);
+        caseField.setFieldType(new FieldType());
+    }
+
+    public CaseFieldBuilder withType(String type) {
+        caseField.getFieldType().setType(type);
+        return this;
+    }
+
+    public CaseFieldBuilder withMax(Integer max) {
+        return withMax(new BigDecimal(max));
+    }
+
+    public CaseFieldBuilder withMax(Float max) {
+        return withMax(new BigDecimal(max));
+    }
+
+    public CaseFieldBuilder withMax(BigDecimal max) {
+        caseField.getFieldType().setMax(max);
+        return this;
+    }
+
+    public CaseFieldBuilder withMin(Integer min) {
+        return withMin(new BigDecimal(min));
+    }
+
+    public CaseFieldBuilder withMin(Float min) {
+        return withMin(new BigDecimal(min));
+    }
+
+    public CaseFieldBuilder withMin(BigDecimal min) {
+        caseField.getFieldType().setMin(min);
+        return this;
+    }
+
+    public CaseFieldBuilder withRegExp(String regExp) {
+        caseField.getFieldType().setRegularExpression(regExp);
+        return this;
+    }
+
+    public CaseField build() {
+        return caseField;
+    }
+
+    public CaseFieldBuilder withFixedListItem(String itemCode) {
+        if (null == caseField.getFieldType().getFixedListItems()) {
+            caseField.getFieldType().setFixedListItems(new ArrayList<>());
+        }
+
+        final FixedListItem item = new FixedListItem();
+        item.setCode(itemCode);
+
+        caseField.getFieldType()
+                 .getFixedListItems()
+                 .add(item);
+        return this;
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

Initially part of https://tools.hmcts.net/jira/browse/RDM-1582

### Change description ###

Try and refactor some unit tests to remove dependency on Spring and/or Wiremock. The aim is to make tests lighter and faster to run and hopefully improve the stability of tests in Data Store.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
