### PR TITLE
RDM-2438: Fix classifications on simple collections

### DIFF
--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/common/CaseDataService.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/common/CaseDataService.java
@@ -97,10 +97,10 @@ public class CaseDataService {
 
     private void deduceClassificationForSimpleType(ObjectNode dataNode, JsonNode existingDataClassificationNode, String fieldName, CaseField caseField) {
         dataNode.put(fieldName, existingDataClassificationNode.equals(JSON_NODE_FACTORY.objectNode())
-            ? getClassificationFromCaseFieldOrEmpty(caseField) : existingDataClassificationNode.textValue());
+            ? getClassificationFromCaseFieldOrDefault(caseField) : existingDataClassificationNode.textValue());
     }
 
-    private String getClassificationFromCaseFieldOrEmpty(CaseField caseField) {
+    private String getClassificationFromCaseFieldOrDefault(CaseField caseField) {
         return ofNullable(caseField.getSecurityLabel()).orElse(DEFAULT_CLASSIFICATION);
     }
 
@@ -126,7 +126,7 @@ public class CaseDataService {
                     final ObjectNode simpleCollectionItemNode = (ObjectNode) field;
                     // Add `classification` property
                     final String newClassification = itemClassification.isTextual() ?
-                        itemClassification.textValue() : getClassificationFromCaseFieldOrEmpty(caseField);
+                        itemClassification.textValue() : getClassificationFromCaseFieldOrDefault(caseField);
                     simpleCollectionItemNode.put(CLASSIFICATION, newClassification);
                     // Remove `value` property
                     simpleCollectionItemNode.remove(VALUE);

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/common/CaseDataService.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/common/CaseDataService.java
@@ -125,8 +125,8 @@ public class CaseDataService {
                 } else {
                     final ObjectNode simpleCollectionItemNode = (ObjectNode) field;
                     // Add `classification` property
-                    final String newClassification = itemClassification.isTextual() ?
-                        itemClassification.textValue() : getClassificationFromCaseFieldOrDefault(caseField);
+                    final String newClassification = itemClassification.isTextual()
+                        ? itemClassification.textValue() : getClassificationFromCaseFieldOrDefault(caseField);
                     simpleCollectionItemNode.put(CLASSIFICATION, newClassification);
                     // Remove `value` property
                     simpleCollectionItemNode.remove(VALUE);

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/common/CaseDataService.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/common/CaseDataService.java
@@ -110,17 +110,24 @@ public class CaseDataService {
             ArrayNode arrayNode = (ArrayNode) fieldNode;
             final FieldType collectionFieldType = caseField.getFieldType().getCollectionFieldType();
             for (JsonNode field : arrayNode) {
+
+                final JsonNode itemClassification = getExistingDataClassificationFromArrayOrEmpty(
+                    existingDataClassificationNode,
+                    field);
+
                 if (COMPLEX_TYPE.equalsIgnoreCase(collectionFieldType.getType())) {
                     deduceDefaultClassifications(
                         field.get(VALUE),
                         // get value of the field with given ID
-                        getExistingDataClassificationFromArrayOrEmpty(existingDataClassificationNode, field),
+                        itemClassification,
                         caseField.getFieldType().getCollectionFieldType().getComplexFields(),
                         fieldIdPrefix + fieldName + FIELD_SEPARATOR);
                 } else {
                     final ObjectNode simpleCollectionItemNode = (ObjectNode) field;
                     // Add `classification` property
-                    deduceClassificationForSimpleType(simpleCollectionItemNode, existingDataClassificationNode, CLASSIFICATION, caseField);
+                    final String newClassification = itemClassification.isTextual() ?
+                        itemClassification.textValue() : getClassificationFromCaseFieldOrEmpty(caseField);
+                    simpleCollectionItemNode.put(CLASSIFICATION, newClassification);
                     // Remove `value` property
                     simpleCollectionItemNode.remove(VALUE);
                 }

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/common/SecurityClassificationService.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/common/SecurityClassificationService.java
@@ -161,7 +161,16 @@ public class SecurityClassificationService {
                                       relevantDataClassificationValue.get(collectionElementValue.textValue()));
                 }
             } else {
-                dataCollectionIterator.remove();
+                // For collection of simple field type, the classification is stored as `classification`, not `value`
+                relevantDataClassificationValue = dataClassificationForData.get(CLASSIFICATION);
+
+                if (null != relevantDataClassificationValue) {
+                    filterSimpleField(userClassification,
+                                      dataCollectionIterator,
+                                      relevantDataClassificationValue);
+                } else {
+                    dataCollectionIterator.remove();
+                }
             }
             if (collectionElementValue.equals(EMPTY_NODE)) {
                 dataCollectionIterator.remove();

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/common/CaseDataServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/common/CaseDataServiceTest.java
@@ -26,8 +26,6 @@ import static uk.gov.hmcts.ccd.domain.service.common.TestBuildersUtil.CaseDataBu
 import static uk.gov.hmcts.ccd.domain.service.common.TestBuildersUtil.CaseDataClassificationBuilder.dataClassification;
 import static uk.gov.hmcts.ccd.domain.service.common.TestBuildersUtil.CaseFieldBuilder.aCaseField;
 import static uk.gov.hmcts.ccd.domain.service.common.TestBuildersUtil.FieldTypeBuilder.aFieldType;
-import static uk.gov.hmcts.ccd.domain.service.common.TestBuildersUtil.collectionClassification;
-import static uk.gov.hmcts.ccd.domain.service.common.TestBuildersUtil.collectionItem;
 
 class CaseDataServiceTest {
     private static final TypeReference STRING_JSON_MAP = new TypeReference<HashMap<String, JsonNode>>() {

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/common/CaseDataServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/common/CaseDataServiceTest.java
@@ -4,35 +4,50 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Maps;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.json.JSONException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.ccd.data.casedetails.SecurityClassification;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseField;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseType;
+import uk.gov.hmcts.ccd.domain.model.definition.FieldType;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 import static uk.gov.hmcts.ccd.data.casedetails.SecurityClassification.*;
+import static uk.gov.hmcts.ccd.domain.service.common.TestBuildersUtil.CaseDataBuilder.aCaseData;
+import static uk.gov.hmcts.ccd.domain.service.common.TestBuildersUtil.CaseDataClassificationBuilder.aDataClassification;
 import static uk.gov.hmcts.ccd.domain.service.common.TestBuildersUtil.CaseFieldBuilder.aCaseField;
 import static uk.gov.hmcts.ccd.domain.service.common.TestBuildersUtil.FieldTypeBuilder.aFieldType;
+import static uk.gov.hmcts.ccd.domain.service.common.TestBuildersUtil.aCollectionClassification;
+import static uk.gov.hmcts.ccd.domain.service.common.TestBuildersUtil.aCollectionItem;
 
-public class CaseDataServiceTest {
+class CaseDataServiceTest {
     private static final TypeReference STRING_JSON_MAP = new TypeReference<HashMap<String, JsonNode>>() {
     };
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final CaseDataService caseDataService = new CaseDataService();
     private CaseType caseType;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    void setUp() {
         setCaseType(RESTRICTED);
     }
 
     private void setCaseType(SecurityClassification securityClassification) {
+        final FieldType textFieldType = aFieldType().withType("Text")
+                                           .build();
+
         CaseField postalAddress = aCaseField()
             .withId("PostalAddress")
             .withSC(SecurityClassification.PRIVATE.name())
@@ -40,37 +55,27 @@ public class CaseDataServiceTest {
                                .withType("Complex")
                                .withComplexField(aCaseField()
                                                      .withId("AddressLine1")
-                                                     .withFieldType(aFieldType()
-                                                                        .withType("Text")
-                                                                        .build())
+                                                     .withFieldType(textFieldType)
                                                      .withSC(securityClassification.name())
                                                      .build())
                                .withComplexField(aCaseField()
                                                      .withId("AddressLine2")
-                                                     .withFieldType(aFieldType()
-                                                                        .withType("Text")
-                                                                        .build())
+                                                     .withFieldType(textFieldType)
                                                      .withSC(securityClassification.name())
                                                      .build())
                                .withComplexField(aCaseField()
                                                      .withId("AddressLine3")
-                                                     .withFieldType(aFieldType()
-                                                                        .withType("Text")
-                                                                        .build())
+                                                     .withFieldType(textFieldType)
                                                      .withSC(securityClassification.name())
                                                      .build())
                                .withComplexField(aCaseField()
                                                      .withId("Country")
-                                                     .withFieldType(aFieldType()
-                                                                        .withType("Text")
-                                                                        .build())
+                                                     .withFieldType(textFieldType)
                                                      .withSC(PRIVATE.name())
                                                      .build())
                                .withComplexField(aCaseField()
                                                      .withId("PostCode")
-                                                     .withFieldType(aFieldType()
-                                                                        .withType("Text")
-                                                                        .build())
+                                                     .withFieldType(textFieldType)
                                                      .withSC(RESTRICTED.name())
                                                      .build())
                                .withComplexField(aCaseField()
@@ -81,10 +86,7 @@ public class CaseDataServiceTest {
                                                                                               .withId(
                                                                                                   "Title")
                                                                                               .withFieldType(
-                                                                                                  aFieldType()
-                                                                                                      .withType(
-                                                                                                          "Text")
-                                                                                                      .build())
+                                                                                                  textFieldType)
                                                                                               .withSC(
                                                                                                   PUBLIC.name())
                                                                                               .build())
@@ -92,10 +94,7 @@ public class CaseDataServiceTest {
                                                                                               .withId(
                                                                                                   "FirstName")
                                                                                               .withFieldType(
-                                                                                                  aFieldType()
-                                                                                                      .withType(
-                                                                                                          "Text")
-                                                                                                      .build())
+                                                                                                  textFieldType)
                                                                                               .withSC(
                                                                                                   PUBLIC.name())
                                                                                               .build())
@@ -103,10 +102,7 @@ public class CaseDataServiceTest {
                                                                                               .withId(
                                                                                                   "MiddleName")
                                                                                               .withFieldType(
-                                                                                                  aFieldType()
-                                                                                                      .withType(
-                                                                                                          "Text")
-                                                                                                      .build())
+                                                                                                  textFieldType)
                                                                                               .withSC(
                                                                                                   PRIVATE.name())
                                                                                               .build())
@@ -114,10 +110,7 @@ public class CaseDataServiceTest {
                                                                                               .withId(
                                                                                                   "LastName")
                                                                                               .withFieldType(
-                                                                                                  aFieldType()
-                                                                                                      .withType(
-                                                                                                          "Text")
-                                                                                                      .build())
+                                                                                                  textFieldType)
                                                                                               .withSC(
                                                                                                   PRIVATE.name())
                                                                                               .build())
@@ -136,10 +129,7 @@ public class CaseDataServiceTest {
                                                                                               .withId(
                                                                                                   "NationalInsuranceNumber")
                                                                                               .withFieldType(
-                                                                                                  aFieldType()
-                                                                                                      .withType(
-                                                                                                          "Text")
-                                                                                                      .build())
+                                                                                                  textFieldType)
                                                                                               .withSC(
                                                                                                   RESTRICTED.name())
                                                                                               .build())
@@ -182,9 +172,7 @@ public class CaseDataServiceTest {
                                    .withType("Complex")
                                    .withComplexField(aCaseField()
                                                          .withId("Name")
-                                                         .withFieldType(aFieldType()
-                                                                            .withType("Text")
-                                                                            .build())
+                                                         .withFieldType(textFieldType)
                                                          .withSC(PRIVATE.name())
                                                          .build())
                                    .withComplexField(postalAddress)
@@ -194,16 +182,22 @@ public class CaseDataServiceTest {
             )
             .withField(aCaseField()
                            .withId("OtherInfo")
-                           .withFieldType(aFieldType()
-                                              .withType("Text")
-                                              .build())
+                           .withFieldType(textFieldType)
                            .withSC(PRIVATE.name())
                            .build())
+            .withField(aCaseField().withId("simple_collection")
+                                   .withSC("PUBLIC")
+                                   .withFieldType(aFieldType().withType("Collection")
+                                                              .withCollectionFieldType(textFieldType)
+                                                              .build()
+                                   )
+                                   .build()
+            )
             .build();
     }
 
     @Test
-    public void testGetDefaultSecurityClassifications() throws IOException, JSONException {
+    void testGetDefaultSecurityClassifications() throws IOException, JSONException {
         final Map<String, JsonNode> DATA = MAPPER.convertValue(MAPPER.readTree(
             "{\n" +
                 "  \"PersonFirstName\": \"First Name\",\n" +
@@ -312,7 +306,7 @@ public class CaseDataServiceTest {
     }
 
     @Test
-    public void shouldNotOverwriteExistingClassificationIfSet() throws IOException, JSONException {
+    void shouldNotOverwriteExistingClassificationIfSet() throws IOException, JSONException {
         // ARRANGE
         final Map<String, JsonNode> DATA = MAPPER.convertValue(MAPPER.readTree(
             "{\n" +
@@ -497,4 +491,74 @@ public class CaseDataServiceTest {
            assertEquals(expectedNewResult, newClassificationsResult.toString(), false);
     }
 
+    @Test
+    @DisplayName("should assign default classifications to simple collection items")
+    void shouldAssignDefaultClassificationToCollectionItems() {
+        final Map<String, JsonNode> caseData = aCaseData().withField("simple_collection")
+                                                          .asCollectionOf(
+                                                              aCollectionItem("1", "Item 1"),
+                                                              aCollectionItem("2", "Item 2")
+                                                          )
+                                                          .build();
+
+        final Map<String, JsonNode> classifications = caseDataService.getDefaultSecurityClassifications(
+            caseType,
+            caseData,
+            new HashMap<>());
+
+        assertThat(classifications.size(), equalTo(1));
+        final JsonNode collection = classifications.get("simple_collection");
+        assertSimpleCollectionClassification(collection,
+                                             "PUBLIC",
+                                             "PUBLIC", "PUBLIC");
+    }
+
+    @Test
+    @DisplayName("should preserve existing classifications to simple collection items")
+    void shouldPreserveExistingClassificationForCollectionItems() {
+        final Map<String, JsonNode> caseData = aCaseData().withField("simple_collection")
+                                                          .asCollectionOf(
+                                                              aCollectionItem("1", "Item 1"),
+                                                              aCollectionItem("2", "Item 2")
+                                                          )
+                                                          .build();
+        final Map<String, JsonNode> existingClassification =
+            aDataClassification().withField("simple_collection")
+                                 .asCollectionOf("PRIVATE",
+                                                 aCollectionClassification(
+                                                     "1",
+                                                     "PUBLIC"),
+                                                 aCollectionClassification(
+                                                     "2",
+                                                     "RESTRICTED")
+                                 )
+                                 .build();
+
+        final Map<String, JsonNode> classifications = caseDataService.getDefaultSecurityClassifications(
+            caseType,
+            caseData,
+            existingClassification);
+
+        assertThat(classifications.size(), equalTo(1));
+        final JsonNode collection = classifications.get("simple_collection");
+        assertSimpleCollectionClassification(collection,
+                                             "PRIVATE",
+                                             "PUBLIC", "RESTRICTED");
+    }
+
+    private void assertSimpleCollectionClassification(JsonNode collection,
+                                                      String expectedCollectionClassification,
+                                                      String... expectedItemClassifications) {
+        assertThat(collection.isObject(), is(true));
+        assertThat(collection.size(), is(2));
+        assertThat(collection.get("classification").textValue(), is(expectedCollectionClassification));
+        final JsonNode classificationValues = collection.get("value");
+        assertThat(classificationValues.isArray(), is(true));
+        assertThat(classificationValues.size(), is(expectedItemClassifications.length));
+
+        for (int i = 0; i < expectedItemClassifications.length; i++) {
+            assertThat(classificationValues.get(i).get("classification").textValue(),
+                       is(expectedItemClassifications[i]));
+        }
+    }
 }

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/common/CaseDataServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/common/CaseDataServiceTest.java
@@ -4,8 +4,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Maps;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.json.JSONException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -16,7 +14,6 @@ import uk.gov.hmcts.ccd.domain.model.definition.CaseType;
 import uk.gov.hmcts.ccd.domain.model.definition.FieldType;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/common/CaseDataServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/common/CaseDataServiceTest.java
@@ -22,12 +22,12 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 import static uk.gov.hmcts.ccd.data.casedetails.SecurityClassification.*;
-import static uk.gov.hmcts.ccd.domain.service.common.TestBuildersUtil.CaseDataBuilder.aCaseData;
-import static uk.gov.hmcts.ccd.domain.service.common.TestBuildersUtil.CaseDataClassificationBuilder.aDataClassification;
+import static uk.gov.hmcts.ccd.domain.service.common.TestBuildersUtil.CaseDataBuilder.caseData;
+import static uk.gov.hmcts.ccd.domain.service.common.TestBuildersUtil.CaseDataClassificationBuilder.dataClassification;
 import static uk.gov.hmcts.ccd.domain.service.common.TestBuildersUtil.CaseFieldBuilder.aCaseField;
 import static uk.gov.hmcts.ccd.domain.service.common.TestBuildersUtil.FieldTypeBuilder.aFieldType;
-import static uk.gov.hmcts.ccd.domain.service.common.TestBuildersUtil.aCollectionClassification;
-import static uk.gov.hmcts.ccd.domain.service.common.TestBuildersUtil.aCollectionItem;
+import static uk.gov.hmcts.ccd.domain.service.common.TestBuildersUtil.collectionClassification;
+import static uk.gov.hmcts.ccd.domain.service.common.TestBuildersUtil.collectionItem;
 
 class CaseDataServiceTest {
     private static final TypeReference STRING_JSON_MAP = new TypeReference<HashMap<String, JsonNode>>() {
@@ -37,7 +37,7 @@ class CaseDataServiceTest {
     private CaseType caseType;
 
     @BeforeEach
-    void setUp() {
+    public void setUp() {
         setCaseType(RESTRICTED);
     }
 
@@ -194,7 +194,8 @@ class CaseDataServiceTest {
     }
 
     @Test
-    void testGetDefaultSecurityClassifications() throws IOException, JSONException {
+    @DisplayName("should get the default security classifications")
+    void shouldGetDefaultClassifications() throws IOException, JSONException {
         final Map<String, JsonNode> DATA = MAPPER.convertValue(MAPPER.readTree(
             "{\n" +
                 "  \"PersonFirstName\": \"First Name\",\n" +
@@ -303,7 +304,8 @@ class CaseDataServiceTest {
     }
 
     @Test
-    void shouldNotOverwriteExistingClassificationIfSet() throws IOException, JSONException {
+    @DisplayName("should not overwrite previously set classifications")
+    void shouldKeepExistingClassifications() throws IOException, JSONException {
         // ARRANGE
         final Map<String, JsonNode> DATA = MAPPER.convertValue(MAPPER.readTree(
             "{\n" +
@@ -491,12 +493,12 @@ class CaseDataServiceTest {
     @Test
     @DisplayName("should assign default classifications to simple collection items")
     void shouldAssignDefaultClassificationToCollectionItems() {
-        final Map<String, JsonNode> caseData = aCaseData().withField("simple_collection")
-                                                          .asCollectionOf(
-                                                              aCollectionItem("1", "Item 1"),
-                                                              aCollectionItem("2", "Item 2")
+        final Map<String, JsonNode> caseData = caseData().withField("simple_collection")
+                                                         .asCollectionOf(
+                                                             TestBuildersUtil.collectionItem("1", "Item 1"),
+                                                             TestBuildersUtil.collectionItem("2", "Item 2")
                                                           )
-                                                          .build();
+                                                         .build();
 
         final Map<String, JsonNode> classifications = caseDataService.getDefaultSecurityClassifications(
             caseType,
@@ -513,23 +515,23 @@ class CaseDataServiceTest {
     @Test
     @DisplayName("should preserve existing classifications to simple collection items")
     void shouldPreserveExistingClassificationForCollectionItems() {
-        final Map<String, JsonNode> caseData = aCaseData().withField("simple_collection")
-                                                          .asCollectionOf(
-                                                              aCollectionItem("1", "Item 1"),
-                                                              aCollectionItem("2", "Item 2")
+        final Map<String, JsonNode> caseData = caseData().withField("simple_collection")
+                                                         .asCollectionOf(
+                                                             TestBuildersUtil.collectionItem("1", "Item 1"),
+                                                             TestBuildersUtil.collectionItem("2", "Item 2")
                                                           )
-                                                          .build();
+                                                         .build();
         final Map<String, JsonNode> existingClassification =
-            aDataClassification().withField("simple_collection")
-                                 .asCollectionOf("PRIVATE",
-                                                 aCollectionClassification(
+            dataClassification().withField("simple_collection")
+                                .asCollectionOf("PRIVATE",
+                                                TestBuildersUtil.collectionClassification(
                                                      "1",
                                                      "PUBLIC"),
-                                                 aCollectionClassification(
+                                                TestBuildersUtil.collectionClassification(
                                                      "2",
                                                      "RESTRICTED")
                                  )
-                                 .build();
+                                .build();
 
         final Map<String, JsonNode> classifications = caseDataService.getDefaultSecurityClassifications(
             caseType,

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/common/TestBuildersUtil.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/common/TestBuildersUtil.java
@@ -2,38 +2,22 @@ package uk.gov.hmcts.ccd.domain.service.common;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import uk.gov.hmcts.ccd.data.casedetails.SecurityClassification;
-import uk.gov.hmcts.ccd.domain.model.aggregated.CaseEventTrigger;
-import uk.gov.hmcts.ccd.domain.model.aggregated.CaseHistoryView;
-import uk.gov.hmcts.ccd.domain.model.aggregated.CaseView;
-import uk.gov.hmcts.ccd.domain.model.aggregated.CaseViewEvent;
-import uk.gov.hmcts.ccd.domain.model.aggregated.CaseViewField;
-import uk.gov.hmcts.ccd.domain.model.aggregated.CaseViewTrigger;
-import uk.gov.hmcts.ccd.domain.model.aggregated.ProfileCaseState;
+import uk.gov.hmcts.ccd.domain.model.aggregated.*;
 import uk.gov.hmcts.ccd.domain.model.callbacks.CallbackResponse;
-import uk.gov.hmcts.ccd.domain.model.definition.AccessControlList;
-import uk.gov.hmcts.ccd.domain.model.definition.CaseDetails;
-import uk.gov.hmcts.ccd.domain.model.definition.CaseEvent;
-import uk.gov.hmcts.ccd.domain.model.definition.CaseField;
-import uk.gov.hmcts.ccd.domain.model.definition.CaseState;
-import uk.gov.hmcts.ccd.domain.model.definition.CaseTabCollection;
-import uk.gov.hmcts.ccd.domain.model.definition.CaseType;
-import uk.gov.hmcts.ccd.domain.model.definition.CaseTypeTab;
-import uk.gov.hmcts.ccd.domain.model.definition.CaseTypeTabField;
-import uk.gov.hmcts.ccd.domain.model.definition.FieldType;
-import uk.gov.hmcts.ccd.domain.model.definition.Jurisdiction;
-import uk.gov.hmcts.ccd.domain.model.definition.WizardPage;
-import uk.gov.hmcts.ccd.domain.model.definition.WizardPageField;
+import uk.gov.hmcts.ccd.domain.model.definition.*;
 import uk.gov.hmcts.ccd.domain.model.search.Field;
 import uk.gov.hmcts.ccd.domain.model.search.SearchInput;
 import uk.gov.hmcts.ccd.domain.model.search.WorkbasketInput;
 import uk.gov.hmcts.ccd.domain.model.std.AuditEvent;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.function.Consumer;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static java.util.Arrays.asList;
@@ -628,5 +612,116 @@ public class TestBuildersUtil {
         public static CaseTabCollectionBuilder aCaseTabCollection() {
             return new CaseTabCollectionBuilder();
         }
+    }
+
+    public static class CaseDataBuilder {
+
+        private final HashMap<String, JsonNode> caseData;
+
+        private CaseDataBuilder() {
+            caseData = new HashMap<>();
+        }
+
+        private Consumer<JsonNode> putFn(String fieldId) {
+            return (JsonNode node) -> caseData.put(fieldId, node);
+        }
+
+        public static CaseDataBuilder aCaseData() {
+            return new CaseDataBuilder();
+        }
+
+        public CaseDataFieldBuilder withField(String fieldId) {
+            return new CaseDataFieldBuilder(this, putFn(fieldId));
+        }
+
+        public Map<String, JsonNode> build() {
+            return caseData;
+        }
+    }
+
+    public static class CaseDataFieldBuilder {
+        private final CaseDataBuilder caseDataBuilder;
+        private final Consumer<JsonNode> putFn;
+
+        CaseDataFieldBuilder(CaseDataBuilder caseDataBuilder, Consumer<JsonNode> putFn) {
+            this.caseDataBuilder = caseDataBuilder;
+            this.putFn = putFn;
+        }
+
+        public CaseDataBuilder asCollectionOf(JsonNode... nodes) {
+            final ArrayNode collection = JsonNodeFactory.instance.arrayNode();
+            Arrays.stream(nodes).forEach(collection::add);
+            putFn.accept(collection);
+            return caseDataBuilder;
+        }
+    }
+
+    public static JsonNode aCollectionItem(String id, String value) {
+        return aCollectionItem(id, JsonNodeFactory.instance.textNode(value));
+    }
+
+    public static JsonNode aCollectionItem(String id, JsonNode value) {
+        final ObjectNode item = JsonNodeFactory.instance.objectNode();
+        item.put("id", id);
+        item.set("value", value);
+        return item;
+    }
+
+    public static class CaseDataClassificationBuilder {
+
+        private final HashMap<String, JsonNode> dataClassification;
+
+        private CaseDataClassificationBuilder() {
+            dataClassification = new HashMap<>();
+        }
+
+        private Consumer<JsonNode> putFn(String fieldId) {
+            return (JsonNode node) -> dataClassification.put(fieldId, node);
+        }
+
+        public static CaseDataClassificationBuilder aDataClassification() {
+            return new CaseDataClassificationBuilder();
+        }
+
+        public CaseDataClassificationFieldBuilder withField(String fieldId) {
+            return new CaseDataClassificationFieldBuilder(this, putFn(fieldId));
+        }
+
+        public Map<String, JsonNode> build() {
+            return dataClassification;
+        }
+    }
+
+    public static class CaseDataClassificationFieldBuilder {
+        private final CaseDataClassificationBuilder caseDataClassificationBuilder;
+        private final Consumer<JsonNode> putFn;
+
+        CaseDataClassificationFieldBuilder(CaseDataClassificationBuilder caseDataClassificationBuilder, Consumer<JsonNode> putFn) {
+            this.caseDataClassificationBuilder = caseDataClassificationBuilder;
+            this.putFn = putFn;
+        }
+
+        public CaseDataClassificationBuilder asCollectionOf(String classification, JsonNode... nodes) {
+            final ObjectNode collection = JsonNodeFactory.instance.objectNode();
+            final ArrayNode collectionValue = JsonNodeFactory.instance.arrayNode();
+            Arrays.stream(nodes).forEach(collectionValue::add);
+
+            collection.put("classification", classification);
+            collection.set("value", collectionValue);
+
+            putFn.accept(collection);
+            return caseDataClassificationBuilder;
+        }
+    }
+
+    public static JsonNode aCollectionClassification(String id, String classification) {
+        return aCollectionItem(id, JsonNodeFactory.instance.textNode(classification));
+    }
+
+    public static JsonNode aCollectionClassification(String id, JsonNode classification) {
+        final ObjectNode item = JsonNodeFactory.instance.objectNode();
+        item.put("id", id);
+        item.set("classification", classification);
+        return item;
     }
 }

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/common/TestBuildersUtil.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/common/TestBuildersUtil.java
@@ -25,6 +25,8 @@ import static java.util.Arrays.asList;
 public class TestBuildersUtil {
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
+    private TestBuildersUtil() {}
+
     public static class CallbackResponseBuilder {
         private final CallbackResponse callbackResponse;
 
@@ -626,7 +628,7 @@ public class TestBuildersUtil {
             return (JsonNode node) -> caseData.put(fieldId, node);
         }
 
-        public static CaseDataBuilder aCaseData() {
+        public static CaseDataBuilder caseData() {
             return new CaseDataBuilder();
         }
 
@@ -656,11 +658,11 @@ public class TestBuildersUtil {
         }
     }
 
-    public static JsonNode aCollectionItem(String id, String value) {
-        return aCollectionItem(id, JsonNodeFactory.instance.textNode(value));
+    public static JsonNode collectionItem(String id, String value) {
+        return collectionItem(id, JsonNodeFactory.instance.textNode(value));
     }
 
-    public static JsonNode aCollectionItem(String id, JsonNode value) {
+    public static JsonNode collectionItem(String id, JsonNode value) {
         final ObjectNode item = JsonNodeFactory.instance.objectNode();
         item.put("id", id);
         item.set("value", value);
@@ -679,7 +681,7 @@ public class TestBuildersUtil {
             return (JsonNode node) -> dataClassification.put(fieldId, node);
         }
 
-        public static CaseDataClassificationBuilder aDataClassification() {
+        public static CaseDataClassificationBuilder dataClassification() {
             return new CaseDataClassificationBuilder();
         }
 
@@ -696,7 +698,8 @@ public class TestBuildersUtil {
         private final CaseDataClassificationBuilder caseDataClassificationBuilder;
         private final Consumer<JsonNode> putFn;
 
-        CaseDataClassificationFieldBuilder(CaseDataClassificationBuilder caseDataClassificationBuilder, Consumer<JsonNode> putFn) {
+        CaseDataClassificationFieldBuilder(CaseDataClassificationBuilder caseDataClassificationBuilder,
+                                           Consumer<JsonNode> putFn) {
             this.caseDataClassificationBuilder = caseDataClassificationBuilder;
             this.putFn = putFn;
         }
@@ -714,11 +717,11 @@ public class TestBuildersUtil {
         }
     }
 
-    public static JsonNode aCollectionClassification(String id, String classification) {
-        return aCollectionItem(id, JsonNodeFactory.instance.textNode(classification));
+    public static JsonNode collectionClassification(String id, String classification) {
+        return collectionItem(id, JsonNodeFactory.instance.textNode(classification));
     }
 
-    public static JsonNode aCollectionClassification(String id, JsonNode classification) {
+    public static JsonNode collectionClassification(String id, JsonNode classification) {
         final ObjectNode item = JsonNodeFactory.instance.objectNode();
         item.put("id", id);
         item.set("classification", classification);

--- a/src/test/java/uk/gov/hmcts/ccd/endpoint/std/CaseDetailsEndpointIT.java
+++ b/src/test/java/uk/gov/hmcts/ccd/endpoint/std/CaseDetailsEndpointIT.java
@@ -245,8 +245,9 @@ public class CaseDetailsEndpointIT extends WireMockBaseTest {
             "    \"AddressLine1\": \"Address Line 1\",\n" +
             "    \"AddressLine2\": \"Address Line 2\"\n" +
             "  },\n" +
-                "\"D8Document\":{" +
-                "\"document_url\": \"http://localhost:" + DM_API_RULE.port() + "/documents/05e7cd7e-7041-4d8a-826a-7bb49dfd83d0\"}" +
+            "  \"Aliases\": [{\"value\": \"x1\", \"id\": \"1\"}, {\"value\": \"x2\", \"id\": \"2\"}]," +
+            "  \"D8Document\":{" +
+            "    \"document_url\": \"http://localhost:" + DM_API_RULE.port() + "/documents/05e7cd7e-7041-4d8a-826a-7bb49dfd83d0\"}" +
             "}\n"
         );
         final JsonNode SANITIZED_DATA = mapper.readTree(
@@ -257,6 +258,7 @@ public class CaseDetailsEndpointIT extends WireMockBaseTest {
             "    \"AddressLine1\": \"Address Line 1\",\n" +
             "    \"AddressLine2\": \"Address Line 2\"\n" +
             "  },\n" +
+            "  \"Aliases\": [{\"value\": \"x1\", \"id\": \"1\"}, {\"value\": \"x2\", \"id\": \"2\"}]," +
             "  \"D8Document\":{\n" +
             "    \"document_url\": \"http://localhost:" + DM_API_RULE.port() + "/documents/05e7cd7e-7041-4d8a-826a-7bb49dfd83d0\",\n" +
             "    \"document_binary_url\": \"http://localhost:" + DM_API_RULE.port() + "/documents/05e7cd7e-7041-4d8a-826a-7bb49dfd83d0/binary\",\n" +
@@ -293,7 +295,7 @@ public class CaseDetailsEndpointIT extends WireMockBaseTest {
         Map sanitizedData = mapper.convertValue(SANITIZED_DATA, new TypeReference<HashMap<String, JsonNode>>() {
         });
         assertThat( "Incorrect Data content", savedCaseDetails.getData().entrySet(), everyItem(isIn(sanitizedData.entrySet())));
-        assertEquals("Incorrect security classification size", 4, savedCaseDetails.getDataClassification().size());
+        assertEquals("Incorrect security classification size", 5, savedCaseDetails.getDataClassification().size());
         JsonNode expectedClassification = mapper.readTree("{" +
                                                               "  \"PersonAddress\":{" +
                                                               "    \"classification\": \"PUBLIC\"," +
@@ -304,6 +306,7 @@ public class CaseDetailsEndpointIT extends WireMockBaseTest {
                                                               "  }," +
                                                               "  \"PersonLastName\":\"PUBLIC\"," +
                                                               "  \"PersonFirstName\":\"PUBLIC\"," +
+                                                              "  \"Aliases\": {\"classification\": \"PUBLIC\", \"value\": [{\"id\": \"1\", \"classification\": \"PUBLIC\"}, {\"id\": \"2\", \"classification\": \"PUBLIC\"}]}," +
                                                               "  \"D8Document\":\"PUBLIC\"" +
                                                               "}");
         JsonNode actualClassification = mapper.convertValue(savedCaseDetails.getDataClassification(), JsonNode.class);

--- a/src/test/resources/mappings/bookcase-definition.json
+++ b/src/test/resources/mappings/bookcase-definition.json
@@ -380,6 +380,35 @@
           }
         },
         {
+          "id": "Aliases",
+          "case_type_id": "TestAddressBookCase",
+          "label": "Aliases",
+          "security_classification": "PUBLIC",
+          "acls": [
+            {
+              "role": "caseworker-probate-public",
+              "create": true,
+              "read": true,
+              "update": true,
+              "delete": false
+            },
+            {
+              "role": "caseworker-probate-private",
+              "create": true,
+              "read": true,
+              "update": true,
+              "delete": false
+            }],
+          "field_type": {
+            "type": "Collection",
+            "id": "Collection",
+            "collection_field_type": {
+              "type": "Text",
+              "id": "Text"
+            }
+          }
+        },
+        {
           "id": "D8Document",
           "case_type_id": "TestAddressBookCase",
           "label": "Document",


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDM-2438

### Change description ###

Fixes RDM-2438

Classifications for simple collections were store as `classification` but read as `value`. As such, classifications were not found and by default items were filtered out.
Add fallback to read classification from `classification` node

This is a quick fix to restore the use of simple collections. Additional work around classifications on collections will be provided as part of RDM-882.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```