### PR TITLE
RDM-882: Cleanup collection classification structure

### DIFF
--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/common/SecurityClassificationService.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/common/SecurityClassificationService.java
@@ -156,9 +156,8 @@ public class SecurityClassificationService {
                                        relevantDataClassificationValue,
                                        userClassification);
                 } else {
-                    filterSimpleField(userClassification,
-                                      dataCollectionIterator,
-                                      relevantDataClassificationValue.get(collectionElementValue.textValue()));
+                    LOG.warn("Invalid security classification structure for collection item: {}", relevantDataClassificationValue.toString());
+                    dataCollectionIterator.remove();
                 }
             } else {
                 // For collection of simple field type, the classification is stored as `classification`, not `value`

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/common/SecurityClassificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/common/SecurityClassificationServiceTest.java
@@ -1049,62 +1049,7 @@ public class SecurityClassificationServiceTest {
         }
 
         @Test
-        // TODO Target implementation, see RDM-1204
-        @DisplayName("should filter out collection items with higher classification")
-        void shouldFilterOutCollectionItemsWithHigherClassification() throws IOException {
-            final Map<String, JsonNode> data = MAPPER.convertValue(MAPPER.readTree(
-                "{  \"Addresses\":[  \n" +
-                    "         {  \n" +
-                    "            \"value\": \"Address1\",\n" +
-                    "            \"id\":\"" + FIRST_CHILD_ID + "\"\n" +
-                    "         },\n" +
-                    "         {  \n" +
-                    "            \"value\": \"Address2\",\n" +
-                    "            \"id\":\"" + SECOND_CHILD_ID + "\"\n" +
-                    "         }\n" +
-                    "      ]\n" +
-                    "    }\n"
-            ), STRING_JSON_MAP);
-            caseDetails.setData(data);
-            final Map<String, JsonNode> dataClassification = MAPPER.convertValue(MAPPER.readTree(
-                "{  \"Addresses\": {  \n" +
-                    "         \"classification\": \"PRIVATE\", \n" +
-                    "         \"value\": [  \n" +
-                    "           {  \n" +
-                    "             \"value\": {\n" +
-                    "               \"Address1\": \"PRIVATE\"\n" +
-                    "             },\n" +
-                    "             \"id\":\"" + FIRST_CHILD_ID + "\"\n" +
-                    "           },\n" +
-                    "           {  \n" +
-                    "             \"value\": {\n" +
-                    "               \"Address2\": \"RESTRICTED\"\n" +
-                    "             },\n" +
-                    "             \"id\":\"" + SECOND_CHILD_ID + "\"\n" +
-                    "           }\n" +
-                    "         ]\n" +
-                    "      }\n" +
-                    "    }\n"
-            ), STRING_JSON_MAP);
-            caseDetails.setDataClassification(dataClassification);
-
-
-            CaseDetails caseDetails = applyClassification(PRIVATE);
-
-            JsonNode resultNode = MAPPER.convertValue(caseDetails.getData(), JsonNode.class);
-            assertThat(resultNode.get("Addresses"), is(notNullValue()));
-            assertAll(
-                () -> assertThat(resultNode.get("Addresses").size(), equalTo(1)),
-                () -> assertThat(resultNode.get("Addresses").get(0).get(ID),
-                                 is(equalTo(JSON_NODE_FACTORY.textNode(FIRST_CHILD_ID)))),
-                () -> assertThat(resultNode.get("Addresses").get(0).get(VALUE),
-                                 equalTo(JSON_NODE_FACTORY.textNode("Address1")))
-            );
-        }
-
-        @Test
-        // TODO Target implementation, see RDM-1204
-        @DisplayName("should filter out collection items with missing value")
+        @DisplayName("should filter out simple collection items with missing classification")
         void shouldFilterOutCollectionItemsWithMissingValue() throws IOException {
             final Map<String, JsonNode> data = MAPPER.convertValue(MAPPER.readTree(
                 "{  \"Addresses\":[  \n" +
@@ -1125,9 +1070,7 @@ public class SecurityClassificationServiceTest {
                     "         \"classification\": \"PRIVATE\", \n" +
                     "         \"value\": [  \n" +
                     "           {  \n" +
-                    "             \"value\": {\n" +
-                    "               \"Address1\": \"PRIVATE\"\n" +
-                    "             },\n" +
+                    "             \"classification\": \"PRIVATE\",\n" +
                     "             \"id\":\"" + FIRST_CHILD_ID + "\"\n" +
                     "           },\n" +
                     "           {  \n" +
@@ -1143,12 +1086,14 @@ public class SecurityClassificationServiceTest {
             CaseDetails caseDetails = applyClassification(PRIVATE);
 
             JsonNode resultNode = MAPPER.convertValue(caseDetails.getData(), JsonNode.class);
-            assertThat(resultNode.get("Addresses"), is(notNullValue()));
+
+            final JsonNode addresses = resultNode.get("Addresses");
+            assertThat(addresses, is(notNullValue()));
             assertAll(
-                () -> assertThat(resultNode.get("Addresses").size(), equalTo(1)),
-                () -> assertThat(resultNode.get("Addresses").get(0).get(ID),
+                () -> assertThat(addresses.size(), equalTo(1)),
+                () -> assertThat(addresses.get(0).get(ID),
                                  is(equalTo(JSON_NODE_FACTORY.textNode(FIRST_CHILD_ID)))),
-                () -> assertThat(resultNode.get("Addresses").get(0).get(VALUE),
+                () -> assertThat(addresses.get(0).get(VALUE),
                                  equalTo(JSON_NODE_FACTORY.textNode("Address1")))
             );
         }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDM-882

### Change description ###

Couple of tests were assuming that classification structure for simple collection was:
```json
{
    "Addresses": [
        {
            "id": "xxx-xxx-xxx",
            "value": {
                "Address1": "PRIVATE"
            }
        }
    ]
}
```

This seems to be a confusion between structure for simple and complex collection. Actual structure for simple collection is:

```json
{
    "Addresses": [
        {
            "id": "xxx-xxx-xxx",
            "classification": "PRIVATE"
        }
    ]
}
```
As supported by function `CaseDataService#deduceClassificationForCollectionType()` which does:

```java
final ObjectNode simpleCollectionItemNode = (ObjectNode) field;
// Add `classification` property
deduceClassificationForSimpleType(simpleCollectionItemNode, existingDataClassificationNode, CLASSIFICATION, caseField);
// Remove `value` property
simpleCollectionItemNode.remove(VALUE);
```

This assumption has been corrected and warnings have been added in the event of incorrect classification structure being used.
The warning would display as:

```
2018-07-09T14:52:08.391+0100 WARN  [main] uk.gov.hmcts.ccd.domain.service.common.SecurityClassificationService:159: Invalid security classification structure for collection item {"Address1":"PUBLIC"}
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```