### PR TITLE
NEW - RDM-626 - Display metadata in search results

### DIFF
--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/search/MetaData.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/search/MetaData.java
@@ -9,18 +9,23 @@ import static java.util.stream.Collectors.toList;
 
 public class MetaData {
 
-    public static final String STATE_PARAM = "state";
-    public static final String CASE_REFERENCE_PARAM = "case_reference";
-    public static final String CREATED_DATE_PARAM = "created_date";
-    public static final String LAST_MODIFIED_PARAM = "last_modified_date";
-    public static final String SECURITY_CLASSIFICATION_PARAM = "security_classification";
-    public static final String PAGE_PARAM = "page";
-    public static final String SORT_DIRECTION_PARAM = "sortDirection";
-    private static final List<String> ALL_METADATA = newArrayList(STATE_PARAM, CASE_REFERENCE_PARAM,
-            CREATED_DATE_PARAM, LAST_MODIFIED_PARAM, SECURITY_CLASSIFICATION_PARAM, PAGE_PARAM, SORT_DIRECTION_PARAM);
+    public static final String JURISDICTION_METADATA = "jurisdiction";
+    public static final String CASE_TYPE_METADATA = "case_type";
+    public static final String STATE_METADATA = "state";
+    public static final String CASE_REFERENCE_METADATA = "case_reference";
+    public static final String CREATED_DATE_METADATA = "created_date";
+    public static final String LAST_MODIFIED_METADATA = "last_modified_date";
+    public static final String SECURITY_CLASSIFICATION_METADATA = "security_classification";
+    public static final String PAGE_METADATA = "page";
+    public static final String SORT_DIRECTION_METADATA = "sortDirection";
+    private static final List<String> METADATA_QUERY_PARAMETERS = newArrayList(STATE_METADATA, CASE_REFERENCE_METADATA,
+                                                                               CREATED_DATE_METADATA,
+                                                                               LAST_MODIFIED_METADATA,
+                                                                               SECURITY_CLASSIFICATION_METADATA,
+                                                                               PAGE_METADATA, SORT_DIRECTION_METADATA);
 
-    private String caseTypeId;
-    private String jurisdiction;
+    private final String caseTypeId;
+    private final String jurisdiction;
     private Optional<String> state = Optional.empty();
     private Optional<String> caseReference = Optional.empty();
     private Optional<String> createdDate = Optional.empty();
@@ -99,7 +104,7 @@ public class MetaData {
     }
 
     public static List<String> unknownMetadata(List<String> parameters) {
-        return parameters.stream().filter(p -> !ALL_METADATA.contains(p)).collect(toList());
+        return parameters.stream().filter(p -> !METADATA_QUERY_PARAMETERS.contains(p)).collect(toList());
     }
 
     private String toTrimmedLowerCase(String s) {
@@ -108,8 +113,12 @@ public class MetaData {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         MetaData metaData = (MetaData) o;
         return Objects.equals(caseTypeId, metaData.caseTypeId) &&
             Objects.equals(jurisdiction, metaData.jurisdiction) &&

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/search/MetaData.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/search/MetaData.java
@@ -6,23 +6,47 @@ import java.util.Optional;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static java.util.stream.Collectors.toList;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CaseField.CASE_REFERENCE;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CaseField.CREATED_DATE;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CaseField.LAST_MODIFIED_DATE;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CaseField.SECURITY_CLASSIFICATION;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CaseField.STATE;
 
 public class MetaData {
 
-    public static final String JURISDICTION_METADATA = "jurisdiction";
-    public static final String CASE_TYPE_METADATA = "case_type";
-    public static final String STATE_METADATA = "state";
-    public static final String CASE_REFERENCE_METADATA = "case_reference";
-    public static final String CREATED_DATE_METADATA = "created_date";
-    public static final String LAST_MODIFIED_METADATA = "last_modified_date";
-    public static final String SECURITY_CLASSIFICATION_METADATA = "security_classification";
-    public static final String PAGE_METADATA = "page";
-    public static final String SORT_DIRECTION_METADATA = "sortDirection";
-    private static final List<String> METADATA_QUERY_PARAMETERS = newArrayList(STATE_METADATA, CASE_REFERENCE_METADATA,
-                                                                               CREATED_DATE_METADATA,
-                                                                               LAST_MODIFIED_METADATA,
-                                                                               SECURITY_CLASSIFICATION_METADATA,
-                                                                               PAGE_METADATA, SORT_DIRECTION_METADATA);
+    public static final String PAGE_PARAM = "page";
+    public static final String SORT_PARAM = "sortDirection";
+    private static final List<String> METADATA_QUERY_PARAMETERS = newArrayList(STATE.getParameterName(),
+                                                                               CASE_REFERENCE.getParameterName(),
+                                                                               CREATED_DATE.getParameterName(),
+                                                                               LAST_MODIFIED_DATE.getParameterName(),
+                                                                               SECURITY_CLASSIFICATION.getParameterName(),
+                                                                               PAGE_PARAM, SORT_PARAM);
+
+    // Metadata case fields
+    public enum CaseField {
+        JURISDICTION("jurisdiction"),
+        CASE_TYPE("case_type"),
+        STATE("state"),
+        CASE_REFERENCE("case_reference"),
+        CREATED_DATE("created_date"),
+        LAST_MODIFIED_DATE("last_modified_date"),
+        SECURITY_CLASSIFICATION("security_classification");
+
+        private final String parameterName;
+
+        CaseField(String parameterName) {
+            this.parameterName = parameterName;
+        }
+
+        public String getParameterName() {
+            return parameterName;
+        }
+
+        public String getReference() {
+            return String.join(getParameterName().toUpperCase(), "[", "]");
+        }
+    }
 
     private final String caseTypeId;
     private final String jurisdiction;

--- a/src/main/java/uk/gov/hmcts/ccd/domain/model/aggregated/AbstractCaseView.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/model/aggregated/AbstractCaseView.java
@@ -3,6 +3,8 @@ package uk.gov.hmcts.ccd.domain.model.aggregated;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.ToString;
 
+import java.util.List;
+
 @ToString
 public abstract class AbstractCaseView {
 
@@ -11,6 +13,7 @@ public abstract class AbstractCaseView {
     @JsonProperty("case_type")
     private CaseViewType caseType;
     private CaseViewTab[] tabs;
+    private List<CaseViewField> metadataFields;
 
     public String getCaseId() {
         return caseId;
@@ -36,4 +39,11 @@ public abstract class AbstractCaseView {
         this.tabs = tabs;
     }
 
+    public List<CaseViewField> getMetadataFields() {
+        return metadataFields;
+    }
+
+    public void setMetadataFields(List<CaseViewField> metadataFields) {
+        this.metadataFields = metadataFields;
+    }
 }

--- a/src/main/java/uk/gov/hmcts/ccd/domain/model/aggregated/CaseViewField.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/model/aggregated/CaseViewField.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.ccd.domain.model.aggregated;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
 import lombok.ToString;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseField;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseTypeTabField;
@@ -24,7 +23,7 @@ public class CaseViewField {
     private String securityLabel;
     @JsonProperty("order")
     private Integer order;
-    private JsonNode value;
+    private Object value;
     @JsonProperty("display_context")
     private String displayContext;
     @JsonProperty("show_condition")
@@ -98,11 +97,11 @@ public class CaseViewField {
         this.order = order;
     }
 
-    public JsonNode getValue() {
+    public Object getValue() {
         return value;
     }
 
-    public void setValue(JsonNode value) {
+    public void setValue(Object value) {
         this.value = value;
     }
 
@@ -138,9 +137,16 @@ public class CaseViewField {
         this.showSummaryContentOption = showSummaryContentOption;
     }
 
-    public static CaseViewField createFrom(CaseTypeTabField field, Map<String, JsonNode> data) {
+    public static CaseViewField createFrom(CaseTypeTabField field, Map<String, ?> data) {
+        CaseViewField caseViewField = createFrom(field.getCaseField(), data);
+        caseViewField.setOrder(field.getDisplayOrder());
+        caseViewField.setShowCondition(field.getShowCondition());
+
+        return caseViewField;
+    }
+
+    public static CaseViewField createFrom(CaseField caseField, Map<String, ?> data) {
         CaseViewField caseViewField = new CaseViewField();
-        CaseField caseField = field.getCaseField();
         caseViewField.setId(caseField.getId());
         caseViewField.setLabel(caseField.getLabel());
         caseViewField.setFieldType(caseField.getFieldType());
@@ -148,11 +154,8 @@ public class CaseViewField {
         caseViewField.setHintText(caseField.getHintText());
         caseViewField.setSecurityLabel(caseField.getSecurityLabel());
         caseViewField.setValidationExpression(caseField.getFieldType().getRegularExpression());
-        caseViewField.setOrder(field.getDisplayOrder());
-        caseViewField.setShowCondition(field.getShowCondition());
         caseViewField.setValue(data.get(caseField.getId()));
 
         return caseViewField;
-
     }
 }

--- a/src/main/java/uk/gov/hmcts/ccd/domain/model/aggregated/CaseViewFieldBuilder.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/model/aggregated/CaseViewFieldBuilder.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.ccd.domain.model.aggregated;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseEventField;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseField;
 
@@ -32,14 +31,14 @@ public class CaseViewFieldBuilder {
         return field;
     }
 
-    public CaseViewField build(CaseField caseField, CaseEventField eventField, JsonNode value) {
+    public CaseViewField build(CaseField caseField, CaseEventField eventField, Object value) {
         final CaseViewField field = build(caseField, eventField);
         field.setValue(value);
 
         return field;
     }
 
-    public List<CaseViewField> build(List<CaseField> caseFields, List<CaseEventField> eventFields, Map<String, JsonNode> data) {
+    public List<CaseViewField> build(List<CaseField> caseFields, List<CaseEventField> eventFields, Map<String, ?> data) {
         final Map<String, CaseField> caseFieldMap = caseFields.stream()
             .collect(Collectors.toMap(CaseField::getId, Function.identity()));
 

--- a/src/main/java/uk/gov/hmcts/ccd/domain/model/definition/CaseDetails.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/model/definition/CaseDetails.java
@@ -14,9 +14,18 @@ import uk.gov.hmcts.ccd.data.casedetails.SecurityClassification;
 import uk.gov.hmcts.ccd.domain.model.callbacks.AfterSubmitCallbackResponse;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.Map;
 
+import static java.util.Optional.ofNullable;
 import static org.apache.http.HttpStatus.SC_OK;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CASE_REFERENCE_METADATA;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CASE_TYPE_METADATA;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CREATED_DATE_METADATA;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.JURISDICTION_METADATA;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.LAST_MODIFIED_METADATA;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.SECURITY_CLASSIFICATION_METADATA;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.STATE_METADATA;
 
 public class CaseDetails implements Cloneable {
     private static final Logger LOG = LoggerFactory.getLogger(CaseDetails.class);
@@ -63,6 +72,9 @@ public class CaseDetails implements Cloneable {
     /** Attribute passed to UI layer, does not need persistence */
     @JsonProperty("callback_response_status")
     private String callbackResponseStatus;
+
+    @JsonIgnore
+    private final Map<String, Object> metadata = new HashMap<>();
 
     public Long getId() {
         return id;
@@ -182,7 +194,8 @@ public class CaseDetails implements Cloneable {
 
     public boolean existsInData(CaseTypeTabField caseTypeTabField) {
         return isFieldWithNoValue(caseTypeTabField)
-            || data.keySet().contains(caseTypeTabField.getCaseField().getId());
+            || data.keySet().contains(caseTypeTabField.getCaseField().getId())
+            || getMetadata().containsKey(caseTypeTabField.getCaseField().getId());
     }
 
     private boolean isFieldWithNoValue(CaseTypeTabField caseTypeTabField) {
@@ -208,6 +221,27 @@ public class CaseDetails implements Cloneable {
                      callBackResponse.getBody().toJson());
             setIncompleteCallbackResponse();
         }
+    }
+
+    @JsonIgnore
+    public Map<String, Object> getMetadata() {
+        if (metadata.isEmpty()) {
+            metadata.put(JURISDICTION_METADATA, getJurisdiction());
+            metadata.put(CASE_TYPE_METADATA, getCaseTypeId());
+            metadata.put(STATE_METADATA, getState());
+            metadata.put(CASE_REFERENCE_METADATA, getReference());
+            metadata.put(CREATED_DATE_METADATA, getCreatedDate());
+            metadata.put(LAST_MODIFIED_METADATA, getLastModified());
+            metadata.put(SECURITY_CLASSIFICATION_METADATA, getSecurityClassification());
+        }
+        return metadata;
+    }
+
+    @JsonIgnore
+    public Map<String, Object> getCaseDataAndMetadata() {
+        Map<String, Object> allData = new HashMap<>(getMetadata());
+        ofNullable(getData()).ifPresent(allData::putAll);
+        return allData;
     }
 
     @JsonIgnore

--- a/src/main/java/uk/gov/hmcts/ccd/domain/model/definition/CaseDetails.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/model/definition/CaseDetails.java
@@ -19,13 +19,13 @@ import java.util.Map;
 
 import static java.util.Optional.ofNullable;
 import static org.apache.http.HttpStatus.SC_OK;
-import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CASE_REFERENCE_METADATA;
-import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CASE_TYPE_METADATA;
-import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CREATED_DATE_METADATA;
-import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.JURISDICTION_METADATA;
-import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.LAST_MODIFIED_METADATA;
-import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.SECURITY_CLASSIFICATION_METADATA;
-import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.STATE_METADATA;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CaseField.CASE_REFERENCE;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CaseField.CASE_TYPE;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CaseField.CREATED_DATE;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CaseField.JURISDICTION;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CaseField.LAST_MODIFIED_DATE;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CaseField.SECURITY_CLASSIFICATION;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CaseField.STATE;
 
 public class CaseDetails implements Cloneable {
     private static final Logger LOG = LoggerFactory.getLogger(CaseDetails.class);
@@ -226,13 +226,13 @@ public class CaseDetails implements Cloneable {
     @JsonIgnore
     public Map<String, Object> getMetadata() {
         if (metadata.isEmpty()) {
-            metadata.put(JURISDICTION_METADATA, getJurisdiction());
-            metadata.put(CASE_TYPE_METADATA, getCaseTypeId());
-            metadata.put(STATE_METADATA, getState());
-            metadata.put(CASE_REFERENCE_METADATA, getReference());
-            metadata.put(CREATED_DATE_METADATA, getCreatedDate());
-            metadata.put(LAST_MODIFIED_METADATA, getLastModified());
-            metadata.put(SECURITY_CLASSIFICATION_METADATA, getSecurityClassification());
+            metadata.put(JURISDICTION.getReference(), getJurisdiction());
+            metadata.put(CASE_TYPE.getReference(), getCaseTypeId());
+            metadata.put(STATE.getReference(), getState());
+            metadata.put(CASE_REFERENCE.getReference(), getReference());
+            metadata.put(CREATED_DATE.getReference(), getCreatedDate());
+            metadata.put(LAST_MODIFIED_DATE.getReference(), getLastModified());
+            metadata.put(SECURITY_CLASSIFICATION.getReference(), getSecurityClassification());
         }
         return metadata;
     }

--- a/src/main/java/uk/gov/hmcts/ccd/domain/model/definition/CaseField.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/model/definition/CaseField.java
@@ -30,6 +30,7 @@ public class CaseField implements Serializable {
     private String showConditon = null;
     @JsonProperty("acls")
     private List<AccessControlList> accessControlLists;
+    private boolean metadata;
 
     public String getId() {
         return id;
@@ -115,4 +116,11 @@ public class CaseField implements Serializable {
         this.accessControlLists = accessControlLists;
     }
 
+    public boolean isMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(boolean metadata) {
+        this.metadata = metadata;
+    }
 }

--- a/src/main/java/uk/gov/hmcts/ccd/domain/model/definition/SearchResultField.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/model/definition/SearchResultField.java
@@ -1,8 +1,8 @@
 package uk.gov.hmcts.ccd.domain.model.definition;
 
-import java.io.Serializable;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.Serializable;
 
 public class SearchResultField implements Serializable {
     @JsonProperty("case_type_id")
@@ -12,6 +12,7 @@ public class SearchResultField implements Serializable {
     private String label;
     @JsonProperty("order")
     private Integer displayOrder;
+    private boolean metadata;
 
     public String getCaseTypeId() {
         return caseTypeId;
@@ -43,5 +44,13 @@ public class SearchResultField implements Serializable {
 
     public void setDisplayOrder(Integer displayOrder) {
         this.displayOrder = displayOrder;
+    }
+
+    public boolean isMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(boolean metadata) {
+        this.metadata = metadata;
     }
 }

--- a/src/main/java/uk/gov/hmcts/ccd/domain/model/search/Field.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/model/search/Field.java
@@ -7,6 +7,7 @@ public class Field {
     private String id;
     @JsonProperty("field_type")
     private FieldType type;
+    private boolean metadata;
 
     public String getId() {
         return id;
@@ -22,5 +23,13 @@ public class Field {
 
     public void setType(FieldType type) {
         this.type = type;
+    }
+
+    public boolean isMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(boolean metadata) {
+        this.metadata = metadata;
     }
 }

--- a/src/main/java/uk/gov/hmcts/ccd/domain/model/search/SearchResultView.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/model/search/SearchResultView.java
@@ -2,27 +2,29 @@ package uk.gov.hmcts.ccd.domain.model.search;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.List;
+
 public class SearchResultView {
     @JsonProperty("columns")
-    private SearchResultViewColumn[] searchResultViewColumns;
+    private List<SearchResultViewColumn> searchResultViewColumns;
     @JsonProperty("results")
-    private SearchResultViewItem[] searchResultViewItems;
+    private List<SearchResultViewItem> searchResultViewItems;
 
     public SearchResultView() {
         // Default constructor for JSON mapper
     }
 
-    public SearchResultView(final SearchResultViewColumn[] searchResultViewColumns,
-                            final SearchResultViewItem[] searchResultViewItems) {
+    public SearchResultView(final List<SearchResultViewColumn> searchResultViewColumns,
+                            final List<SearchResultViewItem> searchResultViewItems) {
         this.searchResultViewColumns = searchResultViewColumns;
         this.searchResultViewItems = searchResultViewItems;
     }
 
-    public SearchResultViewColumn[] getSearchResultViewColumns() {
+    public List<SearchResultViewColumn> getSearchResultViewColumns() {
         return searchResultViewColumns;
     }
 
-    public SearchResultViewItem[] getSearchResultViewItems() {
+    public List<SearchResultViewItem> getSearchResultViewItems() {
         return searchResultViewItems;
     }
 }

--- a/src/main/java/uk/gov/hmcts/ccd/domain/model/search/SearchResultViewColumn.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/model/search/SearchResultViewColumn.java
@@ -11,6 +11,7 @@ public class SearchResultViewColumn {
     private FieldType caseFieldType;
     private String label;
     private Integer order;
+    private boolean metadata;
 
     public SearchResultViewColumn() {
         // Default constructor for JSON mapper
@@ -19,11 +20,13 @@ public class SearchResultViewColumn {
     public SearchResultViewColumn(final String caseFieldId,
                                   final FieldType caseFieldType,
                                   final String label,
-                                  final Integer order) {
+                                  final Integer order,
+                                  final boolean metadata) {
         this.caseFieldId = caseFieldId;
         this.caseFieldType = caseFieldType;
         this.label = label;
         this.order = order;
+        this.metadata = metadata;
     }
 
     public String getCaseFieldId() {
@@ -40,5 +43,9 @@ public class SearchResultViewColumn {
 
     public Integer getOrder() {
         return order;
+    }
+
+    public boolean isMetadata() {
+        return metadata;
     }
 }

--- a/src/main/java/uk/gov/hmcts/ccd/domain/model/search/SearchResultViewItem.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/model/search/SearchResultViewItem.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.ccd.domain.model.search;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
 
 import java.util.Map;
 
@@ -9,14 +8,14 @@ public class SearchResultViewItem {
     @JsonProperty("case_id")
     private String caseId;
     @JsonProperty("case_fields")
-    private Map<String, JsonNode> caseFields;
+    private Map<String, Object> caseFields;
 
     public SearchResultViewItem() {
         // Default constructor for JSON mapper
     }
 
     public SearchResultViewItem(final String caseId,
-                                final Map<String, JsonNode> caseFields) {
+                                final Map<String, Object> caseFields) {
         this.caseId = caseId;
         this.caseFields = caseFields;
     }
@@ -25,7 +24,7 @@ public class SearchResultViewItem {
         return caseId;
     }
 
-    public Map<String, JsonNode> getCaseFields() {
+    public Map<String, Object> getCaseFields() {
         return caseFields;
     }
 }

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/aggregated/AbstractDefaultGetCaseViewOperation.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/aggregated/AbstractDefaultGetCaseViewOperation.java
@@ -62,10 +62,6 @@ public abstract class AbstractDefaultGetCaseViewOperation {
         return getTabs(caseDetails, data, getCaseTabCollection(caseDetails.getCaseTypeId()));
     }
 
-    CaseTabCollection getCaseTabCollection(String caseTypeId) {
-        return uiDefinitionRepository.getCaseTabCollection(caseTypeId);
-    }
-
     CaseViewTab[] getTabs(CaseDetails caseDetails, Map<String, ?> data, CaseTabCollection caseTabCollection) {
         return caseTabCollection.getTabs().stream().map(tab -> {
             CaseViewField[] caseViewFields = tab.getTabFields().stream()
@@ -77,6 +73,10 @@ public abstract class AbstractDefaultGetCaseViewOperation {
                                    tab.getShowCondition());
 
         }).toArray(CaseViewTab[]::new);
+    }
+
+    CaseTabCollection getCaseTabCollection(String caseTypeId) {
+        return uiDefinitionRepository.getCaseTabCollection(caseTypeId);
     }
 
     private Predicate<CaseTypeTabField> filterCaseTabFieldsBasedOnSecureData(CaseDetails caseDetails) {

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/aggregated/AbstractDefaultGetCaseViewOperation.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/aggregated/AbstractDefaultGetCaseViewOperation.java
@@ -1,10 +1,10 @@
 package uk.gov.hmcts.ccd.domain.service.aggregated;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import uk.gov.hmcts.ccd.data.definition.UIDefinitionRepository;
 import uk.gov.hmcts.ccd.domain.model.aggregated.CaseViewField;
 import uk.gov.hmcts.ccd.domain.model.aggregated.CaseViewTab;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseDetails;
+import uk.gov.hmcts.ccd.domain.model.definition.CaseField;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseTabCollection;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseType;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseTypeTabField;
@@ -14,8 +14,10 @@ import uk.gov.hmcts.ccd.domain.service.getcase.GetCaseOperation;
 import uk.gov.hmcts.ccd.endpoint.exceptions.BadRequestException;
 import uk.gov.hmcts.ccd.endpoint.exceptions.ResourceNotFoundException;
 
+import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 public abstract class AbstractDefaultGetCaseViewOperation {
 
@@ -56,19 +58,15 @@ public abstract class AbstractDefaultGetCaseViewOperation {
                                                               caseReference)));
     }
 
+    CaseViewTab[] getTabs(CaseDetails caseDetails, Map<String, ?> data) {
+        return getTabs(caseDetails, data, getCaseTabCollection(caseDetails.getCaseTypeId()));
+    }
+
     CaseTabCollection getCaseTabCollection(String caseTypeId) {
         return uiDefinitionRepository.getCaseTabCollection(caseTypeId);
     }
 
-    private Predicate<CaseTypeTabField> filterCaseTabFieldsBasedOnSecureData(CaseDetails caseDetails) {
-        return caseDetails::existsInData;
-    }
-
-    CaseViewTab[] getTabs(CaseDetails caseDetails, Map<String, JsonNode> data) {
-        return getTabs(caseDetails, data, getCaseTabCollection(caseDetails.getCaseTypeId()));
-    }
-
-    CaseViewTab[] getTabs(CaseDetails caseDetails, Map<String, JsonNode> data, CaseTabCollection caseTabCollection) {
+    CaseViewTab[] getTabs(CaseDetails caseDetails, Map<String, ?> data, CaseTabCollection caseTabCollection) {
         return caseTabCollection.getTabs().stream().map(tab -> {
             CaseViewField[] caseViewFields = tab.getTabFields().stream()
                 .filter(filterCaseTabFieldsBasedOnSecureData(caseDetails))
@@ -79,6 +77,15 @@ public abstract class AbstractDefaultGetCaseViewOperation {
                                    tab.getShowCondition());
 
         }).toArray(CaseViewTab[]::new);
+    }
+
+    private Predicate<CaseTypeTabField> filterCaseTabFieldsBasedOnSecureData(CaseDetails caseDetails) {
+        return caseDetails::existsInData;
+    }
+
+    List<CaseViewField> getMetadataFields(CaseType caseType, CaseDetails caseDetails) {
+        return caseType.getCaseFields().stream().filter(CaseField::isMetadata).map(caseField -> CaseViewField.createFrom(caseField, caseDetails
+            .getCaseDataAndMetadata())).collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/aggregated/DefaultFindSearchInputOperation.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/aggregated/DefaultFindSearchInputOperation.java
@@ -7,7 +7,11 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.ccd.data.definition.CachedCaseDefinitionRepository;
 import uk.gov.hmcts.ccd.data.definition.CaseDefinitionRepository;
 import uk.gov.hmcts.ccd.data.definition.UIDefinitionRepository;
-import uk.gov.hmcts.ccd.domain.model.definition.*;
+import uk.gov.hmcts.ccd.domain.model.definition.AccessControlList;
+import uk.gov.hmcts.ccd.domain.model.definition.CaseField;
+import uk.gov.hmcts.ccd.domain.model.definition.CaseType;
+import uk.gov.hmcts.ccd.domain.model.definition.SearchInputDefinition;
+import uk.gov.hmcts.ccd.domain.model.definition.SearchInputField;
 import uk.gov.hmcts.ccd.domain.model.search.Field;
 import uk.gov.hmcts.ccd.domain.model.search.SearchInput;
 
@@ -30,6 +34,7 @@ public class DefaultFindSearchInputOperation implements FindSearchInputOperation
         this.caseDefinitionRepository = caseDefinitionRepository;
     }
 
+    @Override
     public List<SearchInput> execute(final String jurisdictionId, final String caseTypeId, Predicate<AccessControlList> access) {
         LOG.debug("Finding SearchInput fields for jurisdiction={}, caseType={}", jurisdictionId, caseTypeId);
         final CaseType caseType = caseDefinitionRepository.getCaseType(caseTypeId);
@@ -37,7 +42,7 @@ public class DefaultFindSearchInputOperation implements FindSearchInputOperation
 
         return searchInputDefinition.getFields()
             .stream()
-            .map(field -> toSearchInput(field,caseType))
+            .map(field -> toSearchInput(field, caseType))
             .collect(toList());
     }
 
@@ -47,16 +52,17 @@ public class DefaultFindSearchInputOperation implements FindSearchInputOperation
         result.setOrder(in.getDisplayOrder());
         final Field field =new Field();
         field.setId(in.getCaseFieldId());
-        field.setType(getFieldType(in.getCaseFieldId(), caseType));
+        CaseField caseField = getCaseField(in.getCaseFieldId(), caseType);
+        field.setType(caseField.getFieldType());
+        field.setMetadata(caseField.isMetadata());
         result.setField(field);
         return result;
     }
 
-    private FieldType getFieldType(final String fieldId, final CaseType caseType){
+    private CaseField getCaseField(final String fieldId, final CaseType caseType) {
         return caseType.getCaseFields().stream()
             .filter(c -> c.getId().equals(fieldId))
             .findFirst()
-            .orElseThrow(() -> new RuntimeException(String.format("FieldId %s not found",fieldId)))
-            .getFieldType();
+            .orElseThrow(() -> new RuntimeException(String.format("FieldId %s not found", fieldId)));
     }
 }

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/aggregated/DefaultFindWorkbasketInputOperation.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/aggregated/DefaultFindWorkbasketInputOperation.java
@@ -7,7 +7,11 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.ccd.data.definition.CachedCaseDefinitionRepository;
 import uk.gov.hmcts.ccd.data.definition.CaseDefinitionRepository;
 import uk.gov.hmcts.ccd.data.definition.UIDefinitionRepository;
-import uk.gov.hmcts.ccd.domain.model.definition.*;
+import uk.gov.hmcts.ccd.domain.model.definition.AccessControlList;
+import uk.gov.hmcts.ccd.domain.model.definition.CaseField;
+import uk.gov.hmcts.ccd.domain.model.definition.CaseType;
+import uk.gov.hmcts.ccd.domain.model.definition.WorkbasketInputDefinition;
+import uk.gov.hmcts.ccd.domain.model.definition.WorkbasketInputField;
 import uk.gov.hmcts.ccd.domain.model.search.Field;
 import uk.gov.hmcts.ccd.domain.model.search.WorkbasketInput;
 
@@ -22,8 +26,8 @@ public class DefaultFindWorkbasketInputOperation implements FindWorkbasketInputO
     private static final Logger LOG = LoggerFactory.getLogger(DefaultFindWorkbasketInputOperation.class);
 
     public static final String QUALIFIER = "default";
-    private UIDefinitionRepository uiDefinitionRepository;
-    private CaseDefinitionRepository caseDefinitionRepository;
+    private final UIDefinitionRepository uiDefinitionRepository;
+    private final CaseDefinitionRepository caseDefinitionRepository;
 
     public DefaultFindWorkbasketInputOperation(UIDefinitionRepository uiDefinitionRepository,
                                                @Qualifier(CachedCaseDefinitionRepository.QUALIFIER) final CaseDefinitionRepository caseDefinitionRepository) {
@@ -31,6 +35,7 @@ public class DefaultFindWorkbasketInputOperation implements FindWorkbasketInputO
         this.caseDefinitionRepository = caseDefinitionRepository;
     }
 
+    @Override
     public List<WorkbasketInput> execute(String jurisdictionId, String caseTypeId, Predicate<AccessControlList> access) {
         LOG.debug("Finding WorkbasketInput fields for jurisdiction={}, caseType={}", jurisdictionId, caseTypeId);
 
@@ -50,16 +55,17 @@ public class DefaultFindWorkbasketInputOperation implements FindWorkbasketInputO
         result.setOrder(in.getOrder());
         final Field field = new Field();
         field.setId(in.getCaseFieldId());
-        field.setType(getFieldType(in.getCaseFieldId(), caseType));
+        CaseField caseField = getCaseField(in.getCaseFieldId(), caseType);
+        field.setType(caseField.getFieldType());
+        field.setMetadata(caseField.isMetadata());
         result.setField(field);
         return result;
     }
 
-    private FieldType getFieldType(final String fieldId, final CaseType caseType) {
+    private CaseField getCaseField(final String fieldId, final CaseType caseType) {
         return caseType.getCaseFields().stream()
             .filter(c -> c.getId().equals(fieldId))
             .findFirst()
-            .orElseThrow(() -> new RuntimeException(String.format("FieldId %s not found", fieldId)))
-            .getFieldType();
+            .orElseThrow(() -> new RuntimeException(String.format("FieldId %s not found", fieldId)));
     }
 }

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/aggregated/DefaultGetCaseViewOperation.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/aggregated/DefaultGetCaseViewOperation.java
@@ -68,7 +68,8 @@ public class DefaultGetCaseViewOperation extends AbstractDefaultGetCaseViewOpera
         caseView.setState(new ProfileCaseState(caseState.getId(), caseState.getName(), caseState.getDescription()));
 
         caseView.setCaseType(CaseViewType.createFrom(caseType));
-        caseView.setTabs(getTabs(caseDetails, caseDetails.getData(), caseTabCollection));
+        caseView.setTabs(getTabs(caseDetails, caseDetails.getCaseDataAndMetadata(), caseTabCollection));
+        caseView.setMetadataFields(getMetadataFields(caseType, caseDetails));
 
         final CaseViewTrigger[] triggers = caseType.getEvents()
             .stream()

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/aggregated/DefaultGetEventTriggerOperation.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/aggregated/DefaultGetEventTriggerOperation.java
@@ -10,7 +10,12 @@ import uk.gov.hmcts.ccd.domain.model.aggregated.CaseEventTrigger;
 import uk.gov.hmcts.ccd.domain.model.aggregated.CaseViewField;
 import uk.gov.hmcts.ccd.domain.model.aggregated.CaseViewFieldBuilder;
 import uk.gov.hmcts.ccd.domain.model.callbacks.StartEventTrigger;
-import uk.gov.hmcts.ccd.domain.model.definition.*;
+import uk.gov.hmcts.ccd.domain.model.definition.CaseDetails;
+import uk.gov.hmcts.ccd.domain.model.definition.CaseEvent;
+import uk.gov.hmcts.ccd.domain.model.definition.CaseEventField;
+import uk.gov.hmcts.ccd.domain.model.definition.CaseField;
+import uk.gov.hmcts.ccd.domain.model.definition.CaseType;
+import uk.gov.hmcts.ccd.domain.model.definition.WizardPage;
 import uk.gov.hmcts.ccd.domain.service.common.EventTriggerService;
 import uk.gov.hmcts.ccd.domain.service.startevent.StartEventOperation;
 import uk.gov.hmcts.ccd.endpoint.exceptions.ResourceNotFoundException;
@@ -125,6 +130,6 @@ public class DefaultGetEventTriggerOperation implements GetEventTriggerOperation
         final List<CaseEventField> eventFields = eventTrigger.getCaseFields();
         final List<CaseField> caseFields = caseType.getCaseFields();
 
-        return caseViewFieldBuilder.build(caseFields, eventFields, caseDetails != null ? caseDetails.getData() : null);
+        return caseViewFieldBuilder.build(caseFields, eventFields, caseDetails != null ? caseDetails.getCaseDataAndMetadata() : null);
     }
 }

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/aggregated/MergeDataToSearchResultOperation.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/aggregated/MergeDataToSearchResultOperation.java
@@ -13,6 +13,7 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Named
 @Singleton
@@ -25,20 +26,21 @@ public class MergeDataToSearchResultOperation {
 
     public SearchResultView execute(final CaseType caseType, final List<CaseDetails> caseDetails,final String view) {
         final SearchResult searchResult = getSearchResult(caseType, view);
-        final SearchResultViewColumn[] viewColumns = Arrays.stream(searchResult.getFields())
+        final List<SearchResultViewColumn> viewColumns = Arrays.stream(searchResult.getFields())
             .flatMap(searchResultField -> caseType.getCaseFields().stream()
             .filter(caseField -> caseField.getId().equals(searchResultField.getCaseFieldId()))
             .map(caseField ->  new SearchResultViewColumn(
                 searchResultField.getCaseFieldId(),
                 caseField.getFieldType(),
                 searchResultField.getLabel(),
-                searchResultField.getDisplayOrder())
+                searchResultField.getDisplayOrder(),
+                searchResultField.isMetadata())
              ))
-            .toArray(SearchResultViewColumn[]::new);
+            .collect(Collectors.toList());
 
-        final SearchResultViewItem[] viewItems = caseDetails.stream()
-            .map(caseData -> new SearchResultViewItem(caseData.getReference().toString(), caseData.getData()))
-            .toArray(SearchResultViewItem[]::new);
+        final List<SearchResultViewItem> viewItems = caseDetails.stream()
+            .map(caseData -> new SearchResultViewItem(caseData.getReference().toString(), caseData.getCaseDataAndMetadata()))
+            .collect(Collectors.toList());
         return new SearchResultView(viewColumns, viewItems);
     }
 

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/aggregated/SearchQueryOperation.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/aggregated/SearchQueryOperation.java
@@ -7,12 +7,11 @@ import uk.gov.hmcts.ccd.data.casedetails.search.MetaData;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseDetails;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseType;
 import uk.gov.hmcts.ccd.domain.model.search.SearchResultView;
-import uk.gov.hmcts.ccd.domain.model.search.SearchResultViewColumn;
-import uk.gov.hmcts.ccd.domain.model.search.SearchResultViewItem;
 import uk.gov.hmcts.ccd.domain.service.common.CaseTypeService;
 import uk.gov.hmcts.ccd.domain.service.search.CreatorSearchOperation;
 import uk.gov.hmcts.ccd.domain.service.search.SearchOperation;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -49,7 +48,7 @@ public class SearchQueryOperation {
             .findFirst();
 
         if (!caseType.isPresent()) {
-            return new SearchResultView(new SearchResultViewColumn[0], new SearchResultViewItem[0]);
+            return new SearchResultView(Collections.emptyList(), Collections.emptyList());
         }
         final List<CaseDetails> caseData = searchOperation.execute(metadata, queryParameters);
         return mergeDataToSearchResultOperation.execute(caseType.get(), caseData, view);

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/common/AccessControlService.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/common/AccessControlService.java
@@ -8,10 +8,21 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.ccd.domain.model.aggregated.CaseEventTrigger;
 import uk.gov.hmcts.ccd.domain.model.aggregated.CaseViewTrigger;
-import uk.gov.hmcts.ccd.domain.model.definition.*;
+import uk.gov.hmcts.ccd.domain.model.definition.AccessControlList;
+import uk.gov.hmcts.ccd.domain.model.definition.CaseEvent;
+import uk.gov.hmcts.ccd.domain.model.definition.CaseField;
+import uk.gov.hmcts.ccd.domain.model.definition.CaseState;
+import uk.gov.hmcts.ccd.domain.model.definition.CaseType;
+import uk.gov.hmcts.ccd.domain.model.definition.WizardPage;
 import uk.gov.hmcts.ccd.domain.model.std.AuditEvent;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.Spliterator;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -270,9 +281,9 @@ public class AccessControlService {
         if (caseFieldDefinitions != null) {
             filteredCaseFields = caseFieldDefinitions
                 .stream()
-                .filter(caseField -> hasAccessControlList(userRoles,
-                                                          access,
-                                                          caseField.getAccessControlLists()))
+                .filter(caseField -> caseField.isMetadata() || hasAccessControlList(userRoles,
+                                                                                    access,
+                                                                                    caseField.getAccessControlLists()))
                 .collect(toList());
 
         }

--- a/src/main/java/uk/gov/hmcts/ccd/endpoint/std/CaseDetailsEndpoint.java
+++ b/src/main/java/uk/gov/hmcts/ccd/endpoint/std/CaseDetailsEndpoint.java
@@ -41,13 +41,13 @@ import uk.gov.hmcts.ccd.domain.service.validate.ValidateCaseFieldsOperation;
 import uk.gov.hmcts.ccd.endpoint.exceptions.ApiException;
 import uk.gov.hmcts.ccd.endpoint.exceptions.BadRequestException;
 
+import javax.transaction.Transactional;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
-import javax.transaction.Transactional;
 
 import static java.util.stream.Collectors.toList;
 
@@ -467,13 +467,13 @@ public class CaseDetailsEndpoint {
             throw new BadRequestException(String.format("unknown metadata search parameters: %s",
                     String.join((","), MetaData.unknownMetadata(metadataParams))));
         }
-        param(queryParameters, MetaData.SECURITY_CLASSIFICATION_PARAM).ifPresent(sc -> {
+        param(queryParameters, MetaData.SECURITY_CLASSIFICATION_METADATA).ifPresent(sc -> {
             if(!EnumUtils.isValidEnum(SecurityClassification.class, sc.toUpperCase())) {
                 throw new BadRequestException(String.format("unknown security classification '%s'", sc));
             }
         });
 
-        param(queryParameters, MetaData.SORT_DIRECTION_PARAM).ifPresent(sd -> {
+        param(queryParameters, MetaData.SORT_DIRECTION_METADATA).ifPresent(sd -> {
             if (Stream.of("ASC", "DESC").noneMatch(direction -> direction.equalsIgnoreCase(sd))) {
                 throw new BadRequestException(String.format("Unknown sort direction: %s", sd));
             }
@@ -489,13 +489,13 @@ public class CaseDetailsEndpoint {
         validateMetadataSearchParameters(queryParameters);
 
         final MetaData metadata = new MetaData(caseTypeId, jurisdictionId);
-        metadata.setState(param(queryParameters, MetaData.STATE_PARAM));
-        metadata.setCaseReference(param(queryParameters, MetaData.CASE_REFERENCE_PARAM));
-        metadata.setCreatedDate(param(queryParameters, MetaData.CREATED_DATE_PARAM));
-        metadata.setLastModified(param(queryParameters, MetaData.LAST_MODIFIED_PARAM));
-        metadata.setSecurityClassification(param(queryParameters, MetaData.SECURITY_CLASSIFICATION_PARAM));
-        metadata.setPage(param(queryParameters, MetaData.PAGE_PARAM));
-        metadata.setSortDirection(param(queryParameters, MetaData.SORT_DIRECTION_PARAM));
+        metadata.setState(param(queryParameters, MetaData.STATE_METADATA));
+        metadata.setCaseReference(param(queryParameters, MetaData.CASE_REFERENCE_METADATA));
+        metadata.setCreatedDate(param(queryParameters, MetaData.CREATED_DATE_METADATA));
+        metadata.setLastModified(param(queryParameters, MetaData.LAST_MODIFIED_METADATA));
+        metadata.setSecurityClassification(param(queryParameters, MetaData.SECURITY_CLASSIFICATION_METADATA));
+        metadata.setPage(param(queryParameters, MetaData.PAGE_METADATA));
+        metadata.setSortDirection(param(queryParameters, MetaData.SORT_DIRECTION_METADATA));
 
         return metadata;
     }

--- a/src/main/java/uk/gov/hmcts/ccd/endpoint/std/CaseDetailsEndpoint.java
+++ b/src/main/java/uk/gov/hmcts/ccd/endpoint/std/CaseDetailsEndpoint.java
@@ -50,6 +50,13 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CaseField.CASE_REFERENCE;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CaseField.CREATED_DATE;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CaseField.LAST_MODIFIED_DATE;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CaseField.SECURITY_CLASSIFICATION;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CaseField.STATE;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.PAGE_PARAM;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.SORT_PARAM;
 
 @RestController
 @RequestMapping(path = "/",
@@ -467,13 +474,13 @@ public class CaseDetailsEndpoint {
             throw new BadRequestException(String.format("unknown metadata search parameters: %s",
                     String.join((","), MetaData.unknownMetadata(metadataParams))));
         }
-        param(queryParameters, MetaData.SECURITY_CLASSIFICATION_METADATA).ifPresent(sc -> {
+        param(queryParameters, SECURITY_CLASSIFICATION.getParameterName()).ifPresent(sc -> {
             if(!EnumUtils.isValidEnum(SecurityClassification.class, sc.toUpperCase())) {
                 throw new BadRequestException(String.format("unknown security classification '%s'", sc));
             }
         });
 
-        param(queryParameters, MetaData.SORT_DIRECTION_METADATA).ifPresent(sd -> {
+        param(queryParameters, SORT_PARAM).ifPresent(sd -> {
             if (Stream.of("ASC", "DESC").noneMatch(direction -> direction.equalsIgnoreCase(sd))) {
                 throw new BadRequestException(String.format("Unknown sort direction: %s", sd));
             }
@@ -489,13 +496,13 @@ public class CaseDetailsEndpoint {
         validateMetadataSearchParameters(queryParameters);
 
         final MetaData metadata = new MetaData(caseTypeId, jurisdictionId);
-        metadata.setState(param(queryParameters, MetaData.STATE_METADATA));
-        metadata.setCaseReference(param(queryParameters, MetaData.CASE_REFERENCE_METADATA));
-        metadata.setCreatedDate(param(queryParameters, MetaData.CREATED_DATE_METADATA));
-        metadata.setLastModified(param(queryParameters, MetaData.LAST_MODIFIED_METADATA));
-        metadata.setSecurityClassification(param(queryParameters, MetaData.SECURITY_CLASSIFICATION_METADATA));
-        metadata.setPage(param(queryParameters, MetaData.PAGE_METADATA));
-        metadata.setSortDirection(param(queryParameters, MetaData.SORT_DIRECTION_METADATA));
+        metadata.setState(param(queryParameters, STATE.getParameterName()));
+        metadata.setCaseReference(param(queryParameters, CASE_REFERENCE.getParameterName()));
+        metadata.setCreatedDate(param(queryParameters, CREATED_DATE.getParameterName()));
+        metadata.setLastModified(param(queryParameters, LAST_MODIFIED_DATE.getParameterName()));
+        metadata.setSecurityClassification(param(queryParameters, SECURITY_CLASSIFICATION.getParameterName()));
+        metadata.setPage(param(queryParameters, PAGE_PARAM));
+        metadata.setSortDirection(param(queryParameters, SORT_PARAM));
 
         return metadata;
     }

--- a/src/main/java/uk/gov/hmcts/ccd/endpoint/ui/QueryEndpoint.java
+++ b/src/main/java/uk/gov/hmcts/ccd/endpoint/ui/QueryEndpoint.java
@@ -49,6 +49,13 @@ import java.util.Optional;
 import java.util.function.Predicate;
 
 import static java.util.Optional.ofNullable;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CaseField.CASE_REFERENCE;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CaseField.CREATED_DATE;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CaseField.LAST_MODIFIED_DATE;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CaseField.SECURITY_CLASSIFICATION;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CaseField.STATE;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.PAGE_PARAM;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.SORT_PARAM;
 import static uk.gov.hmcts.ccd.domain.service.common.AccessControlService.CAN_CREATE;
 import static uk.gov.hmcts.ccd.domain.service.common.AccessControlService.CAN_READ;
 import static uk.gov.hmcts.ccd.domain.service.common.AccessControlService.CAN_UPDATE;
@@ -123,13 +130,13 @@ public class QueryEndpoint {
                                       @RequestParam java.util.Map<String, String> params) {
         String view = params.get("view");
         MetaData metadata = new MetaData(caseTypeId, jurisdictionId);
-        metadata.setState(param(params, MetaData.STATE_METADATA));
-        metadata.setCaseReference(param(params, MetaData.CASE_REFERENCE_METADATA));
-        metadata.setCreatedDate(param(params, MetaData.CREATED_DATE_METADATA));
-        metadata.setLastModified(param(params, MetaData.LAST_MODIFIED_METADATA));
-        metadata.setSecurityClassification(param(params, MetaData.SECURITY_CLASSIFICATION_METADATA));
-        metadata.setPage(param(params, MetaData.PAGE_METADATA));
-        metadata.setSortDirection(param(params, MetaData.SORT_DIRECTION_METADATA));
+        metadata.setState(param(params, STATE.getParameterName()));
+        metadata.setCaseReference(param(params, CASE_REFERENCE.getParameterName()));
+        metadata.setCreatedDate(param(params, CREATED_DATE.getParameterName()));
+        metadata.setLastModified(param(params, LAST_MODIFIED_DATE.getParameterName()));
+        metadata.setSecurityClassification(param(params, SECURITY_CLASSIFICATION.getParameterName()));
+        metadata.setPage(param(params, PAGE_PARAM));
+        metadata.setSortDirection(param(params, SORT_PARAM));
 
         Map<String, String> sanitized = fieldMapSanitizeOperation.execute(params);
 

--- a/src/main/java/uk/gov/hmcts/ccd/endpoint/ui/QueryEndpoint.java
+++ b/src/main/java/uk/gov/hmcts/ccd/endpoint/ui/QueryEndpoint.java
@@ -123,13 +123,13 @@ public class QueryEndpoint {
                                       @RequestParam java.util.Map<String, String> params) {
         String view = params.get("view");
         MetaData metadata = new MetaData(caseTypeId, jurisdictionId);
-        metadata.setState(param(params, MetaData.STATE_PARAM));
-        metadata.setCaseReference(param(params, MetaData.CASE_REFERENCE_PARAM));
-        metadata.setCreatedDate(param(params, MetaData.CREATED_DATE_PARAM));
-        metadata.setLastModified(param(params, MetaData.LAST_MODIFIED_PARAM));
-        metadata.setSecurityClassification(param(params, MetaData.SECURITY_CLASSIFICATION_PARAM));
-        metadata.setPage(param(params, MetaData.PAGE_PARAM));
-        metadata.setSortDirection(param(params, MetaData.SORT_DIRECTION_PARAM));
+        metadata.setState(param(params, MetaData.STATE_METADATA));
+        metadata.setCaseReference(param(params, MetaData.CASE_REFERENCE_METADATA));
+        metadata.setCreatedDate(param(params, MetaData.CREATED_DATE_METADATA));
+        metadata.setLastModified(param(params, MetaData.LAST_MODIFIED_METADATA));
+        metadata.setSecurityClassification(param(params, MetaData.SECURITY_CLASSIFICATION_METADATA));
+        metadata.setPage(param(params, MetaData.PAGE_METADATA));
+        metadata.setSortDirection(param(params, MetaData.SORT_DIRECTION_METADATA));
 
         Map<String, String> sanitized = fieldMapSanitizeOperation.execute(params);
 

--- a/src/test/java/uk/gov/hmcts/ccd/domain/model/definition/CaseDetailsTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/model/definition/CaseDetailsTest.java
@@ -1,16 +1,25 @@
 package uk.gov.hmcts.ccd.domain.model.definition;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-
-import java.util.Map;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.ccd.data.casedetails.SecurityClassification;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CASE_REFERENCE_METADATA;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CASE_TYPE_METADATA;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CREATED_DATE_METADATA;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.JURISDICTION_METADATA;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.LAST_MODIFIED_METADATA;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.SECURITY_CLASSIFICATION_METADATA;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.STATE_METADATA;
 
 class CaseDetailsTest {
 
@@ -54,11 +63,33 @@ class CaseDetailsTest {
         assertThat(caseDetails.existsInData(tabField), equalTo(true));
     }
 
+    @Test
+    void shouldReturnCaseDataAndMetadataFieldMap() {
+        LocalDateTime now = LocalDateTime.now();
+        caseDetails.setJurisdiction("jurisdiction");
+        caseDetails.setCaseTypeId("caseType");
+        caseDetails.setState("state");
+        caseDetails.setReference(1234567L);
+        caseDetails.setCreatedDate(now);
+        caseDetails.setLastModified(now);
+        caseDetails.setSecurityClassification(SecurityClassification.PUBLIC);
+
+        Map<String, Object> allData = caseDetails.getCaseDataAndMetadata();
+
+        assertThat(((JsonNode) allData.get(CASE_DETAIL_FIELD)).asText(), equalTo(CASE_DETAIL_FIELD));
+        assertThat(allData.get(JURISDICTION_METADATA), equalTo(caseDetails.getJurisdiction()));
+        assertThat(allData.get(CASE_TYPE_METADATA), equalTo(caseDetails.getCaseTypeId()));
+        assertThat(allData.get(STATE_METADATA), equalTo(caseDetails.getState()));
+        assertThat(allData.get(CASE_REFERENCE_METADATA), equalTo(caseDetails.getReference()));
+        assertThat(allData.get(CREATED_DATE_METADATA), equalTo(caseDetails.getCreatedDate()));
+        assertThat(allData.get(LAST_MODIFIED_METADATA), equalTo(caseDetails.getLastModified()));
+        assertThat(allData.get(SECURITY_CLASSIFICATION_METADATA), equalTo(caseDetails.getSecurityClassification()));
+    }
+
     private Map<String, JsonNode> buildData(String... dataFieldIds) {
         Map<String, JsonNode> dataMap = Maps.newHashMap();
-        Lists.newArrayList(dataFieldIds).forEach(dataFieldId -> {
-            dataMap.put(dataFieldId, JSON_NODE_FACTORY.textNode(dataFieldId));
-        });
+        Lists.newArrayList(dataFieldIds)
+            .forEach(dataFieldId -> dataMap.put(dataFieldId, JSON_NODE_FACTORY.textNode(dataFieldId)));
         return dataMap;
     }
 
@@ -72,6 +103,5 @@ class CaseDetailsTest {
         tabField.setCaseField(caseField);
         return tabField;
     }
-
 
 }

--- a/src/test/java/uk/gov/hmcts/ccd/domain/model/definition/CaseDetailsTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/model/definition/CaseDetailsTest.java
@@ -13,13 +13,13 @@ import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CASE_REFERENCE_METADATA;
-import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CASE_TYPE_METADATA;
-import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CREATED_DATE_METADATA;
-import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.JURISDICTION_METADATA;
-import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.LAST_MODIFIED_METADATA;
-import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.SECURITY_CLASSIFICATION_METADATA;
-import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.STATE_METADATA;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CaseField.CASE_REFERENCE;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CaseField.CASE_TYPE;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CaseField.CREATED_DATE;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CaseField.JURISDICTION;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CaseField.LAST_MODIFIED_DATE;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CaseField.SECURITY_CLASSIFICATION;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CaseField.STATE;
 
 class CaseDetailsTest {
 
@@ -77,13 +77,13 @@ class CaseDetailsTest {
         Map<String, Object> allData = caseDetails.getCaseDataAndMetadata();
 
         assertThat(((JsonNode) allData.get(CASE_DETAIL_FIELD)).asText(), equalTo(CASE_DETAIL_FIELD));
-        assertThat(allData.get(JURISDICTION_METADATA), equalTo(caseDetails.getJurisdiction()));
-        assertThat(allData.get(CASE_TYPE_METADATA), equalTo(caseDetails.getCaseTypeId()));
-        assertThat(allData.get(STATE_METADATA), equalTo(caseDetails.getState()));
-        assertThat(allData.get(CASE_REFERENCE_METADATA), equalTo(caseDetails.getReference()));
-        assertThat(allData.get(CREATED_DATE_METADATA), equalTo(caseDetails.getCreatedDate()));
-        assertThat(allData.get(LAST_MODIFIED_METADATA), equalTo(caseDetails.getLastModified()));
-        assertThat(allData.get(SECURITY_CLASSIFICATION_METADATA), equalTo(caseDetails.getSecurityClassification()));
+        assertThat(allData.get(JURISDICTION.getReference()), equalTo(caseDetails.getJurisdiction()));
+        assertThat(allData.get(CASE_TYPE.getReference()), equalTo(caseDetails.getCaseTypeId()));
+        assertThat(allData.get(STATE.getReference()), equalTo(caseDetails.getState()));
+        assertThat(allData.get(CASE_REFERENCE.getReference()), equalTo(caseDetails.getReference()));
+        assertThat(allData.get(CREATED_DATE.getReference()), equalTo(caseDetails.getCreatedDate()));
+        assertThat(allData.get(LAST_MODIFIED_DATE.getReference()), equalTo(caseDetails.getLastModified()));
+        assertThat(allData.get(SECURITY_CLASSIFICATION.getReference()), equalTo(caseDetails.getSecurityClassification()));
     }
 
     private Map<String, JsonNode> buildData(String... dataFieldIds) {

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/aggregated/DefaultFindSearchInputOperationTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/aggregated/DefaultFindSearchInputOperationTest.java
@@ -6,7 +6,11 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import uk.gov.hmcts.ccd.data.definition.CaseDefinitionRepository;
 import uk.gov.hmcts.ccd.data.definition.UIDefinitionRepository;
-import uk.gov.hmcts.ccd.domain.model.definition.*;
+import uk.gov.hmcts.ccd.domain.model.definition.CaseField;
+import uk.gov.hmcts.ccd.domain.model.definition.CaseType;
+import uk.gov.hmcts.ccd.domain.model.definition.FieldType;
+import uk.gov.hmcts.ccd.domain.model.definition.SearchInputDefinition;
+import uk.gov.hmcts.ccd.domain.model.definition.SearchInputField;
 import uk.gov.hmcts.ccd.domain.model.search.SearchInput;
 
 import java.util.Arrays;
@@ -24,11 +28,12 @@ class DefaultFindSearchInputOperationTest {
     @Mock
     private CaseDefinitionRepository caseDefinitionRepository;
 
-    private CaseType caseType = new CaseType();
+    private final CaseType caseType = new CaseType();
     private DefaultFindSearchInputOperation findSearchInputOperation;
-    private CaseField caseField1 = new CaseField();
-    private CaseField caseField2 = new CaseField();
-    private CaseField caseField3 = new CaseField();
+    private final CaseField caseField1 = new CaseField();
+    private final CaseField caseField2 = new CaseField();
+    private final CaseField caseField3 = new CaseField();
+    private final CaseField caseField4 = new CaseField();
 
     @BeforeEach
     void setup() {
@@ -40,8 +45,11 @@ class DefaultFindSearchInputOperationTest {
         caseField2.setFieldType(fieldType);
         caseField3.setId("field3");
         caseField3.setFieldType(fieldType);
+        caseField4.setId("field4");
+        caseField4.setFieldType(fieldType);
+        caseField4.setMetadata(true);
         caseType.setId("Test case type");
-        caseType.setCaseFields(Arrays.asList(caseField1, caseField2, caseField3));
+        caseType.setCaseFields(Arrays.asList(caseField1, caseField2, caseField3, caseField4));
 
         findSearchInputOperation = new DefaultFindSearchInputOperation(uiDefinitionRepository, caseDefinitionRepository);
 
@@ -54,15 +62,19 @@ class DefaultFindSearchInputOperationTest {
         List<SearchInput> searchInputs = findSearchInputOperation.execute("TEST", caseType.getId(), CAN_READ);
 
         assertAll(
-            () -> assertThat(searchInputs.size(), is(3)),
-            () -> assertThat(searchInputs.get(0).getField().getId(), is("field1"))
+            () -> assertThat(searchInputs.size(), is(4)),
+            () -> assertThat(searchInputs.get(0).getField().getId(), is("field1")),
+            () -> assertThat(searchInputs.get(3).getField().isMetadata(), is(true))
         );
     }
 
     private SearchInputDefinition generateSearchInput() {
         SearchInputDefinition searchInputDefinition = new SearchInputDefinition();
         searchInputDefinition.setCaseTypeId(caseType.getId());
-        searchInputDefinition.setFields(Arrays.asList(getField(caseField1.getId(), 1), getField(caseField2.getId(), 2), getField(caseField3.getId(), 3)));
+        searchInputDefinition.setFields(Arrays.asList(getField(caseField1.getId(), 1),
+                                                      getField(caseField2.getId(), 2),
+                                                      getField(caseField3.getId(), 3),
+                                                      getField(caseField4.getId(), 4)));
         return searchInputDefinition;
 
     }

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/aggregated/DefaultFindWorkbasketInputOperationTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/aggregated/DefaultFindWorkbasketInputOperationTest.java
@@ -6,7 +6,11 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import uk.gov.hmcts.ccd.data.definition.CaseDefinitionRepository;
 import uk.gov.hmcts.ccd.data.definition.UIDefinitionRepository;
-import uk.gov.hmcts.ccd.domain.model.definition.*;
+import uk.gov.hmcts.ccd.domain.model.definition.CaseField;
+import uk.gov.hmcts.ccd.domain.model.definition.CaseType;
+import uk.gov.hmcts.ccd.domain.model.definition.FieldType;
+import uk.gov.hmcts.ccd.domain.model.definition.WorkbasketInputDefinition;
+import uk.gov.hmcts.ccd.domain.model.definition.WorkbasketInputField;
 import uk.gov.hmcts.ccd.domain.model.search.WorkbasketInput;
 
 import java.util.Arrays;
@@ -24,11 +28,12 @@ class DefaultFindWorkbasketInputOperationTest {
     @Mock
     private CaseDefinitionRepository caseDefinitionRepository;
 
-    private CaseType caseType = new CaseType();
+    private final CaseType caseType = new CaseType();
     private DefaultFindWorkbasketInputOperation findWorkbasketInputOperation;
-    private CaseField caseField1 = new CaseField();
-    private CaseField caseField2 = new CaseField();
-    private CaseField caseField3 = new CaseField();
+    private final CaseField caseField1 = new CaseField();
+    private final CaseField caseField2 = new CaseField();
+    private final CaseField caseField3 = new CaseField();
+    private final CaseField caseField4 = new CaseField();
 
     @BeforeEach
     void setup() {
@@ -40,8 +45,11 @@ class DefaultFindWorkbasketInputOperationTest {
         caseField2.setFieldType(fieldType);
         caseField3.setId("field3");
         caseField3.setFieldType(fieldType);
+        caseField4.setId("field4");
+        caseField4.setFieldType(fieldType);
+        caseField4.setMetadata(true);
         caseType.setId("Test case type");
-        caseType.setCaseFields(Arrays.asList(caseField1, caseField2, caseField3));
+        caseType.setCaseFields(Arrays.asList(caseField1, caseField2, caseField3, caseField4));
 
         findWorkbasketInputOperation = new DefaultFindWorkbasketInputOperation(uiDefinitionRepository, caseDefinitionRepository);
 
@@ -54,15 +62,20 @@ class DefaultFindWorkbasketInputOperationTest {
         List<WorkbasketInput> workbasketInputs = findWorkbasketInputOperation.execute("TEST", caseType.getId(), CAN_READ);
 
         assertAll(
-            () -> assertThat(workbasketInputs.size(), is(3)),
-            () -> assertThat(workbasketInputs.get(0).getField().getId(), is("field1"))
+            () -> assertThat(workbasketInputs.size(), is(4)),
+            () -> assertThat(workbasketInputs.get(0).getField().getId(), is("field1")),
+            () -> assertThat(workbasketInputs.get(3).getField().isMetadata(), is(true))
         );
     }
 
     private WorkbasketInputDefinition generateWorkbasketInput() {
         WorkbasketInputDefinition workbasketInputDefinition = new WorkbasketInputDefinition();
         workbasketInputDefinition.setCaseTypeId(caseType.getId());
-        workbasketInputDefinition.setFields(Arrays.asList(getField(caseField1.getId(), 1), getField(caseField2.getId(), 2), getField(caseField3.getId(), 3)));
+        workbasketInputDefinition.setFields(
+            Arrays.asList(getField(caseField1.getId(), 1),
+                          getField(caseField2.getId(), 2),
+                          getField(caseField3.getId(), 3),
+                          getField(caseField4.getId(), 4)));
         return workbasketInputDefinition;
     }
 

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/aggregated/DefaultGetCaseViewOperationTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/aggregated/DefaultGetCaseViewOperationTest.java
@@ -111,7 +111,7 @@ class DefaultGetCaseViewOperationTest {
         jurisdiction.setName(JURISDICTION_ID);
         caseType.setJurisdiction(jurisdiction);
         CaseField caseField = new CaseField();
-        caseField.setId(MetaData.CASE_TYPE_METADATA);
+        caseField.setId(MetaData.CaseField.CASE_TYPE.getReference());
         caseField.setMetadata(true);
         caseField.setFieldType(new FieldType());
         caseType.setCaseFields(Collections.singletonList(caseField));

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/aggregated/DefaultGetCaseViewOperationTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/aggregated/DefaultGetCaseViewOperationTest.java
@@ -8,12 +8,15 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import uk.gov.hmcts.ccd.data.casedetails.CaseAuditEventRepository;
+import uk.gov.hmcts.ccd.data.casedetails.search.MetaData;
 import uk.gov.hmcts.ccd.data.definition.UIDefinitionRepository;
 import uk.gov.hmcts.ccd.domain.model.aggregated.CaseView;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseDetails;
+import uk.gov.hmcts.ccd.domain.model.definition.CaseField;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseState;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseTabCollection;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseType;
+import uk.gov.hmcts.ccd.domain.model.definition.FieldType;
 import uk.gov.hmcts.ccd.domain.model.definition.Jurisdiction;
 import uk.gov.hmcts.ccd.domain.model.std.AuditEvent;
 import uk.gov.hmcts.ccd.domain.service.common.CaseTypeService;
@@ -22,6 +25,7 @@ import uk.gov.hmcts.ccd.domain.service.common.UIDService;
 import uk.gov.hmcts.ccd.domain.service.getcase.GetCaseOperation;
 import uk.gov.hmcts.ccd.domain.service.getevents.GetEventsOperation;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -106,6 +110,11 @@ class DefaultGetCaseViewOperationTest {
         Jurisdiction jurisdiction = new Jurisdiction();
         jurisdiction.setName(JURISDICTION_ID);
         caseType.setJurisdiction(jurisdiction);
+        CaseField caseField = new CaseField();
+        caseField.setId(MetaData.CASE_TYPE_METADATA);
+        caseField.setMetadata(true);
+        caseField.setFieldType(new FieldType());
+        caseType.setCaseFields(Collections.singletonList(caseField));
         doReturn(caseType).when(caseTypeService).getCaseTypeForJurisdiction(CASE_TYPE_ID, JURISDICTION_ID);
 
         caseState = new CaseState();
@@ -137,6 +146,7 @@ class DefaultGetCaseViewOperationTest {
                                    hasItemInArray(allOf(hasProperty("id", equalTo("dataTestField2")),
                                                         hasProperty("showCondition",
                                                                     equalTo("dataTestField2-fieldShowCondition"))))),
+                  () -> assertThat(caseView.getMetadataFields().get(0).getValue(), equalTo(CASE_TYPE_ID)),
                   () -> assertThat(caseView.getEvents(), arrayWithSize(2)),
                   () -> assertThat(caseView.getEvents(),
                                    hasItemInArray(hasProperty("summary", equalTo(EVENT_SUMMARY_1)))),

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/aggregated/MergeDataToSearchResultOperationTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/aggregated/MergeDataToSearchResultOperationTest.java
@@ -51,9 +51,11 @@ class MergeDataToSearchResultOperationTest {
         CaseDetails caseDetails1 = new CaseDetails();
         caseDetails1.setReference(999L);
         caseDetails1.setData(dataMap);
+        caseDetails1.setState("state1");
         CaseDetails caseDetails2 = new CaseDetails();
         caseDetails2.setReference(1000L);
         caseDetails2.setData(dataMap);
+        caseDetails2.setState("state2");
         caseDetailsList = Arrays.asList(caseDetails1, caseDetails2);
 
         caseType = aCaseType()
@@ -80,8 +82,10 @@ class MergeDataToSearchResultOperationTest {
 
         final SearchResultView searchResultView = classUnderTest.execute(caseType, caseDetailsList, WORKBASKET_VIEW);
         assertAll(
-            () -> assertThat(searchResultView.getSearchResultViewItems().length, is(2)),
-            () -> assertThat(searchResultView.getSearchResultViewColumns().length, is(2))
+            () -> assertThat(searchResultView.getSearchResultViewColumns().size(), is(2)),
+            () -> assertThat(searchResultView.getSearchResultViewItems().size(), is(2)),
+            () -> assertThat(searchResultView.getSearchResultViewItems().get(0).getCaseFields().get("state"), is("state1")),
+            () -> assertThat(searchResultView.getSearchResultViewItems().get(1).getCaseFields().get("state"), is("state2"))
         );
     }
 
@@ -96,8 +100,8 @@ class MergeDataToSearchResultOperationTest {
 
         final SearchResultView searchResultView = classUnderTest.execute(caseType, caseDetailsList, SEARCH_VIEW);
         assertAll(
-            () -> assertThat(searchResultView.getSearchResultViewItems().length, is(2)),
-            () -> assertThat(searchResultView.getSearchResultViewColumns().length, is(1))
+            () -> assertThat(searchResultView.getSearchResultViewItems().size(), is(2)),
+            () -> assertThat(searchResultView.getSearchResultViewColumns().size(), is(1))
         );
     }
 }

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/aggregated/MergeDataToSearchResultOperationTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/aggregated/MergeDataToSearchResultOperationTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.doReturn;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CaseField.STATE;
 import static uk.gov.hmcts.ccd.domain.service.aggregated.SearchResultUtil.SearchResultBuilder.aSearchResult;
 import static uk.gov.hmcts.ccd.domain.service.aggregated.SearchResultUtil.buildData;
 import static uk.gov.hmcts.ccd.domain.service.aggregated.SearchResultUtil.buildSearchResultField;
@@ -84,8 +85,8 @@ class MergeDataToSearchResultOperationTest {
         assertAll(
             () -> assertThat(searchResultView.getSearchResultViewColumns().size(), is(2)),
             () -> assertThat(searchResultView.getSearchResultViewItems().size(), is(2)),
-            () -> assertThat(searchResultView.getSearchResultViewItems().get(0).getCaseFields().get("state"), is("state1")),
-            () -> assertThat(searchResultView.getSearchResultViewItems().get(1).getCaseFields().get("state"), is("state2"))
+            () -> assertThat(searchResultView.getSearchResultViewItems().get(0).getCaseFields().get(STATE.getReference()), is("state1")),
+            () -> assertThat(searchResultView.getSearchResultViewItems().get(1).getCaseFields().get(STATE.getReference()), is("state2"))
         );
     }
 

--- a/src/test/java/uk/gov/hmcts/ccd/endpoint/ui/QueryEndpointIT.java
+++ b/src/test/java/uk/gov/hmcts/ccd/endpoint/ui/QueryEndpointIT.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.ccd.endpoint.ui;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -39,6 +38,7 @@ import uk.gov.hmcts.ccd.domain.model.std.AuditEvent;
 import javax.inject.Inject;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -150,44 +150,54 @@ public class QueryEndpointIT extends WireMockBaseTest {
 
         final SearchResultView searchResultView = mapper.readValue(result.getResponse().getContentAsString(),
             SearchResultView.class);
-        final SearchResultViewColumn[] searchResultViewColumns = searchResultView.getSearchResultViewColumns();
-        final SearchResultViewItem[] searchResultViewItems = searchResultView.getSearchResultViewItems();
+        final List<SearchResultViewColumn> searchResultViewColumns = searchResultView.getSearchResultViewColumns();
+        final List<SearchResultViewItem> searchResultViewItems = searchResultView.getSearchResultViewItems();
 
-        assertEquals("Incorrect view columns count", 3, searchResultViewColumns.length);
+        assertEquals("Incorrect view columns count", 3, searchResultViewColumns.size());
 
-        assertEquals("PersonFirstName", searchResultViewColumns[0].getCaseFieldId());
-        assertEquals("First Name", searchResultViewColumns[0].getLabel());
-        assertEquals(1, searchResultViewColumns[0].getOrder().intValue());
+        assertEquals("PersonFirstName", searchResultViewColumns.get(0).getCaseFieldId());
+        assertEquals("First Name", searchResultViewColumns.get(0).getLabel());
+        assertEquals(1, searchResultViewColumns.get(0).getOrder().intValue());
 
-        assertEquals("PersonLastName", searchResultViewColumns[1].getCaseFieldId());
-        assertEquals("Last Name", searchResultViewColumns[1].getLabel());
-        assertEquals(1, searchResultViewColumns[1].getOrder().intValue());
+        assertEquals("PersonLastName", searchResultViewColumns.get(1).getCaseFieldId());
+        assertEquals("Last Name", searchResultViewColumns.get(1).getLabel());
+        assertEquals(1, searchResultViewColumns.get(1).getOrder().intValue());
 
-        assertEquals("PersonAddress", searchResultViewColumns[2].getCaseFieldId());
-        assertEquals("Address", searchResultViewColumns[2].getLabel());
-        assertEquals(1, searchResultViewColumns[2].getOrder().intValue());
-        assertEquals("Address", searchResultViewColumns[2].getCaseFieldType().getId());
-        assertEquals("Address", searchResultViewColumns[2].getCaseFieldType().getType());
+        assertEquals("PersonAddress", searchResultViewColumns.get(2).getCaseFieldId());
+        assertEquals("Address", searchResultViewColumns.get(2).getLabel());
+        assertEquals(1, searchResultViewColumns.get(2).getOrder().intValue());
+        assertEquals("Address", searchResultViewColumns.get(2).getCaseFieldType().getId());
+        assertEquals("Address", searchResultViewColumns.get(2).getCaseFieldType().getType());
 
-        assertEquals("Incorrect view items count", 2, searchResultViewItems.length);
+        assertEquals("Incorrect view items count", 2, searchResultViewItems.size());
 
-        assertNotNull(searchResultViewItems[0].getCaseId());
-        assertEquals("Janet", searchResultViewItems[0].getCaseFields().get("PersonFirstName").asText());
-        assertEquals("Parker", searchResultViewItems[0].getCaseFields().get("PersonLastName").asText());
-        assertEquals("123", searchResultViewItems[0].getCaseFields().get("PersonAddress").get("AddressLine1").asText());
-        assertEquals("Fake Street", searchResultViewItems[0].getCaseFields().get("PersonAddress").get("AddressLine2").asText());
-        assertEquals("Hexton", searchResultViewItems[0].getCaseFields().get("PersonAddress").get("AddressLine3").asText());
-        assertEquals("England", searchResultViewItems[0].getCaseFields().get("PersonAddress").get("Country").asText());
-        assertEquals("HX08 UTG", searchResultViewItems[0].getCaseFields().get("PersonAddress").get("Postcode").asText());
+        assertNotNull(searchResultViewItems.get(0).getCaseId());
+        assertEquals("Janet", searchResultViewItems.get(0).getCaseFields().get("PersonFirstName"));
+        assertEquals("Parker", searchResultViewItems.get(0).getCaseFields().get("PersonLastName"));
+        assertEquals("123", ((Map) searchResultViewItems.get(0).getCaseFields().get("PersonAddress"))
+            .get("AddressLine1"));
+        assertEquals("Fake Street", ((Map) searchResultViewItems.get(0).getCaseFields().get("PersonAddress"))
+            .get("AddressLine2"));
+        assertEquals("Hexton", ((Map) searchResultViewItems.get(0).getCaseFields().get("PersonAddress"))
+            .get("AddressLine3"));
+        assertEquals("England", ((Map) searchResultViewItems.get(0).getCaseFields().get("PersonAddress"))
+            .get("Country"));
+        assertEquals("HX08 UTG", ((Map) searchResultViewItems.get(0).getCaseFields().get("PersonAddress"))
+            .get("Postcode"));
 
-        assertNotNull(searchResultViewItems[1].getCaseId());
-        assertEquals("George", searchResultViewItems[1].getCaseFields().get("PersonFirstName").asText());
-        assertEquals("Roof", searchResultViewItems[1].getCaseFields().get("PersonLastName").asText());
-        assertEquals("Flat 9", searchResultViewItems[1].getCaseFields().get("PersonAddress").get("AddressLine1").asText());
-        assertEquals("2 Hubble Avenue", searchResultViewItems[1].getCaseFields().get("PersonAddress").get("AddressLine2").asText());
-        assertEquals("ButtonVillie", searchResultViewItems[1].getCaseFields().get("PersonAddress").get("AddressLine3").asText());
-        assertEquals("Wales", searchResultViewItems[1].getCaseFields().get("PersonAddress").get("Country").asText());
-        assertEquals("W11 5DF", searchResultViewItems[1].getCaseFields().get("PersonAddress").get("Postcode").asText());
+        assertNotNull(searchResultViewItems.get(1).getCaseId());
+        assertEquals("George", searchResultViewItems.get(1).getCaseFields().get("PersonFirstName"));
+        assertEquals("Roof", searchResultViewItems.get(1).getCaseFields().get("PersonLastName"));
+        assertEquals("Flat 9", ((Map) searchResultViewItems.get(1).getCaseFields().get("PersonAddress"))
+            .get("AddressLine1"));
+        assertEquals("2 Hubble Avenue", ((Map) searchResultViewItems.get(1).getCaseFields().get("PersonAddress"))
+            .get("AddressLine2"));
+        assertEquals("ButtonVillie", ((Map) searchResultViewItems.get(1).getCaseFields().get("PersonAddress"))
+            .get("AddressLine3"));
+        assertEquals("Wales", ((Map) searchResultViewItems.get(1).getCaseFields().get("PersonAddress"))
+            .get("Country"));
+        assertEquals("W11 5DF", ((Map) searchResultViewItems.get(1).getCaseFields().get("PersonAddress"))
+            .get("Postcode"));
     }
 
     @Test
@@ -206,27 +216,37 @@ public class QueryEndpointIT extends WireMockBaseTest {
             .andReturn();
 
         final SearchResultView searchResultView = mapper.readValue(result.getResponse().getContentAsString(), SearchResultView.class);
-        final SearchResultViewItem[] searchResultViewItems = searchResultView.getSearchResultViewItems();
+        final List<SearchResultViewItem> searchResultViewItems = searchResultView.getSearchResultViewItems();
 
-        assertEquals("Incorrect view items count", 2, searchResultViewItems.length);
+        assertEquals("Incorrect view items count", 2, searchResultViewItems.size());
 
-        assertNotNull(searchResultViewItems[0].getCaseId());
-        assertThat(searchResultViewItems[0].getCaseFields().get("PersonFirstName"), is(nullValue()));
-        assertEquals("Pullen", searchResultViewItems[0].getCaseFields().get("PersonLastName").asText());
-        assertEquals("Governer House", searchResultViewItems[0].getCaseFields().get("PersonAddress").get("AddressLine1").asText());
-        assertEquals("1 Puddle Lane", searchResultViewItems[0].getCaseFields().get("PersonAddress").get("AddressLine2").asText());
-        assertEquals("London", searchResultViewItems[0].getCaseFields().get("PersonAddress").get("AddressLine3").asText());
-        assertEquals("England", searchResultViewItems[0].getCaseFields().get("PersonAddress").get("Country").asText());
-        assertEquals("SE1 4EE", searchResultViewItems[0].getCaseFields().get("PersonAddress").get("Postcode").asText());
+        assertNotNull(searchResultViewItems.get(0).getCaseId());
+        assertThat(searchResultViewItems.get(0).getCaseFields().get("PersonFirstName"), is(nullValue()));
+        assertEquals("Pullen", searchResultViewItems.get(0).getCaseFields().get("PersonLastName"));
+        assertEquals("Governer House", ((Map) searchResultViewItems.get(0).getCaseFields().get("PersonAddress"))
+            .get("AddressLine1"));
+        assertEquals("1 Puddle Lane", ((Map) searchResultViewItems.get(0).getCaseFields().get("PersonAddress"))
+            .get("AddressLine2"));
+        assertEquals("London", ((Map) searchResultViewItems.get(0).getCaseFields().get("PersonAddress"))
+            .get("AddressLine3"));
+        assertEquals("England", ((Map) searchResultViewItems.get(0).getCaseFields().get("PersonAddress"))
+            .get("Country"));
+        assertEquals("SE1 4EE", ((Map) searchResultViewItems.get(0).getCaseFields().get("PersonAddress"))
+            .get("Postcode"));
 
-        assertNotNull(searchResultViewItems[1].getCaseId());
-        assertThat(searchResultViewItems[1].getCaseFields().get("PersonFirstName"), is(nullValue()));
-        assertEquals("Parker", searchResultViewItems[1].getCaseFields().get("PersonLastName").asText());
-        assertEquals("123", searchResultViewItems[1].getCaseFields().get("PersonAddress").get("AddressLine1").asText());
-        assertEquals("Fake Street", searchResultViewItems[1].getCaseFields().get("PersonAddress").get("AddressLine2").asText());
-        assertEquals("Hexton", searchResultViewItems[1].getCaseFields().get("PersonAddress").get("AddressLine3").asText());
-        assertEquals("England", searchResultViewItems[1].getCaseFields().get("PersonAddress").get("Country").asText());
-        assertEquals("HX08 UTG", searchResultViewItems[1].getCaseFields().get("PersonAddress").get("Postcode").asText());
+        assertNotNull(searchResultViewItems.get(1).getCaseId());
+        assertThat(searchResultViewItems.get(1).getCaseFields().get("PersonFirstName"), is(nullValue()));
+        assertEquals("Parker", searchResultViewItems.get(1).getCaseFields().get("PersonLastName"));
+        assertEquals("123", ((Map) searchResultViewItems.get(1).getCaseFields().get("PersonAddress"))
+            .get("AddressLine1"));
+        assertEquals("Fake Street", ((Map) searchResultViewItems.get(1).getCaseFields().get("PersonAddress"))
+            .get("AddressLine2"));
+        assertEquals("Hexton", ((Map) searchResultViewItems.get(1).getCaseFields().get("PersonAddress"))
+            .get("AddressLine3"));
+        assertEquals("England", ((Map) searchResultViewItems.get(1).getCaseFields().get("PersonAddress"))
+            .get("Country"));
+        assertEquals("HX08 UTG", ((Map) searchResultViewItems.get(1).getCaseFields().get("PersonAddress"))
+            .get("Postcode"));
     }
 
     @Test
@@ -246,9 +266,9 @@ public class QueryEndpointIT extends WireMockBaseTest {
 
         final SearchResultView searchResultView = mapper.readValue(result.getResponse().getContentAsString(),
             SearchResultView.class);
-        final SearchResultViewItem[] searchResultViewItems = searchResultView.getSearchResultViewItems();
+        final List<SearchResultViewItem> searchResultViewItems = searchResultView.getSearchResultViewItems();
 
-        assertEquals("Incorrect view items count", 0, searchResultViewItems.length);
+        assertEquals("Incorrect view items count", 0, searchResultViewItems.size());
     }
 
     @Test
@@ -268,34 +288,38 @@ public class QueryEndpointIT extends WireMockBaseTest {
 
         final SearchResultView searchResultView = mapper.readValue(result.getResponse().getContentAsString(),
             SearchResultView.class);
-        final SearchResultViewColumn[] searchResultViewColumns = searchResultView.getSearchResultViewColumns();
-        final SearchResultViewItem[] searchResultViewItems = searchResultView.getSearchResultViewItems();
+        final List<SearchResultViewColumn> searchResultViewColumns = searchResultView.getSearchResultViewColumns();
+        final List<SearchResultViewItem> searchResultViewItems = searchResultView.getSearchResultViewItems();
 
-        assertEquals("Incorrect view columns count", 3, searchResultViewColumns.length);
+        assertEquals("Incorrect view columns count", 3, searchResultViewColumns.size());
 
-        assertEquals("PersonFirstName", searchResultViewColumns[0].getCaseFieldId());
-        assertEquals("First Name", searchResultViewColumns[0].getLabel());
-        assertEquals(1, searchResultViewColumns[0].getOrder().intValue());
+        assertEquals("PersonFirstName", searchResultViewColumns.get(0).getCaseFieldId());
+        assertEquals("First Name", searchResultViewColumns.get(0).getLabel());
+        assertEquals(1, searchResultViewColumns.get(0).getOrder().intValue());
 
-        assertEquals("PersonLastName", searchResultViewColumns[1].getCaseFieldId());
-        assertEquals("Last Name", searchResultViewColumns[1].getLabel());
-        assertEquals(1, searchResultViewColumns[1].getOrder().intValue());
+        assertEquals("PersonLastName", searchResultViewColumns.get(1).getCaseFieldId());
+        assertEquals("Last Name", searchResultViewColumns.get(1).getLabel());
+        assertEquals(1, searchResultViewColumns.get(1).getOrder().intValue());
 
-        assertEquals("PersonAddress", searchResultViewColumns[2].getCaseFieldId());
-        assertEquals("Address", searchResultViewColumns[2].getLabel());
-        assertEquals(1, searchResultViewColumns[2].getOrder().intValue());
+        assertEquals("PersonAddress", searchResultViewColumns.get(2).getCaseFieldId());
+        assertEquals("Address", searchResultViewColumns.get(2).getLabel());
+        assertEquals(1, searchResultViewColumns.get(2).getOrder().intValue());
 
-        assertEquals("Incorrect view items count", 2, searchResultViewItems.length);
+        assertEquals("Incorrect view items count", 2, searchResultViewItems.size());
 
-        assertNotNull(searchResultViewItems[0].getCaseId());
-        assertEquals("Janet", searchResultViewItems[0].getCaseFields().get("PersonFirstName").asText());
-        assertEquals("Parker", searchResultViewItems[0].getCaseFields().get("PersonLastName").asText());
-        assertEquals("123", searchResultViewItems[0].getCaseFields().get("PersonAddress").get("AddressLine1").asText());
-        assertEquals("Fake Street", searchResultViewItems[0].getCaseFields().get("PersonAddress").get("AddressLine2").asText());
-        assertEquals("Hexton", searchResultViewItems[0].getCaseFields().get("PersonAddress").get("AddressLine3").asText());
-        assertEquals("England", searchResultViewItems[0].getCaseFields().get("PersonAddress").get("Country").asText());
-        assertEquals("HX08 UTG", searchResultViewItems[0].getCaseFields().get("PersonAddress").get("Postcode").asText
-            ());
+        assertNotNull(searchResultViewItems.get(0).getCaseId());
+        assertEquals("Janet", searchResultViewItems.get(0).getCaseFields().get("PersonFirstName"));
+        assertEquals("Parker", searchResultViewItems.get(0).getCaseFields().get("PersonLastName"));
+        assertEquals("123", ((Map) searchResultViewItems.get(0).getCaseFields().get("PersonAddress"))
+            .get("AddressLine1"));
+        assertEquals("Fake Street", ((Map) searchResultViewItems.get(0).getCaseFields().get("PersonAddress"))
+            .get("AddressLine2"));
+        assertEquals("Hexton", ((Map) searchResultViewItems.get(0).getCaseFields().get("PersonAddress"))
+            .get("AddressLine3"));
+        assertEquals("England", ((Map) searchResultViewItems.get(0).getCaseFields().get("PersonAddress"))
+            .get("Country"));
+        assertEquals("HX08 UTG", ((Map) searchResultViewItems.get(0).getCaseFields().get("PersonAddress"))
+            .get("Postcode"));
     }
 
     @Test
@@ -317,24 +341,24 @@ public class QueryEndpointIT extends WireMockBaseTest {
 
         final SearchResultView searchResultView = mapper.readValue(result.getResponse().getContentAsString(),
             SearchResultView.class);
-        final SearchResultViewColumn[] searchResultViewColumns = searchResultView.getSearchResultViewColumns();
-        final SearchResultViewItem[] searchResultViewItems = searchResultView.getSearchResultViewItems();
+        final List<SearchResultViewColumn> searchResultViewColumns = searchResultView.getSearchResultViewColumns();
+        final List<SearchResultViewItem> searchResultViewItems = searchResultView.getSearchResultViewItems();
 
-        assertEquals("Incorrect view columns count", 3, searchResultViewColumns.length);
+        assertEquals("Incorrect view columns count", 3, searchResultViewColumns.size());
 
-        assertEquals("PersonFirstName", searchResultViewColumns[0].getCaseFieldId());
-        assertEquals("First Name", searchResultViewColumns[0].getLabel());
-        assertEquals(1, searchResultViewColumns[0].getOrder().intValue());
+        assertEquals("PersonFirstName", searchResultViewColumns.get(0).getCaseFieldId());
+        assertEquals("First Name", searchResultViewColumns.get(0).getLabel());
+        assertEquals(1, searchResultViewColumns.get(0).getOrder().intValue());
 
-        assertEquals("PersonLastName", searchResultViewColumns[1].getCaseFieldId());
-        assertEquals("Last Name", searchResultViewColumns[1].getLabel());
-        assertEquals(1, searchResultViewColumns[1].getOrder().intValue());
+        assertEquals("PersonLastName", searchResultViewColumns.get(1).getCaseFieldId());
+        assertEquals("Last Name", searchResultViewColumns.get(1).getLabel());
+        assertEquals(1, searchResultViewColumns.get(1).getOrder().intValue());
 
-        assertEquals("PersonAddress", searchResultViewColumns[2].getCaseFieldId());
-        assertEquals("Address", searchResultViewColumns[2].getLabel());
-        assertEquals(1, searchResultViewColumns[2].getOrder().intValue());
+        assertEquals("PersonAddress", searchResultViewColumns.get(2).getCaseFieldId());
+        assertEquals("Address", searchResultViewColumns.get(2).getLabel());
+        assertEquals(1, searchResultViewColumns.get(2).getOrder().intValue());
 
-        assertEquals("Incorrect view items count", 0, searchResultViewItems.length);
+        assertEquals("Incorrect view items count", 0, searchResultViewItems.size());
 
     }
 
@@ -376,30 +400,32 @@ public class QueryEndpointIT extends WireMockBaseTest {
 
         final SearchResultView searchResultView = mapper.readValue(result.getResponse().getContentAsString(),
             SearchResultView.class);
-        final SearchResultViewColumn[] searchResultViewColumns = searchResultView.getSearchResultViewColumns();
-        final SearchResultViewItem[] searchResultViewItems = searchResultView.getSearchResultViewItems();
+        final List<SearchResultViewColumn> searchResultViewColumns = searchResultView.getSearchResultViewColumns();
+        final List<SearchResultViewItem> searchResultViewItems = searchResultView.getSearchResultViewItems();
 
-        assertEquals("Incorrect view columns count", 3, searchResultViewColumns.length);
+        assertEquals("Incorrect view columns count", 3, searchResultViewColumns.size());
 
-        assertEquals("PersonFirstName", searchResultViewColumns[0].getCaseFieldId());
-        assertEquals("First Name", searchResultViewColumns[0].getLabel());
-        assertEquals(1, searchResultViewColumns[0].getOrder().intValue());
+        assertEquals("PersonFirstName", searchResultViewColumns.get(0).getCaseFieldId());
+        assertEquals("First Name", searchResultViewColumns.get(0).getLabel());
+        assertEquals(1, searchResultViewColumns.get(0).getOrder().intValue());
 
-        assertEquals("PersonLastName", searchResultViewColumns[1].getCaseFieldId());
-        assertEquals("Last Name", searchResultViewColumns[1].getLabel());
-        assertEquals(1, searchResultViewColumns[1].getOrder().intValue());
+        assertEquals("PersonLastName", searchResultViewColumns.get(1).getCaseFieldId());
+        assertEquals("Last Name", searchResultViewColumns.get(1).getLabel());
+        assertEquals(1, searchResultViewColumns.get(1).getOrder().intValue());
 
-        assertEquals("PersonAddress", searchResultViewColumns[2].getCaseFieldId());
-        assertEquals("Address", searchResultViewColumns[2].getLabel());
-        assertEquals(1, searchResultViewColumns[2].getOrder().intValue());
+        assertEquals("PersonAddress", searchResultViewColumns.get(2).getCaseFieldId());
+        assertEquals("Address", searchResultViewColumns.get(2).getLabel());
+        assertEquals(1, searchResultViewColumns.get(2).getOrder().intValue());
 
-        assertEquals("Incorrect view items count", 2, searchResultViewItems.length);
+        assertEquals("Incorrect view items count", 2, searchResultViewItems.size());
 
-        assertNotNull(searchResultViewItems[0].getCaseId());
-        assertNotNull(searchResultViewItems[1].getCaseId());
-        assertNotEquals(searchResultViewItems[1].getCaseId(), searchResultViewItems[0].getCaseId());
-        assertEquals("England", searchResultViewItems[0].getCaseFields().get("PersonAddress").get("Country").asText());
-        assertEquals("England", searchResultViewItems[1].getCaseFields().get("PersonAddress").get("Country").asText());
+        assertNotNull(searchResultViewItems.get(0).getCaseId());
+        assertNotNull(searchResultViewItems.get(1).getCaseId());
+        assertNotEquals(searchResultViewItems.get(1).getCaseId(), searchResultViewItems.get(0).getCaseId());
+        assertEquals("England",
+                     ((Map) searchResultViewItems.get(0).getCaseFields().get("PersonAddress")).get("Country"));
+        assertEquals("England",
+                     ((Map) searchResultViewItems.get(1).getCaseFields().get("PersonAddress")).get("Country"));
     }
 
     @Test
@@ -420,29 +446,29 @@ public class QueryEndpointIT extends WireMockBaseTest {
 
         final SearchResultView searchResultView = mapper.readValue(result.getResponse().getContentAsString(),
             SearchResultView.class);
-        final SearchResultViewColumn[] searchResultViewColumns = searchResultView.getSearchResultViewColumns();
-        final SearchResultViewItem[] searchResultViewItems = searchResultView.getSearchResultViewItems();
+        final List<SearchResultViewColumn> searchResultViewColumns = searchResultView.getSearchResultViewColumns();
+        final List<SearchResultViewItem> searchResultViewItems = searchResultView.getSearchResultViewItems();
 
-        assertEquals("Incorrect view columns count", 3, searchResultViewColumns.length);
+        assertEquals("Incorrect view columns count", 3, searchResultViewColumns.size());
 
-        assertEquals("PersonFirstName", searchResultViewColumns[0].getCaseFieldId());
-        assertEquals("First Name", searchResultViewColumns[0].getLabel());
-        assertEquals(1, searchResultViewColumns[0].getOrder().intValue());
+        assertEquals("PersonFirstName", searchResultViewColumns.get(0).getCaseFieldId());
+        assertEquals("First Name", searchResultViewColumns.get(0).getLabel());
+        assertEquals(1, searchResultViewColumns.get(0).getOrder().intValue());
 
-        assertEquals("PersonLastName", searchResultViewColumns[1].getCaseFieldId());
-        assertEquals("Last Name", searchResultViewColumns[1].getLabel());
-        assertEquals(1, searchResultViewColumns[1].getOrder().intValue());
+        assertEquals("PersonLastName", searchResultViewColumns.get(1).getCaseFieldId());
+        assertEquals("Last Name", searchResultViewColumns.get(1).getLabel());
+        assertEquals(1, searchResultViewColumns.get(1).getOrder().intValue());
 
-        assertEquals("PersonAddress", searchResultViewColumns[2].getCaseFieldId());
-        assertEquals("Address", searchResultViewColumns[2].getLabel());
-        assertEquals(1, searchResultViewColumns[2].getOrder().intValue());
+        assertEquals("PersonAddress", searchResultViewColumns.get(2).getCaseFieldId());
+        assertEquals("Address", searchResultViewColumns.get(2).getLabel());
+        assertEquals(1, searchResultViewColumns.get(2).getOrder().intValue());
 
-        assertEquals("Incorrect view items count", 2, searchResultViewItems.length);
+        assertEquals("Incorrect view items count", 2, searchResultViewItems.size());
 
-        assertNotNull(searchResultViewItems[0].getCaseId());
-        assertNotNull(searchResultViewItems[1].getCaseId());
+        assertNotNull(searchResultViewItems.get(0).getCaseId());
+        assertNotNull(searchResultViewItems.get(1).getCaseId());
 
-        assertNotEquals(searchResultViewItems[1].getCaseId(), searchResultViewItems[0].getCaseId());
+        assertNotEquals(searchResultViewItems.get(1).getCaseId(), searchResultViewItems.get(0).getCaseId());
     }
 
     @Test
@@ -463,42 +489,52 @@ public class QueryEndpointIT extends WireMockBaseTest {
 
         final SearchResultView searchResultView = mapper.readValue(result.getResponse().getContentAsString(),
             SearchResultView.class);
-        final SearchResultViewColumn[] searchResultViewColumns = searchResultView.getSearchResultViewColumns();
-        final SearchResultViewItem[] searchResultViewItems = searchResultView.getSearchResultViewItems();
+        final List<SearchResultViewColumn> searchResultViewColumns = searchResultView.getSearchResultViewColumns();
+        final List<SearchResultViewItem> searchResultViewItems = searchResultView.getSearchResultViewItems();
 
-        assertEquals("Incorrect view columns count", 3, searchResultViewColumns.length);
+        assertEquals("Incorrect view columns count", 3, searchResultViewColumns.size());
 
-        assertEquals("PersonFirstName", searchResultViewColumns[0].getCaseFieldId());
-        assertEquals("First Name", searchResultViewColumns[0].getLabel());
-        assertEquals(1, searchResultViewColumns[0].getOrder().intValue());
+        assertEquals("PersonFirstName", searchResultViewColumns.get(0).getCaseFieldId());
+        assertEquals("First Name", searchResultViewColumns.get(0).getLabel());
+        assertEquals(1, searchResultViewColumns.get(0).getOrder().intValue());
 
-        assertEquals("PersonLastName", searchResultViewColumns[1].getCaseFieldId());
-        assertEquals("Last Name", searchResultViewColumns[1].getLabel());
-        assertEquals(1, searchResultViewColumns[1].getOrder().intValue());
+        assertEquals("PersonLastName", searchResultViewColumns.get(1).getCaseFieldId());
+        assertEquals("Last Name", searchResultViewColumns.get(1).getLabel());
+        assertEquals(1, searchResultViewColumns.get(1).getOrder().intValue());
 
-        assertEquals("PersonAddress", searchResultViewColumns[2].getCaseFieldId());
-        assertEquals("Address", searchResultViewColumns[2].getLabel());
-        assertEquals(1, searchResultViewColumns[2].getOrder().intValue());
+        assertEquals("PersonAddress", searchResultViewColumns.get(2).getCaseFieldId());
+        assertEquals("Address", searchResultViewColumns.get(2).getLabel());
+        assertEquals(1, searchResultViewColumns.get(2).getOrder().intValue());
 
-        assertEquals("Incorrect view items count", 2, searchResultViewItems.length);
+        assertEquals("Incorrect view items count", 2, searchResultViewItems.size());
 
-        assertNotNull(searchResultViewItems[0].getCaseId());
-        assertEquals("Janet", searchResultViewItems[0].getCaseFields().get("PersonFirstName").asText());
-        assertEquals("Parker", searchResultViewItems[0].getCaseFields().get("PersonLastName").asText());
-        assertEquals("123", searchResultViewItems[0].getCaseFields().get("PersonAddress").get("AddressLine1").asText());
-        assertEquals("Fake Street", searchResultViewItems[0].getCaseFields().get("PersonAddress").get("AddressLine2").asText());
-        assertEquals("Hexton", searchResultViewItems[0].getCaseFields().get("PersonAddress").get("AddressLine3").asText());
-        assertEquals("England", searchResultViewItems[0].getCaseFields().get("PersonAddress").get("Country").asText());
-        assertEquals("HX08 UTG", searchResultViewItems[0].getCaseFields().get("PersonAddress").get("Postcode").asText());
+        assertNotNull(searchResultViewItems.get(0).getCaseId());
+        assertEquals("Janet", searchResultViewItems.get(0).getCaseFields().get("PersonFirstName"));
+        assertEquals("Parker", searchResultViewItems.get(0).getCaseFields().get("PersonLastName"));
+        assertEquals("123", ((Map) searchResultViewItems.get(0).getCaseFields().get("PersonAddress"))
+            .get("AddressLine1"));
+        assertEquals("Fake Street", ((Map) searchResultViewItems.get(0).getCaseFields().get("PersonAddress"))
+            .get("AddressLine2"));
+        assertEquals("Hexton", ((Map) searchResultViewItems.get(0).getCaseFields().get("PersonAddress"))
+            .get("AddressLine3"));
+        assertEquals("England", ((Map) searchResultViewItems.get(0).getCaseFields().get("PersonAddress"))
+            .get("Country"));
+        assertEquals("HX08 UTG", ((Map) searchResultViewItems.get(0).getCaseFields().get("PersonAddress"))
+            .get("Postcode"));
 
-        assertNotNull(searchResultViewItems[1].getCaseId());
-        assertEquals("George", searchResultViewItems[1].getCaseFields().get("PersonFirstName").asText());
-        assertEquals("Roof", searchResultViewItems[1].getCaseFields().get("PersonLastName").asText());
-        assertEquals("Flat 9", searchResultViewItems[1].getCaseFields().get("PersonAddress").get("AddressLine1").asText());
-        assertEquals("2 Hubble Avenue", searchResultViewItems[1].getCaseFields().get("PersonAddress").get("AddressLine2").asText());
-        assertEquals("ButtonVillie", searchResultViewItems[1].getCaseFields().get("PersonAddress").get("AddressLine3").asText());
-        assertEquals("Wales", searchResultViewItems[1].getCaseFields().get("PersonAddress").get("Country").asText());
-        assertEquals("W11 5DF", searchResultViewItems[1].getCaseFields().get("PersonAddress").get("Postcode").asText());
+        assertNotNull(searchResultViewItems.get(1).getCaseId());
+        assertEquals("George", searchResultViewItems.get(1).getCaseFields().get("PersonFirstName"));
+        assertEquals("Roof", searchResultViewItems.get(1).getCaseFields().get("PersonLastName"));
+        assertEquals("Flat 9", ((Map) searchResultViewItems.get(1).getCaseFields().get("PersonAddress"))
+            .get("AddressLine1"));
+        assertEquals("2 Hubble Avenue", ((Map) searchResultViewItems.get(1).getCaseFields().get("PersonAddress"))
+            .get("AddressLine2"));
+        assertEquals("ButtonVillie", ((Map) searchResultViewItems.get(1).getCaseFields().get("PersonAddress"))
+            .get("AddressLine3"));
+        assertEquals("Wales", ((Map) searchResultViewItems.get(1).getCaseFields().get("PersonAddress"))
+            .get("Country"));
+        assertEquals("W11 5DF", ((Map) searchResultViewItems.get(1).getCaseFields().get("PersonAddress"))
+            .get("Postcode"));
     }
 
     @Test
@@ -518,42 +554,52 @@ public class QueryEndpointIT extends WireMockBaseTest {
 
         final SearchResultView searchResultView = mapper.readValue(result.getResponse().getContentAsString(),
             SearchResultView.class);
-        final SearchResultViewColumn[] searchResultViewColumns = searchResultView.getSearchResultViewColumns();
-        final SearchResultViewItem[] searchResultViewItems = searchResultView.getSearchResultViewItems();
+        final List<SearchResultViewColumn> searchResultViewColumns = searchResultView.getSearchResultViewColumns();
+        final List<SearchResultViewItem> searchResultViewItems = searchResultView.getSearchResultViewItems();
 
-        assertEquals("Incorrect view columns count", 3, searchResultViewColumns.length);
+        assertEquals("Incorrect view columns count", 3, searchResultViewColumns.size());
 
-        assertEquals("PersonFirstName", searchResultViewColumns[0].getCaseFieldId());
-        assertEquals("First Name", searchResultViewColumns[0].getLabel());
-        assertEquals(1, searchResultViewColumns[0].getOrder().intValue());
+        assertEquals("PersonFirstName", searchResultViewColumns.get(0).getCaseFieldId());
+        assertEquals("First Name", searchResultViewColumns.get(0).getLabel());
+        assertEquals(1, searchResultViewColumns.get(0).getOrder().intValue());
 
-        assertEquals("PersonLastName", searchResultViewColumns[1].getCaseFieldId());
-        assertEquals("Last Name", searchResultViewColumns[1].getLabel());
-        assertEquals(1, searchResultViewColumns[1].getOrder().intValue());
+        assertEquals("PersonLastName", searchResultViewColumns.get(1).getCaseFieldId());
+        assertEquals("Last Name", searchResultViewColumns.get(1).getLabel());
+        assertEquals(1, searchResultViewColumns.get(1).getOrder().intValue());
 
-        assertEquals("PersonAddress", searchResultViewColumns[2].getCaseFieldId());
-        assertEquals("Address", searchResultViewColumns[2].getLabel());
-        assertEquals(1, searchResultViewColumns[2].getOrder().intValue());
+        assertEquals("PersonAddress", searchResultViewColumns.get(2).getCaseFieldId());
+        assertEquals("Address", searchResultViewColumns.get(2).getLabel());
+        assertEquals(1, searchResultViewColumns.get(2).getOrder().intValue());
 
-        assertEquals("Incorrect view items count", 2, searchResultViewItems.length);
+        assertEquals("Incorrect view items count", 2, searchResultViewItems.size());
 
-        assertNotNull(searchResultViewItems[0].getCaseId());
-        assertEquals("Janet", searchResultViewItems[0].getCaseFields().get("PersonFirstName").asText());
-        assertEquals("Parker", searchResultViewItems[0].getCaseFields().get("PersonLastName").asText());
-        assertEquals("123", searchResultViewItems[0].getCaseFields().get("PersonAddress").get("AddressLine1").asText());
-        assertEquals("Fake Street", searchResultViewItems[0].getCaseFields().get("PersonAddress").get("AddressLine2").asText());
-        assertEquals("Hexton", searchResultViewItems[0].getCaseFields().get("PersonAddress").get("AddressLine3").asText());
-        assertEquals("England", searchResultViewItems[0].getCaseFields().get("PersonAddress").get("Country").asText());
-        assertEquals("HX08 UTG", searchResultViewItems[0].getCaseFields().get("PersonAddress").get("Postcode").asText());
+        assertNotNull(searchResultViewItems.get(0).getCaseId());
+        assertEquals("Janet", searchResultViewItems.get(0).getCaseFields().get("PersonFirstName"));
+        assertEquals("Parker", searchResultViewItems.get(0).getCaseFields().get("PersonLastName"));
+        assertEquals("123", ((Map) searchResultViewItems.get(0).getCaseFields().get("PersonAddress"))
+            .get("AddressLine1"));
+        assertEquals("Fake Street", ((Map) searchResultViewItems.get(0).getCaseFields().get("PersonAddress"))
+            .get("AddressLine2"));
+        assertEquals("Hexton", ((Map) searchResultViewItems.get(0).getCaseFields().get("PersonAddress"))
+            .get("AddressLine3"));
+        assertEquals("England", ((Map) searchResultViewItems.get(0).getCaseFields().get("PersonAddress"))
+            .get("Country"));
+        assertEquals("HX08 UTG", ((Map) searchResultViewItems.get(0).getCaseFields().get("PersonAddress"))
+            .get("Postcode"));
 
-        assertNotNull(searchResultViewItems[1].getCaseId());
-        assertEquals("George", searchResultViewItems[1].getCaseFields().get("PersonFirstName").asText());
-        assertEquals("Roof", searchResultViewItems[1].getCaseFields().get("PersonLastName").asText());
-        assertEquals("Flat 9", searchResultViewItems[1].getCaseFields().get("PersonAddress").get("AddressLine1").asText());
-        assertEquals("2 Hubble Avenue", searchResultViewItems[1].getCaseFields().get("PersonAddress").get("AddressLine2").asText());
-        assertEquals("ButtonVillie", searchResultViewItems[1].getCaseFields().get("PersonAddress").get("AddressLine3").asText());
-        assertEquals("Wales", searchResultViewItems[1].getCaseFields().get("PersonAddress").get("Country").asText());
-        assertEquals("W11 5DF", searchResultViewItems[1].getCaseFields().get("PersonAddress").get("Postcode").asText());
+        assertNotNull(searchResultViewItems.get(1).getCaseId());
+        assertEquals("George", searchResultViewItems.get(1).getCaseFields().get("PersonFirstName"));
+        assertEquals("Roof", searchResultViewItems.get(1).getCaseFields().get("PersonLastName"));
+        assertEquals("Flat 9", ((Map) searchResultViewItems.get(1).getCaseFields().get("PersonAddress"))
+            .get("AddressLine1"));
+        assertEquals("2 Hubble Avenue", ((Map) searchResultViewItems.get(1).getCaseFields().get("PersonAddress"))
+            .get("AddressLine2"));
+        assertEquals("ButtonVillie", ((Map) searchResultViewItems.get(1).getCaseFields().get("PersonAddress"))
+            .get("AddressLine3"));
+        assertEquals("Wales", ((Map) searchResultViewItems.get(1).getCaseFields().get("PersonAddress"))
+            .get("Country"));
+        assertEquals("W11 5DF", ((Map) searchResultViewItems.get(1).getCaseFields().get("PersonAddress"))
+            .get("Postcode"));
     }
 
     @Test
@@ -648,7 +694,7 @@ public class QueryEndpointIT extends WireMockBaseTest {
         assertEquals("Unexpected Field order", 1, firstNameField.getOrder().intValue());
         assertEquals("Unexpected Field show condition", "PersonLastName=\"Jones\"", firstNameField.getShowCondition());
         assertEquals("Unexpected Field field type", "Text", firstNameField.getFieldType().getType());
-        assertEquals("Unexpected Field value", "Janet", firstNameField.getValue().asText());
+        assertEquals("Unexpected Field value", "Janet", firstNameField.getValue());
 
         final CaseViewField lastNameField = nameFields[1];
         assertNotNull("Field is null", lastNameField);
@@ -657,7 +703,7 @@ public class QueryEndpointIT extends WireMockBaseTest {
         assertEquals("Unexpected Field order", 2, lastNameField.getOrder().intValue());
         assertEquals("Unexpected Field show condition", "PersonFirstName=\"Tom\"", lastNameField.getShowCondition());
         assertEquals("Unexpected Field field type", "Text", lastNameField.getFieldType().getType());
-        assertEquals("Unexpected Field value", "Parker", lastNameField.getValue().asText());
+        assertEquals("Unexpected Field value", "Parker", lastNameField.getValue());
 
         final CaseViewTab addressTab = caseViewTabs[1];
         assertNotNull("First tab is null", addressTab);
@@ -678,13 +724,13 @@ public class QueryEndpointIT extends WireMockBaseTest {
         assertEquals("Unexpected Field show condition", "PersonLastName=\"Smart\"", addressField.getShowCondition());
         assertEquals("Unexpected Field field type", "Address", addressField.getFieldType().getType());
 
-        final JsonNode addressNode = addressField.getValue();
+        final Map addressNode = (Map) addressField.getValue();
         assertNotNull("Null address value", addressNode);
-        assertEquals("Unexpected address value", "123", addressNode.get("AddressLine1").asText());
-        assertEquals("Unexpected address value", "Fake Street", addressNode.get("AddressLine2").asText());
-        assertEquals("Unexpected address value", "Hexton", addressNode.get("AddressLine3").asText());
-        assertEquals("Unexpected address value", "England", addressNode.get("Country").asText());
-        assertEquals("Unexpected address value", "HX08 UTG", addressNode.get("Postcode").asText());
+        assertEquals("Unexpected address value", "123", addressNode.get("AddressLine1"));
+        assertEquals("Unexpected address value", "Fake Street", addressNode.get("AddressLine2"));
+        assertEquals("Unexpected address value", "Hexton", addressNode.get("AddressLine3"));
+        assertEquals("Unexpected address value", "England", addressNode.get("Country"));
+        assertEquals("Unexpected address value", "HX08 UTG", addressNode.get("Postcode"));
 
         final CaseViewTab documentTab = caseViewTabs[2];
         assertNotNull("First tab is null", documentTab);
@@ -705,16 +751,15 @@ public class QueryEndpointIT extends WireMockBaseTest {
         assertEquals("Unexpected Field order", 1, documentField.getOrder().intValue());
         assertEquals("Unexpected Field field type", "Document", documentField.getFieldType().getType());
 
-        final JsonNode documentNode = documentField.getValue();
+        final Map documentNode = (Map) documentField.getValue();
         assertNotNull("Null address value", documentNode);
         assertEquals("Unexpected address value",
-            "http://localhost:[port]/documents/05e7cd7e-7041-4d8a-826a-7bb49dfd83d1", documentNode.get
-                ("document_url").asText());
+                     "http://localhost:[port]/documents/05e7cd7e-7041-4d8a-826a-7bb49dfd83d1", documentNode.get("document_url"));
         assertEquals("Unexpected address value",
             "http://localhost:[port]/documents/05e7cd7e-7041-4d8a-826a-7bb49dfd83d1/binary", documentNode
-                .get("document_binary_url").asText());
+                         .get("document_binary_url"));
         assertEquals("Unexpected address value",
-            "Seagulls_Square.jpg", documentNode.get("document_filename").asText());
+                     "Seagulls_Square.jpg", documentNode.get("document_filename"));
 
         final CaseViewEvent[] events = caseView.getEvents();
         assertNotNull("Events are null", events);
@@ -920,31 +965,22 @@ public class QueryEndpointIT extends WireMockBaseTest {
         assertEquals("Unexpected number of complex fields", 7, occupantField.getFieldType().getComplexFields().size());
 
         // Check all field values are mapped correctly
-        assertEquals("Unexpected Field value", "Test Company", companyField.getValue().get("Name").asText());
-        assertEquals("Unexpected Field value", "New Country", companyField.getValue().get("PostalAddress").get
-            ("Country").asText());
-        assertEquals("Unexpected Field value", "PP01 PPQ", companyField.getValue().get("PostalAddress").get
-            ("Postcode").asText());
-        assertEquals("Unexpected Field value", "123", companyField.getValue().get("PostalAddress").get
-            ("AddressLine1").asText());
-        assertEquals("Unexpected Field value", "New Street", companyField.getValue().get("PostalAddress").get
-            ("AddressLine2").asText());
-        assertEquals("Unexpected Field value", "Some Town", companyField.getValue().get("PostalAddress").get
-            ("AddressLine3").asText());
-        assertEquals("Unexpected Field value", "Mr", companyField.getValue().get("PostalAddress").get("Occupant").get
-            ("Title").asText());
-        assertEquals("Unexpected Field value", "The", companyField.getValue().get("PostalAddress").get("Occupant")
-            .get("FirstName").asText());
-        assertEquals("Unexpected Field value", "Test", companyField.getValue().get("PostalAddress").get("Occupant")
-            .get("MiddleName").asText());
-        assertEquals("Unexpected Field value", "Occupant", companyField.getValue().get("PostalAddress").get
-            ("Occupant").get("LastName").asText());
-        assertEquals("Unexpected Field value", "01/01/1990", companyField.getValue().get("PostalAddress").get
-            ("Occupant").get("DateOfBirth").asText());
-        assertEquals("Unexpected Field value", "MARRIAGE", companyField.getValue().get("PostalAddress").get
-            ("Occupant").get("MarritalStatus").asText());
-        assertEquals("Unexpected Field value", "AB112233A", companyField.getValue().get("PostalAddress").get
-            ("Occupant").get("NationalInsuranceNumber").asText());
+        Map companyNode = (Map) companyField.getValue();
+        assertEquals("Unexpected Field value", "Test Company", companyNode.get("Name"));
+        assertEquals("Unexpected Field value", "New Country", ((Map) companyNode.get("PostalAddress")).get("Country"));
+        Map addressNode = (Map) companyNode.get("PostalAddress");
+        assertEquals("Unexpected Field value", "PP01 PPQ", addressNode.get("Postcode"));
+        assertEquals("Unexpected Field value", "123", addressNode.get("AddressLine1"));
+        assertEquals("Unexpected Field value", "New Street", addressNode.get("AddressLine2"));
+        assertEquals("Unexpected Field value", "Some Town", addressNode.get("AddressLine3"));
+        Map occupantNode = ((Map) addressNode.get("Occupant"));
+        assertEquals("Unexpected Field value", "Mr", occupantNode.get("Title"));
+        assertEquals("Unexpected Field value", "The", occupantNode.get("FirstName"));
+        assertEquals("Unexpected Field value", "Test", occupantNode.get("MiddleName"));
+        assertEquals("Unexpected Field value", "Occupant", occupantNode.get("LastName"));
+        assertEquals("Unexpected Field value", "01/01/1990", occupantNode.get("DateOfBirth"));
+        assertEquals("Unexpected Field value", "MARRIAGE", occupantNode.get("MarritalStatus"));
+        assertEquals("Unexpected Field value", "AB112233A", occupantNode.get("NationalInsuranceNumber"));
 
         final CaseViewTab otherInfoTab = caseViewTabs[1];
         assertNotNull("First tab is null", otherInfoTab);
@@ -962,7 +998,7 @@ public class QueryEndpointIT extends WireMockBaseTest {
         assertEquals("Unexpected Field label", "Other Info", otherInfoField.getLabel());
         assertEquals("Unexpected Field order", 1, otherInfoField.getOrder().intValue());
         assertEquals("Unexpected Field field type", "Text", otherInfoField.getFieldType().getType());
-        assertEquals("Unexpected Field value", "Extra Info", otherInfoField.getValue().asText());
+        assertEquals("Unexpected Field value", "Extra Info", otherInfoField.getValue());
     }
 
     @Test
@@ -1086,7 +1122,7 @@ public class QueryEndpointIT extends WireMockBaseTest {
         assertEquals("Unexpected Case Fields", 2, eventTrigger.getCaseFields().size());
 
         final CaseViewField field1 = eventTrigger.getCaseFields().get(0);
-        assertThat(field1.getValue(), equalTo(JSON_NODE_FACTORY.textNode("George")));
+        assertThat(field1.getValue(), equalTo("George"));
         assertThat(field1.getLabel(), equalTo("First name"));
         assertThat(field1.getOrder(), is(nullValue()));
         assertThat(field1.getFieldType().getId(), equalTo("Text"));
@@ -1096,7 +1132,7 @@ public class QueryEndpointIT extends WireMockBaseTest {
         assertThat(field1.getShowSummaryContentOption(), equalTo(2));
 
         final CaseViewField field2 = eventTrigger.getCaseFields().get(1);
-        assertThat(field2.getValue(), equalTo(JSON_NODE_FACTORY.textNode("Roof")));
+        assertThat(field2.getValue(), equalTo("Roof"));
         assertThat(field2.getLabel(), equalTo("Last name"));
         assertThat(field2.getOrder(), is(nullValue()));
         assertThat(field2.getFieldType().getId(), equalTo("Text"));
@@ -1278,7 +1314,7 @@ public class QueryEndpointIT extends WireMockBaseTest {
         assertEquals("Unexpected Field order", 1, firstNameField.getOrder().intValue());
         assertEquals("Unexpected Field show condition", "PersonLastName=\"Jones\"", firstNameField.getShowCondition());
         assertEquals("Unexpected Field field type", "Text", firstNameField.getFieldType().getType());
-        assertEquals("Unexpected Field value", "Janet", firstNameField.getValue().asText());
+        assertEquals("Unexpected Field value", "Janet", firstNameField.getValue());
 
         final CaseViewField lastNameField = nameFields[1];
         assertNotNull("Field is null", lastNameField);
@@ -1287,7 +1323,7 @@ public class QueryEndpointIT extends WireMockBaseTest {
         assertEquals("Unexpected Field order", 2, lastNameField.getOrder().intValue());
         assertEquals("Unexpected Field show condition", "PersonFirstName=\"Tom\"", lastNameField.getShowCondition());
         assertEquals("Unexpected Field field type", "Text", lastNameField.getFieldType().getType());
-        assertEquals("Unexpected Field value", "Parker", lastNameField.getValue().asText());
+        assertEquals("Unexpected Field value", "Parker", lastNameField.getValue());
 
         final CaseViewTab addressTab = caseViewTabs[1];
         assertNotNull("First tab is null", addressTab);
@@ -1308,13 +1344,13 @@ public class QueryEndpointIT extends WireMockBaseTest {
         assertEquals("Unexpected Field show condition", "PersonLastName=\"Smart\"", addressField.getShowCondition());
         assertEquals("Unexpected Field field type", "Address", addressField.getFieldType().getType());
 
-        final JsonNode addressNode = addressField.getValue();
+        final Map addressNode = (Map) addressField.getValue();
         assertNotNull("Null address value", addressNode);
-        assertEquals("Unexpected address value", "123", addressNode.get("AddressLine1").asText());
-        assertEquals("Unexpected address value", "Fake Street", addressNode.get("AddressLine2").asText());
-        assertEquals("Unexpected address value", "Hexton", addressNode.get("AddressLine3").asText());
-        assertEquals("Unexpected address value", "England", addressNode.get("Country").asText());
-        assertEquals("Unexpected address value", "HX08 UTG", addressNode.get("Postcode").asText());
+        assertEquals("Unexpected address value", "123", addressNode.get("AddressLine1"));
+        assertEquals("Unexpected address value", "Fake Street", addressNode.get("AddressLine2"));
+        assertEquals("Unexpected address value", "Hexton", addressNode.get("AddressLine3"));
+        assertEquals("Unexpected address value", "England", addressNode.get("Country"));
+        assertEquals("Unexpected address value", "HX08 UTG", addressNode.get("Postcode"));
 
         final CaseViewTab documentTab = caseViewTabs[2];
         assertNotNull("First tab is null", documentTab);
@@ -1335,17 +1371,17 @@ public class QueryEndpointIT extends WireMockBaseTest {
         assertEquals("Unexpected Field order", 1, documentField.getOrder().intValue());
         assertEquals("Unexpected Field field type", "Document", documentField.getFieldType().getType());
 
-        final JsonNode documentNode = documentField.getValue();
+        final Map documentNode = (Map) documentField.getValue();
         final int dmApiPort = 10000;
         assertNotNull("Null address value", documentNode);
         assertEquals("Unexpected address value",
             "http://localhost:" + dmApiPort + "/documents/05e7cd7e-7041-4d8a-826a-7bb49dfd83d1", documentNode.get
-                ("document_url").asText());
+                ("document_url"));
         assertEquals("Unexpected address value",
             "http://localhost:" + dmApiPort + "/documents/05e7cd7e-7041-4d8a-826a-7bb49dfd83d1/binary", documentNode
-                .get("document_binary_url").asText());
+                         .get("document_binary_url"));
         assertEquals("Unexpected address value",
-            "Seagulls_Square.jpg", documentNode.get("document_filename").asText());
+                     "Seagulls_Square.jpg", documentNode.get("document_filename"));
 
         final CaseViewEvent event = caseHistoryView.getEvent();
         assertNotNull("Null event value", event);

--- a/src/test/java/uk/gov/hmcts/ccd/endpoint/ui/QueryEndpointIT.java
+++ b/src/test/java/uk/gov/hmcts/ccd/endpoint/ui/QueryEndpointIT.java
@@ -1375,11 +1375,9 @@ public class QueryEndpointIT extends WireMockBaseTest {
         final int dmApiPort = 10000;
         assertNotNull("Null address value", documentNode);
         assertEquals("Unexpected address value",
-            "http://localhost:" + dmApiPort + "/documents/05e7cd7e-7041-4d8a-826a-7bb49dfd83d1", documentNode.get
-                ("document_url"));
+                     "http://localhost:" + dmApiPort + "/documents/05e7cd7e-7041-4d8a-826a-7bb49dfd83d1", documentNode.get("document_url"));
         assertEquals("Unexpected address value",
-            "http://localhost:" + dmApiPort + "/documents/05e7cd7e-7041-4d8a-826a-7bb49dfd83d1/binary", documentNode
-                         .get("document_binary_url"));
+                     "http://localhost:" + dmApiPort + "/documents/05e7cd7e-7041-4d8a-826a-7bb49dfd83d1/binary", documentNode.get("document_binary_url"));
         assertEquals("Unexpected address value",
                      "Seagulls_Square.jpg", documentNode.get("document_filename"));
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/projects/RDM/issues/RDM-626


### Change description ###
Code changes to support metadata fields in search results. Also did a little refactoring from array to list for the search results and made case fields data type more generic rather than a map of String and JsonNode, it is now a map of String and Object. Please review


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
