### PR TITLE
CVE: suppress CVE-2016-7048

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ plugins {
     id 'checkstyle'
     id 'com.github.kt3k.coveralls' version '2.8.2'
     id 'se.patrikerdes.use-latest-versions' version '0.2.3'
-    id 'org.owasp.dependencycheck' version '3.2.1'
+    id 'org.owasp.dependencycheck' version '3.3.2'
     id 'com.github.spotbugs' version '1.6.2'
     id 'net.ltgt.apt' version '0.8'
 }

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -2,10 +2,6 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
 
     <suppress>
-        <gav regex="true">^org\.postgresql:postgresql:.*$</gav>
-        <cpe>cpe:/a:postgresql:postgresql</cpe>
-    </suppress>
-    <suppress>
         <notes>See https://github.com/jeremylong/DependencyCheck/issues/1146 for Embedded Tomcat</notes>
         <cve>CVE-2017-12617</cve>
     </suppress>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -54,4 +54,8 @@
         <gav regex="true">^com\.github\.alexarchambault:case-app(-util|-annotations|)_2\.11:.*$</gav>
         <cpe>cpe:/a:app_project:app</cpe>
     </suppress>
+    <suppress>
+        <notes>CVE-2016-7048: only for Postgres lt 9.6 and we use 9.6 on Azure.  Also only impacts the installer.</notes>
+        <cve>CVE-2016-7048</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
- We don't manage the PG installation
- The version on Azure that we use is not impacted






https://tools.hmcts.net/jira/browse/RDM-3175





**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```