### PR TITLE
[PREVIEW] implemented ElasticSearch health check. Added publishing of ES password

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -51,6 +51,12 @@ data "azurerm_key_vault_secret" "ccd_elastic_search_url" {
   vault_uri = "${data.azurerm_key_vault.ccd_shared_key_vault.vault_uri}"
 }
 
+data "azurerm_key_vault_secret" "ccd_elastic_search_password" {
+  count = "${var.elastic_search_enabled == "false" ? 0 : 1}"
+  name = "ccd-ELASTIC-SEARCH-PASSWORD"
+  vault_uri = "${data.azurerm_key_vault.ccd_shared_key_vault.vault_uri}"
+}
+
 resource "random_string" "draft_encryption_key" {
   length  = 16
   special = true
@@ -104,6 +110,7 @@ module "ccd-data-store-api" {
     CCD_DEFAULTPRINTURL                 = "${local.default_print_url}"
 
     ELASTIC_SEARCH_HOSTS                = "${var.elastic_search_enabled == "false" ? "" : "${format("http://%s:9200", join("", data.azurerm_key_vault_secret.ccd_elastic_search_url.*.value))}"}"
+    ELASTIC_SEARCH_PASSWORD             = "${var.elastic_search_enabled == "false" ? "" : "${join("", data.azurerm_key_vault_secret.ccd_elastic_search_password.*.value)}"}"
     ELASTIC_SEARCH_BLACKLIST            = "${var.elastic_search_blacklist}"
     ELASTIC_SEARCH_CASE_INDEX_NAME_FORMAT = "${var.elastic_search_case_index_name_format}"
     ELASTIC_SEARCH_CASE_INDEX_TYPE      = "${var.elastic_search_case_index_type}"

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CaseDetailsEntity.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CaseDetailsEntity.java
@@ -31,6 +31,11 @@ import java.time.LocalDateTime;
         query = "SELECT cd FROM CaseDetailsEntity cd" +
             " WHERE cd.jurisdiction = :" + CaseDetailsEntity.JURISDICTION_ID_PARAM +
             " AND cd.reference = :" + CaseDetailsEntity.CASE_REFERENCE_PARAM
+    ),
+
+    @NamedQuery(
+        name = CaseDetailsEntity.CASES_COUNT_BY_CASE_TYPE,
+        query = "SELECT cd.caseType, COUNT(cd) FROM CaseDetailsEntity cd GROUP BY cd.caseType"
     )
 })
 @Table(name = "case_data")
@@ -40,6 +45,7 @@ public class CaseDetailsEntity {
     static final String FIND_CASE = "CaseDataEntity_FIND_CASE";
     static final String FIND_BY_REFERENCE = "CaseDataEntity_FIND_BY_REFERENCE";
     static final String FIND_BY_REF_AND_JURISDICTION = "CaseDataEntity_FIND_BY_REFERENCE_AND_JURISDICTION";
+    static final String CASES_COUNT_BY_CASE_TYPE = "CaseDataEntity_CASES_COUNT_BY_CASE_TYPE";
 
     static final String JURISDICTION_ID_PARAM = "JURISDICTION_ID_PARAM";
     static final String CASE_TYPE_PARAM = "CASE_TYPE_PARAM";

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/DefaultCaseDetailsRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/DefaultCaseDetailsRepository.java
@@ -173,6 +173,10 @@ public class DefaultCaseDetailsRepository implements CaseDetailsRepository {
         return sr;
     }
 
+    public List<Object[]> getCasesCountByCaseType() {
+        return em.createNamedQuery(CaseDetailsEntity.CASES_COUNT_BY_CASE_TYPE).getResultList();
+    }
+
     // TODO This accepts null values for backward compatibility. Once deprecated methods are removed, parameters should
     // be annotated with @NotNull
     private Optional<CaseDetailsEntity> find(String jurisdiction, Long id, String reference) {

--- a/src/main/java/uk/gov/hmcts/ccd/health/ElasticSearchHealthIndicator.java
+++ b/src/main/java/uk/gov/hmcts/ccd/health/ElasticSearchHealthIndicator.java
@@ -1,0 +1,132 @@
+package uk.gov.hmcts.ccd.health;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.collect.Lists.newArrayList;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
+import com.google.gson.annotations.SerializedName;
+import io.searchbox.client.JestClient;
+import io.searchbox.client.JestResult;
+import io.searchbox.client.config.exception.CouldNotConnectException;
+import io.searchbox.cluster.Health;
+import io.searchbox.core.Cat;
+import io.searchbox.core.CatResult;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.health.AbstractHealthIndicator;
+import org.springframework.boot.actuate.health.Health.Builder;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.ccd.data.casedetails.DefaultCaseDetailsRepository;
+
+@Component
+@Slf4j
+public class ElasticSearchHealthIndicator extends AbstractHealthIndicator {
+
+    protected static final String COULD_NOT_CONNECT = "COULD_NOT_CONNECT";
+    protected static final String PROBLEMS = "PROBLEMS";
+    protected static final String OUT_OF_SYNC = "OUT_OF_SYNC";
+    private JestClient client;
+    private DefaultCaseDetailsRepository caseDetailsRepository;
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    public ElasticSearchHealthIndicator(JestClient client, DefaultCaseDetailsRepository caseDetailsRepository, ObjectMapper objectMapper) {
+        this.client = client;
+        this.caseDetailsRepository = caseDetailsRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    protected void doHealthCheck(Builder builder) throws Exception {
+        try {
+            JestResult healthResult = getClusterHealth();
+            builder.withDetail("clusterHealth", asJsonNode(healthResult));
+
+            JestResult indicesHealthResult = getClusterIndicesHealth();
+            builder.withDetail("clusterIndices", asJsonNode(indicesHealthResult));
+
+            boolean isOutOfSync = buildIndicesStats(builder, indicesHealthResult);
+
+            if (isOutOfSync) {
+                builder.status(OUT_OF_SYNC);
+            } else {
+                switch (extractStatus(healthResult)) {
+                    case "green":
+                    case "yellow":
+                        builder.up();
+                        break;
+                    case "red":
+                    default:
+                        builder.status(PROBLEMS);
+                }
+            }
+        } catch (CouldNotConnectException e) {
+            builder.status(COULD_NOT_CONNECT);
+        } catch (Exception e) {
+            builder.status(PROBLEMS);
+            log.warn("problems checking ES health", e);
+        }
+    }
+
+    private boolean buildIndicesStats(Builder builder, JestResult indicesHealthResult) {
+        List<Index> indices = toIndexList(indicesHealthResult);
+        List<Object[]> casesCountByCaseType = caseDetailsRepository.getCasesCountByCaseType();
+
+        boolean isOutOfSync = false;
+        for (Object[] row : casesCountByCaseType) {
+            String caseType = (String) row[0];
+            String ccdCasesCount = Long.toString((Long) row[1]);
+            Optional<Index> indexOpt = findIndexForCaseType(indices, caseType);
+            String esCasesCount = indexOpt.map(index -> index.getCount()).orElse("-");
+            builder.withDetail(caseType + " cases CCD/ES", ccdCasesCount + "/" + esCasesCount);
+
+            if (!indexOpt.isPresent() || !esCasesCount.equals(ccdCasesCount)) {
+                isOutOfSync = true;
+            }
+        }
+        return isOutOfSync;
+    }
+
+    private String extractStatus(JestResult healthResult) {
+        return healthResult.getJsonObject().get("status").getAsString();
+    }
+
+    private Optional<Index> findIndexForCaseType(List<Index> indices, String caseType) {
+        return indices.stream().filter(i ->
+                        i.index.split("_cases")[0].equals(caseType.toLowerCase())
+                    ).findAny();
+    }
+
+    private List<Index> toIndexList(JestResult indicesHealthResult) {
+        Gson gson = new Gson();
+        return newArrayList(gson.fromJson(indicesHealthResult.getJsonString(), Index[].class));
+    }
+
+    private CatResult getClusterIndicesHealth() throws IOException {
+        return client.execute(new Cat.IndicesBuilder().build());
+    }
+
+    private JsonNode asJsonNode(JestResult jestResult) throws IOException {
+        return objectMapper.readTree(jestResult.getJsonString());
+    }
+
+    private JestResult getClusterHealth() throws java.io.IOException {
+        Health health = new Health.Builder().build();
+        return client.execute(health);
+    }
+
+    private static class Index {
+        private String index;
+        @SerializedName("docs.count")
+        private int count;
+
+        public String getCount() {
+            return Integer.toString(count);
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/ccd/health/ElasticSearchHealthIndicator.java
+++ b/src/main/java/uk/gov/hmcts/ccd/health/ElasticSearchHealthIndicator.java
@@ -42,7 +42,7 @@ public class ElasticSearchHealthIndicator extends AbstractHealthIndicator {
     }
 
     @Override
-    protected void doHealthCheck(Builder builder) throws Exception {
+    protected void doHealthCheck(Builder builder) {
         try {
             JestResult healthResult = getClusterHealth();
             builder.withDetail("clusterHealth", asJsonNode(healthResult));

--- a/src/main/java/uk/gov/hmcts/ccd/health/ElasticSearchHealthIndicator.java
+++ b/src/main/java/uk/gov/hmcts/ccd/health/ElasticSearchHealthIndicator.java
@@ -115,7 +115,7 @@ public class ElasticSearchHealthIndicator extends AbstractHealthIndicator {
         return objectMapper.readTree(jestResult.getJsonString());
     }
 
-    private JestResult getClusterHealth() throws java.io.IOException {
+    private JestResult getClusterHealth() throws IOException {
         Health health = new Health.Builder().build();
         return client.execute(health);
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -124,4 +124,5 @@ search.cases.index.name.type=${ELASTIC_SEARCH_CASE_INDEX_TYPE:case}
 spring.elasticsearch.jest.uris=${ELASTIC_SEARCH_HOSTS:http://localhost:9200}
 spring.elasticsearch.jest.read-timeout=10000
 management.health.elasticsearch.enabled=false
+management.health.status.order=DOWN, OUT_OF_SERVICE, UNKNOWN, UP, OUT_OF_SYNC, PROBLEMS, COULD_NOT_CONNECT
 

--- a/src/test/java/uk/gov/hmcts/ccd/health/ElasticSearchHealthIndicatorTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/health/ElasticSearchHealthIndicatorTest.java
@@ -1,0 +1,194 @@
+package uk.gov.hmcts.ccd.health;
+
+import java.io.IOException;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import io.searchbox.client.JestClient;
+import io.searchbox.client.JestResult;
+import io.searchbox.client.config.exception.CouldNotConnectException;
+import io.searchbox.core.CatResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+import org.springframework.boot.actuate.health.Health.Builder;
+import uk.gov.hmcts.ccd.data.casedetails.DefaultCaseDetailsRepository;
+
+class ElasticSearchHealthIndicatorTest {
+
+    private static final String ES_HEALTH_RESPONSE_GREEN = "{\"status\": \"green\"}";
+    private static final String ES_HEALTH_RESPONSE_RED = "{\"status\": \"red\"}";
+    private static final String ES_HEALTH_RESPONSE_YELLOW = "{\"status\": \"yellow\"}";
+    private static final String ES_INDICES_RESPONSE = "[\n" +
+        "      {\n" +
+        "        \"health\": \"green\",\n" +
+        "        \"index\": \"testcomplexaddressbookcase_cases-000001\",\n" +
+        "        \"docs.count\": \"0\",\n" +
+        "        \"pri.store.size\": \"522b\"\n" +
+        "      },\n" +
+        "      {\n" +
+        "        \"health\": \"green\",\n" +
+        "        \"index\": \"aat_cases-000001\",\n" +
+        "        \"docs.count\": \"1\",\n" +
+        "        \"pri.store.size\": \"6.9kb\"\n" +
+        "      }]";
+
+    @Mock
+    private JestClient client;
+
+    @Mock
+    private DefaultCaseDetailsRepository repository;
+
+    @InjectMocks
+    private ElasticSearchHealthIndicator healthIndicator;
+
+    @Spy
+    private Builder builder = new Builder();
+
+    @Spy
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @Mock
+    private CatResult indicesHealthResult;
+
+    @Mock
+    private JestResult healthResult;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void statusIsCannotConnectWhenCannotConnectException() throws Exception {
+        when(client.execute(any())).thenThrow(new CouldNotConnectException("test", new RuntimeException()));
+
+        healthIndicator.doHealthCheck(builder);
+
+        verify(builder).status(ElasticSearchHealthIndicator.COULD_NOT_CONNECT);
+        verify(repository, never()).getCasesCountByCaseType();
+    }
+
+    @Test
+    public void statusIsProblemsWhenException() throws Exception {
+        when(repository.getCasesCountByCaseType()).thenThrow(new RuntimeException("test"));
+
+        healthIndicator.doHealthCheck(builder);
+
+        verify(builder).status(ElasticSearchHealthIndicator.PROBLEMS);
+    }
+
+    @Test
+    public void testStatusIsOutOfSyncWhenMissingIndex() throws Exception {
+
+        stubESResponse(ES_HEALTH_RESPONSE_GREEN, ES_INDICES_RESPONSE);
+
+        stubDatabase(
+            new Object[]{"AAT", 22},
+            new Object[]{"GrantOfRepresentation", 14}
+        );
+
+        healthIndicator.doHealthCheck(builder);
+
+        JsonNode healthResultNode = mapper.readTree(healthResult.getJsonString());
+        JsonNode indicesResultNode = mapper.readTree(indicesHealthResult.getJsonString());
+
+        verify(builder).status(ElasticSearchHealthIndicator.OUT_OF_SYNC);
+        verify(builder).withDetail("clusterHealth", healthResultNode);
+        verify(builder).withDetail("clusterIndices", indicesResultNode);
+    }
+
+    @Test
+    public void testStatusIsOutOfSyncWhenMissingCases() throws Exception {
+
+        stubESResponse(ES_HEALTH_RESPONSE_GREEN, ES_INDICES_RESPONSE);
+
+        stubDatabase(
+            new Object[]{"AAT", 0},
+            new Object[]{"testcomplexaddressbookcase", 0}
+        );
+
+        healthIndicator.doHealthCheck(builder);
+
+        JsonNode healthResultNode = mapper.readTree(healthResult.getJsonString());
+        JsonNode indicesResultNode = mapper.readTree(indicesHealthResult.getJsonString());
+
+        verify(builder).status(ElasticSearchHealthIndicator.OUT_OF_SYNC);
+        verify(builder).withDetail("clusterHealth", healthResultNode);
+        verify(builder).withDetail("clusterIndices", indicesResultNode);
+    }
+
+    @Test
+    public void testStatusIsUpWhenClusterHealthIsGreenAndInSync() throws Exception {
+
+        stubESResponse(ES_HEALTH_RESPONSE_GREEN, ES_INDICES_RESPONSE);
+
+        stubDatabase(
+            new Object[]{"AAT", 1},
+            new Object[]{"testcomplexaddressbookcase", 0}
+        );
+
+        healthIndicator.doHealthCheck(builder);
+
+        JsonNode healthResultNode = mapper.readTree(healthResult.getJsonString());
+        JsonNode indicesResultNode = mapper.readTree(indicesHealthResult.getJsonString());
+
+        verify(builder).up();
+        verify(builder).withDetail("clusterHealth", healthResultNode);
+        verify(builder).withDetail("clusterIndices", indicesResultNode);
+    }
+
+    @Test
+    public void testStatusProblems() throws Exception {
+
+        stubESResponse(ES_HEALTH_RESPONSE_RED, ES_INDICES_RESPONSE);
+
+        stubDatabase(
+            new Object[]{"AAT", 1},
+            new Object[]{"testcomplexaddressbookcase", 0}
+        );
+
+        healthIndicator.doHealthCheck(builder);
+
+        verify(builder).status(ElasticSearchHealthIndicator.PROBLEMS);
+    }
+
+    @Test
+    public void testStatusIsUpWhenClusterHealthIsYellowAndInSync() throws Exception {
+
+        stubESResponse(ES_HEALTH_RESPONSE_YELLOW, ES_INDICES_RESPONSE);
+
+        stubDatabase(
+            new Object[]{"AAT", 1},
+            new Object[]{"testcomplexaddressbookcase", 0}
+        );
+
+        healthIndicator.doHealthCheck(builder);
+
+        verify(builder).up();
+    }
+
+    private void stubDatabase(Object[] row1, Object[] row2) {
+        when(repository.getCasesCountByCaseType()).thenReturn(newArrayList(row1, row2));
+    }
+
+    private void stubESResponse(String healthResponse, String indicesResponse) throws IOException {
+        JsonParser parser = new JsonParser();
+        JsonObject healthJsonObject = parser.parse(healthResponse).getAsJsonObject();
+        when(healthResult.getJsonObject()).thenReturn(healthJsonObject);
+        when(healthResult.getJsonString()).thenReturn(healthResponse);
+        when(indicesHealthResult.getJsonString()).thenReturn(indicesResponse);
+        when(client.execute(any())).thenReturn(healthResult, indicesHealthResult);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/ccd/health/ElasticSearchHealthIndicatorTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/health/ElasticSearchHealthIndicatorTest.java
@@ -30,19 +30,19 @@ class ElasticSearchHealthIndicatorTest {
     private static final String ES_HEALTH_RESPONSE_GREEN = "{\"status\": \"green\"}";
     private static final String ES_HEALTH_RESPONSE_RED = "{\"status\": \"red\"}";
     private static final String ES_HEALTH_RESPONSE_YELLOW = "{\"status\": \"yellow\"}";
-    private static final String ES_INDICES_RESPONSE = "[\n" +
-        "      {\n" +
-        "        \"health\": \"green\",\n" +
-        "        \"index\": \"testcomplexaddressbookcase_cases-000001\",\n" +
-        "        \"docs.count\": \"0\",\n" +
-        "        \"pri.store.size\": \"522b\"\n" +
-        "      },\n" +
-        "      {\n" +
-        "        \"health\": \"green\",\n" +
-        "        \"index\": \"aat_cases-000001\",\n" +
-        "        \"docs.count\": \"1\",\n" +
-        "        \"pri.store.size\": \"6.9kb\"\n" +
-        "      }]";
+    private static final String ES_INDICES_RESPONSE = "[\n"
+        + "      {\n"
+        + "        \"health\": \"green\",\n"
+        + "        \"index\": \"testcomplexaddressbookcase_cases-000001\",\n"
+        + "        \"docs.count\": \"0\",\n"
+        + "        \"pri.store.size\": \"522b\"\n"
+        + "      },\n"
+        + "      {\n"
+        + "        \"health\": \"green\",\n"
+        + "        \"index\": \"aat_cases-000001\",\n"
+        + "        \"docs.count\": \"1\",\n"
+        + "        \"pri.store.size\": \"6.9kb\"\n"
+        + "      }]";
 
     @Mock
     private JestClient client;
@@ -58,7 +58,6 @@ class ElasticSearchHealthIndicatorTest {
 
     @Spy
     private Builder builder = new Builder();
-
 
     @Mock
     private CatResult indicesHealthResult;

--- a/src/test/java/uk/gov/hmcts/ccd/health/ElasticSearchHealthIndicatorTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/health/ElasticSearchHealthIndicatorTest.java
@@ -50,14 +50,15 @@ class ElasticSearchHealthIndicatorTest {
     @Mock
     private DefaultCaseDetailsRepository repository;
 
+    @Spy
+    private ObjectMapper mapper = new ObjectMapper();
+
     @InjectMocks
     private ElasticSearchHealthIndicator healthIndicator;
 
     @Spy
     private Builder builder = new Builder();
 
-    @Spy
-    private ObjectMapper mapper = new ObjectMapper();
 
     @Mock
     private CatResult indicesHealthResult;

--- a/src/test/java/uk/gov/hmcts/ccd/health/ElasticSearchHealthIndicatorTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/health/ElasticSearchHealthIndicatorTest.java
@@ -81,7 +81,7 @@ class ElasticSearchHealthIndicatorTest {
     }
 
     @Test
-    public void statusIsProblemsWhenException() throws Exception {
+    public void statusIsProblemsWhenException() {
         when(repository.getCasesCountByCaseType()).thenThrow(new RuntimeException("test"));
 
         healthIndicator.doHealthCheck(builder);
@@ -95,8 +95,8 @@ class ElasticSearchHealthIndicatorTest {
         stubESResponse(ES_HEALTH_RESPONSE_GREEN, ES_INDICES_RESPONSE);
 
         stubDatabase(
-            new Object[]{"AAT", 22},
-            new Object[]{"GrantOfRepresentation", 14}
+            new Object[]{"AAT", 22L},
+            new Object[]{"GrantOfRepresentation", 14L}
         );
 
         healthIndicator.doHealthCheck(builder);
@@ -115,8 +115,8 @@ class ElasticSearchHealthIndicatorTest {
         stubESResponse(ES_HEALTH_RESPONSE_GREEN, ES_INDICES_RESPONSE);
 
         stubDatabase(
-            new Object[]{"AAT", 0},
-            new Object[]{"testcomplexaddressbookcase", 0}
+            new Object[]{"AAT", 0L},
+            new Object[]{"testcomplexaddressbookcase", 0L}
         );
 
         healthIndicator.doHealthCheck(builder);
@@ -135,8 +135,8 @@ class ElasticSearchHealthIndicatorTest {
         stubESResponse(ES_HEALTH_RESPONSE_GREEN, ES_INDICES_RESPONSE);
 
         stubDatabase(
-            new Object[]{"AAT", 1},
-            new Object[]{"testcomplexaddressbookcase", 0}
+            new Object[]{"AAT", 1L},
+            new Object[]{"testcomplexaddressbookcase", 0L}
         );
 
         healthIndicator.doHealthCheck(builder);
@@ -155,8 +155,8 @@ class ElasticSearchHealthIndicatorTest {
         stubESResponse(ES_HEALTH_RESPONSE_RED, ES_INDICES_RESPONSE);
 
         stubDatabase(
-            new Object[]{"AAT", 1},
-            new Object[]{"testcomplexaddressbookcase", 0}
+            new Object[]{"AAT", 1L},
+            new Object[]{"testcomplexaddressbookcase", 0L}
         );
 
         healthIndicator.doHealthCheck(builder);
@@ -170,8 +170,8 @@ class ElasticSearchHealthIndicatorTest {
         stubESResponse(ES_HEALTH_RESPONSE_YELLOW, ES_INDICES_RESPONSE);
 
         stubDatabase(
-            new Object[]{"AAT", 1},
-            new Object[]{"testcomplexaddressbookcase", 0}
+            new Object[]{"AAT", 1L},
+            new Object[]{"testcomplexaddressbookcase", 0L}
         );
 
         healthIndicator.doHealthCheck(builder);


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RDM-3008
An example of the generated health check is provided in the ticket

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
