### PR TITLE
disabling ES health check when ELASTIC_SEARCH_ENABLED=false to avoid …

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -109,6 +109,7 @@ module "ccd-data-store-api" {
 
     CCD_DEFAULTPRINTURL                 = "${local.default_print_url}"
 
+    ELASTIC_SEARCH_ENABLED              = "${var.elastic_search_enabled}"
     ELASTIC_SEARCH_HOSTS                = "${var.elastic_search_enabled == "false" ? "" : "${format("http://%s:9200", join("", data.azurerm_key_vault_secret.ccd_elastic_search_url.*.value))}"}"
     ELASTIC_SEARCH_PASSWORD             = "${var.elastic_search_enabled == "false" ? "" : "${join("", data.azurerm_key_vault_secret.ccd_elastic_search_password.*.value)}"}"
     ELASTIC_SEARCH_BLACKLIST            = "${var.elastic_search_blacklist}"

--- a/src/main/java/uk/gov/hmcts/ccd/ElasticSearchConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/ccd/ElasticSearchConfiguration.java
@@ -27,8 +27,8 @@ public class ElasticSearchConfiguration {
         factory.setHttpClientConfig(new HttpClientConfig.Builder(applicationParams.getElasticSearchHosts())
             .multiThreaded(true)
             .maxConnectionIdleTime(15, TimeUnit.SECONDS)
-            .connTimeout(20000)
-            .readTimeout(20000)
+            .connTimeout(4000)
+            .readTimeout(4000)
             .gson(gson).build());
         return factory.getObject();
     }

--- a/src/main/java/uk/gov/hmcts/ccd/health/ElasticSearchHealthIndicator.java
+++ b/src/main/java/uk/gov/hmcts/ccd/health/ElasticSearchHealthIndicator.java
@@ -20,10 +20,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.AbstractHealthIndicator;
 import org.springframework.boot.actuate.health.Health.Builder;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.ccd.data.casedetails.DefaultCaseDetailsRepository;
 
 @Component
+@ConditionalOnProperty(name = "search.elastic.enabled")
 @Slf4j
 public class ElasticSearchHealthIndicator extends AbstractHealthIndicator {
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -117,6 +117,7 @@ ccd.draft.encryptionKey=${CCD_DRAFT_ENCRYPTION_KEY:xxxxxxxxxxxxxxxx}
 ccd.draft.maxTTLDays=${CCD_DRAFT_TTL_DAYS:180}
 
 # Search
+search.elastic.enabled=${ELASTIC_SEARCH_ENABLED:false}
 search.elastic.hosts=${ELASTIC_SEARCH_HOSTS:http://localhost:9200}
 search.blacklist=${ELASTIC_SEARCH_BLACKLIST:query_string}
 search.cases.index.name.format=${ELASTIC_SEARCH_CASE_INDEX_NAME_FORMAT:%s_cases}


### PR DESCRIPTION
At the moment data store Health Check always tries to check the health of ES, even when ES is not enabled on an env. 
This does not prevent data store health check to pass, but it's an unnecessary network call. I've fixed this.
Also reduced ES connection timeout;

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
