### PR TITLE
RDM-3271: Tune Hikari connection pool

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,7 +11,10 @@ spring.datasource.password=${DATA_STORE_DB_PASSWORD:ccd}
 #spring.datasource.tomcat.max-active=30
 spring.datasource.type=com.zaxxer.hikari.HikariDataSource
 spring.jpa.hibernate.ddl-auto=none
-spring.datasource.hikari.maximum-pool-size=${DATA_STORE_DB_MAX_POOL_SIZE:8}
+spring.datasource.hikari.connection-timeout=${DATA_STORE_DB_CONNECTION_TIMEOUT:40000}
+spring.datasource.hikari.idle-timeout=${DATA_STORE_DB_IDLE_TIMEOUT:300000}
+spring.datasource.hikari.minimum-idle=${DATA_STORE_DB_MIN_IDLE:8}
+spring.datasource.hikari.maximum-pool-size=${DATA_STORE_DB_MAX_POOL_SIZE:16}
 pagination.page.size=25
 
 liquibase.enabled=${ENABLE_DB_MIGRATE:true}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDM-3271

### Change description ###

- Set minimum idle to 8, previous minimum and maximum
- Set maximum connections to 16, previously 8
- Set idle timeout to 5 min so that extra connections are quickly freed, previously not used
- Set connection timeout to 40s, previously 30s

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
