### PR TITLE
RDM-3125 - fix for enabling test when elasticsearch enabled

### DIFF
--- a/src/aat/java/uk/gov/hmcts/ccd/datastore/tests/functional/elasticsearch/ElasticsearchBaseTest.java
+++ b/src/aat/java/uk/gov/hmcts/ccd/datastore/tests/functional/elasticsearch/ElasticsearchBaseTest.java
@@ -2,7 +2,9 @@ package uk.gov.hmcts.ccd.datastore.tests.functional.elasticsearch;
 
 import java.util.function.Supplier;
 
+import static java.util.Optional.ofNullable;
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static uk.gov.hmcts.ccd.datastore.tests.fixture.AATCaseType.AAT_PRIVATE_CASE_TYPE;
 
 import io.restassured.http.ContentType;
@@ -32,6 +34,13 @@ abstract class ElasticsearchBaseTest extends BaseTest {
 
     ElasticsearchBaseTest(AATHelper aat) {
         super(aat);
+    }
+
+    static void assertElasticsearchEnabled() {
+        // stop execution of these tests if Elasticsearch is not enabled
+        LOG.info("ELASTIC_SEARCH_ENABLED: {}", System.getenv("ELASTIC_SEARCH_ENABLED"));
+        boolean elasticsearchEnabled = ofNullable(System.getenv("ELASTIC_SEARCH_ENABLED")).map(Boolean::valueOf).orElse(false);
+        assumeTrue(elasticsearchEnabled, () -> "Ignoring Elasticsearch tests, variable ELASTIC_SEARCH_ENABLED not set");
     }
 
     ValidatableResponse searchCase(Supplier<RequestSpecification> requestSpecification, String jsonSearchRequest) {

--- a/src/aat/java/uk/gov/hmcts/ccd/datastore/tests/functional/elasticsearch/ElasticsearchCaseSearchSecurityTest.java
+++ b/src/aat/java/uk/gov/hmcts/ccd/datastore/tests/functional/elasticsearch/ElasticsearchCaseSearchSecurityTest.java
@@ -8,16 +8,15 @@ import static org.hamcrest.Matchers.hasKey;
 
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.extension.ExtendWith;
 import uk.gov.hmcts.ccd.datastore.tests.AATHelper;
 import uk.gov.hmcts.ccd.datastore.tests.TestData;
 
 @ExtendWith(ElasticsearchTestDataLoaderExtension.class)
-@EnabledIfSystemProperty(named = "ELASTIC_SEARCH_ENABLED", matches = "true")
 class ElasticsearchCaseSearchSecurityTest extends ElasticsearchBaseTest {
 
     static final String CASE_TYPE_SECURITY_TEST_REFERENCE = TestData.uniqueReference();
@@ -27,6 +26,11 @@ class ElasticsearchCaseSearchSecurityTest extends ElasticsearchBaseTest {
 
     ElasticsearchCaseSearchSecurityTest(AATHelper aat) {
         super(aat);
+    }
+
+    @BeforeAll
+    static void setUp() {
+        assertElasticsearchEnabled();
     }
 
     @Nested

--- a/src/aat/java/uk/gov/hmcts/ccd/datastore/tests/functional/elasticsearch/ElasticsearchCaseSearchTest.java
+++ b/src/aat/java/uk/gov/hmcts/ccd/datastore/tests/functional/elasticsearch/ElasticsearchCaseSearchTest.java
@@ -5,16 +5,15 @@ import static uk.gov.hmcts.ccd.datastore.tests.fixture.AATCaseBuilder.FullCase.T
 import static uk.gov.hmcts.ccd.datastore.tests.fixture.AATCaseType.State;
 
 import io.restassured.response.ValidatableResponse;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.extension.ExtendWith;
 import uk.gov.hmcts.ccd.datastore.tests.AATHelper;
 import uk.gov.hmcts.ccd.datastore.tests.TestData;
 
 @ExtendWith(ElasticsearchTestDataLoaderExtension.class)
-@EnabledIfSystemProperty(named = "ELASTIC_SEARCH_ENABLED", matches = "true")
 class ElasticsearchCaseSearchTest extends ElasticsearchBaseTest {
 
     static final String SEARCH_UPDATED_CASE_TEST_REFERENCE = TestData.uniqueReference();
@@ -22,6 +21,11 @@ class ElasticsearchCaseSearchTest extends ElasticsearchBaseTest {
 
     ElasticsearchCaseSearchTest(AATHelper aat) {
         super(aat);
+    }
+
+    @BeforeAll
+    static void setUp() {
+        assertElasticsearchEnabled();
     }
 
     @Nested

--- a/src/aat/java/uk/gov/hmcts/ccd/datastore/tests/functional/elasticsearch/ElasticsearchHelper.java
+++ b/src/aat/java/uk/gov/hmcts/ccd/datastore/tests/functional/elasticsearch/ElasticsearchHelper.java
@@ -4,7 +4,7 @@ import uk.gov.hmcts.ccd.datastore.tests.Env;
 
 final class ElasticsearchHelper {
 
-    private static final long DEFAULT_LOGSTASH_READ_DELAY_MILLIS = 2000;
+    private static final long DEFAULT_LOGSTASH_READ_DELAY_MILLIS = 5000;
 
     String getElasticsearchBaseUri() {
         return Env.require("ELASTIC_SEARCH_SCHEME") + "://" + Env.require("ELASTIC_SEARCH_HOST") + ":" + Env.require("ELASTIC_SEARCH_PORT");


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-3125


### Change description ###
Fix for running ES functional test only when ELASTIC_SEARCH_ENABLED is set to true


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
