### PR TITLE
Rdm 1893 - Add FixedRadioList validator

### DIFF
--- a/src/main/java/uk/gov/hmcts/ccd/domain/types/CaseDataValidator.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/types/CaseDataValidator.java
@@ -95,7 +95,7 @@ public class CaseDataValidator {
                                                        final CaseField caseFieldDefinition,
                                                        final String fieldIdPrefix,
                                                        final BaseType fieldType) {
-        return validators.stream()
+                return validators.stream()
             .filter(validator -> validator.getType() == fieldType)
             .findAny()
             .map(baseTypeValidator -> baseTypeValidator

--- a/src/main/java/uk/gov/hmcts/ccd/domain/types/CaseDataValidator.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/types/CaseDataValidator.java
@@ -95,7 +95,7 @@ public class CaseDataValidator {
                                                        final CaseField caseFieldDefinition,
                                                        final String fieldIdPrefix,
                                                        final BaseType fieldType) {
-                return validators.stream()
+        return validators.stream()
             .filter(validator -> validator.getType() == fieldType)
             .findAny()
             .map(baseTypeValidator -> baseTypeValidator

--- a/src/main/java/uk/gov/hmcts/ccd/domain/types/FixedRadioListValidator.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/types/FixedRadioListValidator.java
@@ -2,17 +2,6 @@ package uk.gov.hmcts.ccd.domain.types;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-
-import static java.math.BigDecimal.ONE;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import uk.gov.hmcts.ccd.domain.model.definition.CaseField;
-import uk.gov.hmcts.ccd.domain.model.definition.FixedListItem;
 
 @Named
 @Singleton

--- a/src/main/java/uk/gov/hmcts/ccd/domain/types/FixedRadioListValidator.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/types/FixedRadioListValidator.java
@@ -1,0 +1,27 @@
+package uk.gov.hmcts.ccd.domain.types;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+
+import static java.math.BigDecimal.ONE;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import uk.gov.hmcts.ccd.domain.model.definition.CaseField;
+import uk.gov.hmcts.ccd.domain.model.definition.FixedListItem;
+
+@Named
+@Singleton
+public class FixedRadioListValidator extends FixedListValidator {
+    static final String TYPE_ID = "FixedRadioList";
+
+    @Override
+    public BaseType getType() {
+        return BaseType.get(TYPE_ID);
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/ccd/domain/types/FixedRadioListValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/types/FixedRadioListValidatorTest.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.ccd.domain.types.BaseTypeValidator.REGEX_GUIDANCE;
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import org.junit.jupiter.api.BeforeEach;
@@ -53,16 +52,16 @@ class FixedRadioListValidatorTest {
     @Test
     void validValue() {
         final List<ValidationResult> result01 = validator.validate(TEST_FIELD_ID,
-                                                                   NODE_FACTORY.textNode("AAAAAA"),
-                                                                   caseField);
+            NODE_FACTORY.textNode("AAAAAA"),
+            caseField);
         assertEquals(0, result01.size());
     }
 
     @Test
     void invalidValue() {
         final List<ValidationResult> result01 = validator.validate(TEST_FIELD_ID,
-                                                                   NODE_FACTORY.textNode("DDDD"),
-                                                                   caseField);
+            NODE_FACTORY.textNode("DDDD"),
+            caseField);
         assertEquals(1, result01.size(), result01.toString());
     }
 
@@ -78,8 +77,8 @@ class FixedRadioListValidatorTest {
 
     private CaseFieldBuilder caseField() {
         return new CaseFieldBuilder(FIELD_ID).withType(FIXED_RADIO_LIST)
-                                             .withFixedListItem("AAAAAA")
-                                             .withFixedListItem("BBBBBB")
-                                             .withFixedListItem("CCCCCC");
+            .withFixedListItem("AAAAAA")
+            .withFixedListItem("BBBBBB")
+            .withFixedListItem("CCCCCC");
     }
 }

--- a/src/test/java/uk/gov/hmcts/ccd/domain/types/FixedRadioListValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/types/FixedRadioListValidatorTest.java
@@ -19,8 +19,10 @@ import uk.gov.hmcts.ccd.test.CaseFieldBuilder;
 
 @DisplayName("FixedRadioListValidator")
 class FixedRadioListValidatorTest {
-    private static final String FIELD_ID = "TEST_FIELD_ID";
+    public static final String TEST_FIELD_ID = "TEST_FIELD_ID";
+    private static final String FIELD_ID = TEST_FIELD_ID;
     private static final JsonNodeFactory NODE_FACTORY = JsonNodeFactory.instance;
+    public static final String FIXED_RADIO_LIST = "FixedRadioList";
 
     @Mock
     private BaseType fixedListBaseType;
@@ -50,7 +52,7 @@ class FixedRadioListValidatorTest {
 
     @Test
     void validValue() {
-        final List<ValidationResult> result01 = validator.validate("TEST_FIELD_ID",
+        final List<ValidationResult> result01 = validator.validate(TEST_FIELD_ID,
                                                                    NODE_FACTORY.textNode("AAAAAA"),
                                                                    caseField);
         assertEquals(0, result01.size());
@@ -58,7 +60,7 @@ class FixedRadioListValidatorTest {
 
     @Test
     void invalidValue() {
-        final List<ValidationResult> result01 = validator.validate("TEST_FIELD_ID",
+        final List<ValidationResult> result01 = validator.validate(TEST_FIELD_ID,
                                                                    NODE_FACTORY.textNode("DDDD"),
                                                                    caseField);
         assertEquals(1, result01.size(), result01.toString());
@@ -66,40 +68,16 @@ class FixedRadioListValidatorTest {
 
     @Test
     void nullValue() {
-        assertEquals(0, validator.validate("TEST_FIELD_ID", null, null).size(), "Did not catch NULL");
+        assertEquals(0, validator.validate(TEST_FIELD_ID, null, null).size(), "Did not catch NULL");
     }
 
     @Test
     void getType() {
-        assertEquals(validator.getType(), BaseType.get("FixedRadioList"), "Type is incorrect");
-    }
-
-    @Test
-    void fieldTypeRegEx() {
-        final CaseField caseFieldWithRegEx = caseField().withRegExp("AAAAAA").build();
-        final List<ValidationResult> result01 = validator.validate("TEST_FIELD_ID", NODE_FACTORY.textNode("AAAAAA"),
-                                                                   caseFieldWithRegEx);
-        assertEquals(0, result01.size());
-
-        final List<ValidationResult> result02 = validator.validate("TEST_FIELD_ID", NODE_FACTORY.textNode("BBBBBB"),
-                                                                   caseFieldWithRegEx);
-        assertEquals(1, result02.size(), "BBBBBB failed regular expression check");
-        assertEquals(REGEX_GUIDANCE, result02.get(0).getErrorMessage());
-        assertEquals("TEST_FIELD_ID", result02.get(0).getFieldId());
-    }
-
-    @Test
-    void baseTypeRegEx() {
-        when(fixedListBaseType.getRegularExpression()).thenReturn("InvalidRegEx");
-        final List<ValidationResult> result = validator.validate("TEST_FIELD_ID",
-                                                                 NODE_FACTORY.textNode("AA"), caseField);
-        assertEquals(1, result.size(), "RegEx validation failed");
-        assertEquals("'AA' failed FixedList Type Regex check: InvalidRegEx", result.get(0).getErrorMessage());
-        assertEquals("TEST_FIELD_ID", result.get(0).getFieldId());
+        assertEquals(validator.getType(), BaseType.get(FIXED_RADIO_LIST), "Type is incorrect");
     }
 
     private CaseFieldBuilder caseField() {
-        return new CaseFieldBuilder(FIELD_ID).withType(FixedListValidator.TYPE_ID)
+        return new CaseFieldBuilder(FIELD_ID).withType(FIXED_RADIO_LIST)
                                              .withFixedListItem("AAAAAA")
                                              .withFixedListItem("BBBBBB")
                                              .withFixedListItem("CCCCCC");

--- a/src/test/java/uk/gov/hmcts/ccd/domain/types/FixedRadioListValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/types/FixedRadioListValidatorTest.java
@@ -1,0 +1,107 @@
+package uk.gov.hmcts.ccd.domain.types;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.ccd.domain.types.BaseTypeValidator.REGEX_GUIDANCE;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import uk.gov.hmcts.ccd.data.definition.CaseDefinitionRepository;
+import uk.gov.hmcts.ccd.domain.model.definition.CaseField;
+import uk.gov.hmcts.ccd.test.CaseFieldBuilder;
+
+@DisplayName("FixedRadioListValidator")
+class FixedRadioListValidatorTest {
+    private static final String FIELD_ID = "TEST_FIELD_ID";
+    private static final JsonNodeFactory NODE_FACTORY = JsonNodeFactory.instance;
+
+    @Mock
+    private BaseType fixedListBaseType;
+
+    @Mock
+    private CaseDefinitionRepository definitionRepository;
+
+    private FixedRadioListValidator validator;
+    private CaseField caseField;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        when(definitionRepository.getBaseTypes()).thenReturn(Collections.emptyList());
+        BaseType.setCaseDefinitionRepository(definitionRepository);
+        BaseType.initialise();
+
+        when(fixedListBaseType.getType()).thenReturn(FixedRadioListValidator.TYPE_ID);
+        when(fixedListBaseType.getRegularExpression()).thenReturn(null);
+        BaseType.register(fixedListBaseType);
+
+        validator = new FixedRadioListValidator();
+
+        caseField = caseField().build();
+    }
+
+    @Test
+    void validValue() {
+        final List<ValidationResult> result01 = validator.validate("TEST_FIELD_ID",
+                                                                   NODE_FACTORY.textNode("AAAAAA"),
+                                                                   caseField);
+        assertEquals(0, result01.size());
+    }
+
+    @Test
+    void invalidValue() {
+        final List<ValidationResult> result01 = validator.validate("TEST_FIELD_ID",
+                                                                   NODE_FACTORY.textNode("DDDD"),
+                                                                   caseField);
+        assertEquals(1, result01.size(), result01.toString());
+    }
+
+    @Test
+    void nullValue() {
+        assertEquals(0, validator.validate("TEST_FIELD_ID", null, null).size(), "Did not catch NULL");
+    }
+
+    @Test
+    void getType() {
+        assertEquals(validator.getType(), BaseType.get("FixedRadioList"), "Type is incorrect");
+    }
+
+    @Test
+    void fieldTypeRegEx() {
+        final CaseField caseFieldWithRegEx = caseField().withRegExp("AAAAAA").build();
+        final List<ValidationResult> result01 = validator.validate("TEST_FIELD_ID", NODE_FACTORY.textNode("AAAAAA"),
+                                                                   caseFieldWithRegEx);
+        assertEquals(0, result01.size());
+
+        final List<ValidationResult> result02 = validator.validate("TEST_FIELD_ID", NODE_FACTORY.textNode("BBBBBB"),
+                                                                   caseFieldWithRegEx);
+        assertEquals(1, result02.size(), "BBBBBB failed regular expression check");
+        assertEquals(REGEX_GUIDANCE, result02.get(0).getErrorMessage());
+        assertEquals("TEST_FIELD_ID", result02.get(0).getFieldId());
+    }
+
+    @Test
+    void baseTypeRegEx() {
+        when(fixedListBaseType.getRegularExpression()).thenReturn("InvalidRegEx");
+        final List<ValidationResult> result = validator.validate("TEST_FIELD_ID",
+                                                                 NODE_FACTORY.textNode("AA"), caseField);
+        assertEquals(1, result.size(), "RegEx validation failed");
+        assertEquals("'AA' failed FixedList Type Regex check: InvalidRegEx", result.get(0).getErrorMessage());
+        assertEquals("TEST_FIELD_ID", result.get(0).getFieldId());
+    }
+
+    private CaseFieldBuilder caseField() {
+        return new CaseFieldBuilder(FIELD_ID).withType(FixedListValidator.TYPE_ID)
+                                             .withFixedListItem("AAAAAA")
+                                             .withFixedListItem("BBBBBB")
+                                             .withFixedListItem("CCCCCC");
+    }
+}


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RDM-1893

As a caseworker
I want to see multiple options in radio button rather than Dropdown
So that I can see all the available options at one go and select one accordingly.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
