### PR TITLE
Attempt to fix AAT performance issues

### DIFF
--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -8,4 +8,3 @@ asp_name = "ccd-data-store-api-aat"
 asp_rg = "ccd-data-store-api-aat"
 elastic_search_enabled = "true"
 
-

--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -7,4 +7,6 @@ frontend_url = "https://www-ccd.nonprod.platform.hmcts.net"
 asp_name = "ccd-data-store-api-aat"
 asp_rg = "ccd-data-store-api-aat"
 elastic_search_enabled = "true"
+definition_cache_max_size = "30000"
+
 

--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -7,6 +7,5 @@ frontend_url = "https://www-ccd.nonprod.platform.hmcts.net"
 asp_name = "ccd-data-store-api-aat"
 asp_rg = "ccd-data-store-api-aat"
 elastic_search_enabled = "true"
-definition_cache_max_size = "30000"
 
 

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -126,6 +126,9 @@ module "ccd-data-store-api" {
 
     CCD_DEFAULTPRINTURL                 = "${local.default_print_url}"
 
+    DEFINITION_CACHE_TTL_SEC            = "${var.definition_cache_ttl_sec}"
+    DEFINITION_CACHE_MAX_SIZE           = "${var.definition_cache_max_size}"
+
     ELASTIC_SEARCH_ENABLED              = "${var.elastic_search_enabled}"
     ELASTIC_SEARCH_HOSTS                = "${local.elastic_search_hosts}"
     ELASTIC_SEARCH_DATA_NODES_HOSTS     = "${local.elastic_search_data_node_hosts}"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -128,6 +128,7 @@ module "ccd-data-store-api" {
 
     DEFINITION_CACHE_TTL_SEC            = "${var.definition_cache_ttl_sec}"
     DEFINITION_CACHE_MAX_SIZE           = "${var.definition_cache_max_size}"
+    DEFINITION_CACHE_EVICTION_POLICY    = "${var.definition_cache_eviction_policy}"
 
     ELASTIC_SEARCH_ENABLED              = "${var.elastic_search_enabled}"
     ELASTIC_SEARCH_HOSTS                = "${local.elastic_search_hosts}"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -65,7 +65,7 @@ variable "definition_cache_ttl_sec" {
 
 variable "definition_cache_max_size" {
   type = "string"
-  default = "1000"
+  default = "10000"
 }
 
 ////////////////////////////////

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -58,6 +58,16 @@ variable "jenkins_AAD_objectId" {
   description                 = "(Required) The Azure AD object ID of a user, service principal or security group in the Azure Active Directory tenant for the vault. The object ID must be unique for the list of access policies."
 }
 
+variable "definition_cache_ttl_sec" {
+  type = "string"
+  default = "86400"
+}
+
+variable "definition_cache_max_size" {
+  type = "string"
+  default = "1000"
+}
+
 ////////////////////////////////
 // Database
 ////////////////////////////////

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -60,12 +60,17 @@ variable "jenkins_AAD_objectId" {
 
 variable "definition_cache_ttl_sec" {
   type = "string"
-  default = "86400"
+  default = "259200"
 }
 
 variable "definition_cache_max_size" {
   type = "string"
   default = "5000"
+}
+
+variable "definition_cache_eviction_policy" {
+  type = "string"
+  default = "NONE"
 }
 
 ////////////////////////////////

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -65,7 +65,7 @@ variable "definition_cache_ttl_sec" {
 
 variable "definition_cache_max_size" {
   type = "string"
-  default = "10000"
+  default = "5000"
 }
 
 ////////////////////////////////

--- a/src/main/java/uk/gov/hmcts/ccd/ApplicationParams.java
+++ b/src/main/java/uk/gov/hmcts/ccd/ApplicationParams.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 import static java.util.stream.Collectors.toList;
 
+import com.hazelcast.config.EvictionPolicy;
 import org.springframework.beans.factory.annotation.Value;
 import uk.gov.hmcts.ccd.endpoint.exceptions.ServiceException;
 
@@ -68,6 +69,9 @@ public class ApplicationParams {
 
     @Value("${definition.cache.max.size}")
     private Integer definitionCacheMaxSize;
+
+    @Value("${definition.cache.eviction.policy}")
+    private EvictionPolicy definitionCacheEvictionPolicy;
 
     @Value("#{'${search.elastic.hosts}'.split(',')}")
     private List<String> elasticSearchHosts;
@@ -222,6 +226,10 @@ public class ApplicationParams {
 
     public int getDefinitionCacheMaxSize() {
         return definitionCacheMaxSize;
+    }
+
+    public EvictionPolicy getDefinitionCacheEvictionPolicy() {
+        return definitionCacheEvictionPolicy;
     }
 
     public List<String> getSearchBlackList() {

--- a/src/main/java/uk/gov/hmcts/ccd/ApplicationParams.java
+++ b/src/main/java/uk/gov/hmcts/ccd/ApplicationParams.java
@@ -66,6 +66,9 @@ public class ApplicationParams {
     @Value("${definition.cache.ttl.secs}")
     private Integer definitionCacheTTLSecs;
 
+    @Value("${definition.cache.max.size}")
+    private Integer definitionCacheMaxSize;
+
     @Value("#{'${search.elastic.hosts}'.split(',')}")
     private List<String> elasticSearchHosts;
 
@@ -215,6 +218,10 @@ public class ApplicationParams {
 
     public int getDefinitionCacheTTLSecs() {
         return definitionCacheTTLSecs;
+    }
+
+    public int getDefinitionCacheMaxSize() {
+        return definitionCacheMaxSize;
     }
 
     public List<String> getSearchBlackList() {

--- a/src/main/java/uk/gov/hmcts/ccd/CachingConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/ccd/CachingConfiguration.java
@@ -35,7 +35,7 @@ public class CachingConfiguration {
 
     private MapConfig newMapConfig(final String name, int definitionCacheTTL) {
         return new MapConfig().setName(name)
-                .setMaxSizeConfig(new MaxSizeConfig(1000, MaxSizeConfig.MaxSizePolicy.FREE_HEAP_SIZE))
+                .setMaxSizeConfig(new MaxSizeConfig(applicationParams.getDefinitionCacheMaxSize(), MaxSizeConfig.MaxSizePolicy.FREE_HEAP_SIZE))
                 .setEvictionPolicy(EvictionPolicy.LRU)
                 .setMaxIdleSeconds(definitionCacheTTL);
     }

--- a/src/main/java/uk/gov/hmcts/ccd/CachingConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/ccd/CachingConfiguration.java
@@ -36,7 +36,7 @@ public class CachingConfiguration {
     private MapConfig newMapConfig(final String name, int definitionCacheTTL) {
         return new MapConfig().setName(name)
                 .setMaxSizeConfig(new MaxSizeConfig(applicationParams.getDefinitionCacheMaxSize(), MaxSizeConfig.MaxSizePolicy.PER_NODE))
-                .setEvictionPolicy(EvictionPolicy.LRU)
+                .setEvictionPolicy(applicationParams.getDefinitionCacheEvictionPolicy())
                 .setMaxIdleSeconds(definitionCacheTTL);
     }
 

--- a/src/main/java/uk/gov/hmcts/ccd/CachingConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/ccd/CachingConfiguration.java
@@ -35,7 +35,7 @@ public class CachingConfiguration {
 
     private MapConfig newMapConfig(final String name, int definitionCacheTTL) {
         return new MapConfig().setName(name)
-                .setMaxSizeConfig(new MaxSizeConfig(applicationParams.getDefinitionCacheMaxSize(), MaxSizeConfig.MaxSizePolicy.FREE_HEAP_SIZE))
+                .setMaxSizeConfig(new MaxSizeConfig(applicationParams.getDefinitionCacheMaxSize(), MaxSizeConfig.MaxSizePolicy.PER_NODE))
                 .setEvictionPolicy(EvictionPolicy.LRU)
                 .setMaxIdleSeconds(definitionCacheTTL);
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,6 +23,10 @@ liquibase.change-log=classpath:/db/changelog/db.changelog-master.xml
 #ttl of cached definitions in seconds
 definition.cache.ttl.secs=${DEFINITION_CACHE_TTL_SEC:86400}
 
+#max size of the various definitions caches
+definition.cache.max.size=${DEFINITION_CACHE_MAX_SIZE:1000}
+
+
 # Jackson ObjectMapper configuration
 spring.jackson.serialization.WRITE_DATES_AS_TIMESTAMPS=false
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,7 +24,7 @@ liquibase.change-log=classpath:/db/changelog/db.changelog-master.xml
 definition.cache.ttl.secs=${DEFINITION_CACHE_TTL_SEC:86400}
 
 #max size of the various definitions caches
-definition.cache.max.size=${DEFINITION_CACHE_MAX_SIZE:10000}
+definition.cache.max.size=${DEFINITION_CACHE_MAX_SIZE:5000}
 
 
 # Jackson ObjectMapper configuration

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,7 +24,7 @@ liquibase.change-log=classpath:/db/changelog/db.changelog-master.xml
 definition.cache.ttl.secs=${DEFINITION_CACHE_TTL_SEC:86400}
 
 #max size of the various definitions caches
-definition.cache.max.size=${DEFINITION_CACHE_MAX_SIZE:1000}
+definition.cache.max.size=${DEFINITION_CACHE_MAX_SIZE:10000}
 
 
 # Jackson ObjectMapper configuration

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,12 +20,16 @@ pagination.page.size=25
 liquibase.enabled=${ENABLE_DB_MIGRATE:true}
 liquibase.change-log=classpath:/db/changelog/db.changelog-master.xml
 
-#ttl of cached definitions in seconds
-definition.cache.ttl.secs=${DEFINITION_CACHE_TTL_SEC:86400}
 
-#max size of the various definitions caches
+#definitions cache parameters
+#ttl of cache map entry
+definition.cache.ttl.secs=${DEFINITION_CACHE_TTL_SEC:259200}
+
+#max size of cache map in terms of number of entries
 definition.cache.max.size=${DEFINITION_CACHE_MAX_SIZE:5000}
 
+#eviction policy. If set to NONE the cache can grow arbitrarily large and definition.cache.max.size is ignored
+definition.cache.eviction.policy=${DEFINITION_CACHE_EVICTION_POLICY:NONE}
 
 # Jackson ObjectMapper configuration
 spring.jackson.serialization.WRITE_DATES_AS_TIMESTAMPS=false


### PR DESCRIPTION
Fix AAT performance issues:

Removed limit on cache size. 
Made definition cache parameters configurable. 
Increased ttl of a cache entry to 3 days

ADDITIONAL INFO:
https://docs.hazelcast.org/docs/latest-dev/manual/html-single/index.html#map

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
