### PR TITLE
Upgrade springboot to 1.15.19 to address jackson-databind CVEs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 plugins {
     id 'application'
     id 'io.spring.dependency-management' version '1.0.6.RELEASE'
-    id 'org.springframework.boot' version '1.5.14.RELEASE'
+    id 'org.springframework.boot' version '1.5.19.RELEASE'
     id 'com.github.ben-manes.versions' version '0.20.0'
     id 'org.sonarqube' version '2.6.2'
     id 'jacoco'

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -124,8 +124,11 @@
         <cve>CVE-2018-19362</cve>
     </suppress>
     <suppress>
-        <notes>Temporarily suppress jackson-databind CVE see RDM-3796</notes>
-        <gav regex="true">^com\.fasterxml\.jackson\.core:jackson-databind:.*$</gav>
+        <notes>jackson-databind 2.8.x will not get a fix for this CVE.  We need
+            to upgrade to 2.9.x. See
+            https://github.com/FasterXML/jackson-modules-java8/issues/90#issuecomment-450544881
+            and RDM-3796</notes>
+        <gav regex="true">^com\.fasterxml\.jackson\.core:jackson-databind:2\.8\.11\.[3].*$</gav>
         <cve>CVE-2018-1000873</cve>
     </suppress>
     <suppress>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -75,38 +75,52 @@
         <cpe>cpe:/a:slf4j:slf4j:1.7.25</cpe>
     </suppress>
     <suppress>
-        <notes>Temporarily suppress jackson-databind CVE see RDM-3796</notes>
-        <gav regex="true">^com\.fasterxml\.jackson\.core:jackson-databind:.*$</gav>
+        <notes>jackson-databind 2.8.11.3 fixes this CVE. See
+            https://github.com/FasterXML/jackson-databind/issues/2097#issuecomment-457071680
+            and RDM-3796</notes>
+        <gav regex="true">^com\.fasterxml\.jackson\.core:jackson-databind:2\.8\.11\.[3].*$</gav>
         <cve>CVE-2018-14718</cve>
     </suppress>
     <suppress>
-        <notes>Temporarily suppress jackson-databind CVE see RDM-3796</notes>
-        <gav regex="true">^com\.fasterxml\.jackson\.core:jackson-databind:.*$</gav>
+        <notes>jackson-databind 2.8.11.3 fixes this CVE. See
+            https://github.com/FasterXML/jackson-databind/issues/2097#issuecomment-457071680
+            and RDM-3796</notes>
+        <gav regex="true">^com\.fasterxml\.jackson\.core:jackson-databind:2\.8\.11\.[3].*$</gav>
         <cve>CVE-2018-14719</cve>
     </suppress>
     <suppress>
-        <notes>Temporarily suppress jackson-databind CVE see RDM-3796</notes>
-        <gav regex="true">^com\.fasterxml\.jackson\.core:jackson-databind:.*$</gav>
+        <notes>jackson-databind 2.8.11.3 fixes this CVE. See
+            https://github.com/FasterXML/jackson-databind/issues/2097#issuecomment-457071680
+            and RDM-3796</notes>
+        <gav regex="true">^com\.fasterxml\.jackson\.core:jackson-databind:2\.8\.11\.[3].*$</gav>
         <cve>CVE-2018-14720</cve>
     </suppress>
     <suppress>
-        <notes>Temporarily suppress jackson-databind CVE see RDM-3796</notes>
-        <gav regex="true">^com\.fasterxml\.jackson\.core:jackson-databind:.*$</gav>
+        <notes>jackson-databind 2.8.11.3 fixes this CVE. See
+            https://github.com/FasterXML/jackson-databind/issues/2097#issuecomment-457071680
+            and RDM-3796</notes>
+        <gav regex="true">^com\.fasterxml\.jackson\.core:jackson-databind:2\.8\.11\.[3].*$</gav>
         <cve>CVE-2018-14721</cve>
     </suppress>
     <suppress>
-        <notes>Temporarily suppress jackson-databind CVE see RDM-3796</notes>
-        <gav regex="true">^com\.fasterxml\.jackson\.core:jackson-databind:.*$</gav>
+        <notes>jackson-databind 2.8.11.3 fixes this CVE. See
+            https://github.com/FasterXML/jackson-databind/issues/2097#issuecomment-457071680
+            and RDM-3796</notes>
+        <gav regex="true">^com\.fasterxml\.jackson\.core:jackson-databind:2\.8\.11\.[3].*$</gav>
         <cve>CVE-2018-19360</cve>
     </suppress>
     <suppress>
-        <notes>Temporarily suppress jackson-databind CVE see RDM-3796</notes>
-        <gav regex="true">^com\.fasterxml\.jackson\.core:jackson-databind:.*$</gav>
+        <notes>jackson-databind 2.8.11.3 fixes this CVE. See
+            https://github.com/FasterXML/jackson-databind/issues/2097#issuecomment-457071680
+            and RDM-3796</notes>
+        <gav regex="true">^com\.fasterxml\.jackson\.core:jackson-databind:2\.8\.11\.[3].*$</gav>
         <cve>CVE-2018-19361</cve>
     </suppress>
     <suppress>
-        <notes>Temporarily suppress jackson-databind CVE see RDM-3796</notes>
-        <gav regex="true">^com\.fasterxml\.jackson\.core:jackson-databind:.*$</gav>
+        <notes>jackson-databind 2.8.11.3 fixes this CVE. See
+            https://github.com/FasterXML/jackson-databind/issues/2097#issuecomment-457071680
+            and RDM-3796</notes>
+        <gav regex="true">^com\.fasterxml\.jackson\.core:jackson-databind:2\.8\.11\.[3].*$</gav>
         <cve>CVE-2018-19362</cve>
     </suppress>
     <suppress>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RDM-3796




* Upgrades spring boot to 1.15.19 - things bring in jackson-databind
2.8.11.3 which address most of the CVEs
* Suppress false positive CVEs
* Suppress CVE-2018-1000873 which won't get fixed on the 2.8.x release
brnach


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```