### PR TITLE
RDM-4030 - cache IDAM user full name

### DIFF
--- a/src/main/java/uk/gov/hmcts/ccd/ApplicationParams.java
+++ b/src/main/java/uk/gov/hmcts/ccd/ApplicationParams.java
@@ -67,6 +67,9 @@ public class ApplicationParams {
     @Value("${definition.cache.ttl.secs}")
     private Integer definitionCacheTTLSecs;
 
+    @Value("${daily.cache.ttl.secs}")
+    private Integer dailyCacheTTLSecs;
+
     @Value("${definition.cache.max.size}")
     private Integer definitionCacheMaxSize;
 
@@ -231,6 +234,10 @@ public class ApplicationParams {
 
     public int getDefinitionCacheTTLSecs() {
         return definitionCacheTTLSecs;
+    }
+
+    public Integer getDailyCacheTTLSecs() {
+        return dailyCacheTTLSecs;
     }
 
     public int getDefinitionCacheMaxSize() {

--- a/src/main/java/uk/gov/hmcts/ccd/CachingConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/ccd/CachingConfiguration.java
@@ -11,9 +11,12 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class CachingConfiguration {
 
-    @Autowired
-    ApplicationParams applicationParams;
+    private final ApplicationParams applicationParams;
 
+    @Autowired
+    public CachingConfiguration(ApplicationParams applicationParams) {
+        this.applicationParams = applicationParams;
+    }
 
     @Bean
     public Config hazelCastConfig() {
@@ -35,6 +38,7 @@ public class CachingConfiguration {
         config.addMapConfig(newMapConfig("caseTabCollectionCache", definitionCacheTTL));
         config.addMapConfig(newMapConfig("wizardPageCollectionCache", definitionCacheTTL));
         config.addMapConfig(newMapConfig("userRolesCache", definitionCacheTTL));
+        config.addMapConfig(newMapConfig("userCache", applicationParams.getDailyCacheTTLSecs()));
     }
 
     private MapConfig newMapConfig(final String name, int definitionCacheTTL) {

--- a/src/main/java/uk/gov/hmcts/ccd/data/user/CachedUserRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/user/CachedUserRepository.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.context.annotation.RequestScope;
 import uk.gov.hmcts.ccd.data.casedetails.SecurityClassification;
 import uk.gov.hmcts.ccd.domain.model.aggregated.IDAMProperties;
+import uk.gov.hmcts.ccd.domain.model.aggregated.IDAMUser;
 import uk.gov.hmcts.ccd.domain.model.aggregated.UserDefault;
 
 @Service
@@ -37,6 +38,11 @@ public class CachedUserRepository implements UserRepository {
     @Override
     public IDAMProperties getUserDetails() {
         return userDetails.computeIfAbsent("userDetails", e -> userRepository.getUserDetails());
+    }
+
+    @Override
+    public IDAMUser getUser() {
+        return userRepository.getUser();
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/ccd/data/user/DefaultUserRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/user/DefaultUserRepository.java
@@ -1,6 +1,10 @@
 package uk.gov.hmcts.ccd.data.user;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.util.Comparator.comparingInt;
@@ -11,6 +15,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.core.GrantedAuthority;
@@ -25,6 +30,7 @@ import uk.gov.hmcts.ccd.data.casedetails.SecurityClassification;
 import uk.gov.hmcts.ccd.data.definition.CachedCaseDefinitionRepository;
 import uk.gov.hmcts.ccd.data.definition.CaseDefinitionRepository;
 import uk.gov.hmcts.ccd.domain.model.aggregated.IDAMProperties;
+import uk.gov.hmcts.ccd.domain.model.aggregated.IDAMUser;
 import uk.gov.hmcts.ccd.domain.model.aggregated.UserDefault;
 import uk.gov.hmcts.ccd.endpoint.exceptions.BadRequestException;
 import uk.gov.hmcts.ccd.endpoint.exceptions.ServiceException;
@@ -59,6 +65,13 @@ public class DefaultUserRepository implements UserRepository {
     public IDAMProperties getUserDetails() {
         final HttpEntity requestEntity = new HttpEntity(securityUtils.userAuthorizationHeaders());
         return restTemplate.exchange(applicationParams.idamUserProfileURL(), HttpMethod.GET, requestEntity, IDAMProperties.class).getBody();
+    }
+
+    @Override
+    @Cacheable(value = "userCache", key = "#securityUtils.getUserId")
+    public IDAMUser getUser() {
+        HttpEntity requestEntity = new HttpEntity(securityUtils.userAuthorizationHeaders());
+        return restTemplate.exchange(applicationParams.idamUserProfileURL(), HttpMethod.GET, requestEntity, IDAMUser.class).getBody();
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/ccd/data/user/UserRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/user/UserRepository.java
@@ -4,11 +4,14 @@ import java.util.Set;
 
 import uk.gov.hmcts.ccd.data.casedetails.SecurityClassification;
 import uk.gov.hmcts.ccd.domain.model.aggregated.IDAMProperties;
+import uk.gov.hmcts.ccd.domain.model.aggregated.IDAMUser;
 import uk.gov.hmcts.ccd.domain.model.aggregated.UserDefault;
 
 public interface UserRepository {
 
     IDAMProperties getUserDetails();
+
+    IDAMUser getUser();
 
     UserDefault getUserDefaultSettings(String userId);
 

--- a/src/main/java/uk/gov/hmcts/ccd/domain/model/aggregated/IDAMProperties.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/model/aggregated/IDAMProperties.java
@@ -1,44 +1,9 @@
 package uk.gov.hmcts.ccd.domain.model.aggregated;
 
-public class IDAMProperties {
-    private String id;
-    private String email;
-    private String forename;
-    private String surname;
+public class IDAMProperties extends IDAMUser {
+
     private String[] roles;
     private String defaultService;
-
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
-    }
-
-    public String getForename() {
-        return forename;
-    }
-
-    public void setForename(String forename) {
-        this.forename = forename;
-    }
-
-    public String getSurname() {
-        return surname;
-    }
-
-    public void setSurname(String surname) {
-        this.surname = surname;
-    }
 
     public String[] getRoles() {
         return roles;
@@ -55,4 +20,5 @@ public class IDAMProperties {
     public void setDefaultService(String defaultService) {
         this.defaultService = defaultService;
     }
+
 }

--- a/src/main/java/uk/gov/hmcts/ccd/domain/model/aggregated/IDAMUser.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/model/aggregated/IDAMUser.java
@@ -1,0 +1,43 @@
+package uk.gov.hmcts.ccd.domain.model.aggregated;
+
+import java.io.Serializable;
+
+public class IDAMUser implements Serializable {
+    private static final long serialVersionUID = -1598749846026580369L;
+    private String id;
+    private String email;
+    private String forename;
+    private String surname;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getForename() {
+        return forename;
+    }
+
+    public void setForename(String forename) {
+        this.forename = forename;
+    }
+
+    public String getSurname() {
+        return surname;
+    }
+
+    public void setSurname(String surname) {
+        this.surname = surname;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/createcase/DefaultCreateCaseOperation.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/createcase/DefaultCreateCaseOperation.java
@@ -18,7 +18,7 @@ import uk.gov.hmcts.ccd.data.draft.CachedDraftGateway;
 import uk.gov.hmcts.ccd.data.draft.DraftGateway;
 import uk.gov.hmcts.ccd.data.user.CachedUserRepository;
 import uk.gov.hmcts.ccd.data.user.UserRepository;
-import uk.gov.hmcts.ccd.domain.model.aggregated.IDAMProperties;
+import uk.gov.hmcts.ccd.domain.model.aggregated.IDAMUser;
 import uk.gov.hmcts.ccd.domain.model.callbacks.AfterSubmitCallbackResponse;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseDetails;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseEvent;
@@ -88,8 +88,7 @@ public class DefaultCreateCaseOperation implements CreateCaseOperation {
             throw new ValidationException("Cannot create case because of event is not specified");
         }
 
-        final IDAMProperties idamUser = userRepository.getUserDetails();
-        final CaseType caseType = caseDefinitionRepository.getCaseType(caseTypeId);
+        CaseType caseType = caseDefinitionRepository.getCaseType(caseTypeId);
         if (caseType == null) {
             throw new ValidationException("Cannot find case type definition for " + caseTypeId);
         }
@@ -122,6 +121,7 @@ public class DefaultCreateCaseOperation implements CreateCaseOperation {
         newCaseDetails.setData(caseSanitiser.sanitise(caseType, data));
         newCaseDetails.setDataClassification(caseDataService.getDefaultSecurityClassifications(caseType, newCaseDetails.getData(), EMPTY_DATA_CLASSIFICATION));
 
+        final IDAMUser idamUser = userRepository.getUser();
         final CaseDetails savedCaseDetails = submitCaseTransaction.submitCase(event,
                                                                               caseType,
                                                                               idamUser,

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/createcase/SubmitCaseTransaction.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/createcase/SubmitCaseTransaction.java
@@ -1,5 +1,12 @@
 package uk.gov.hmcts.ccd.domain.service.createcase;
 
+import javax.inject.Inject;
+import javax.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import static uk.gov.hmcts.ccd.data.caseaccess.GlobalCaseRole.CREATOR;
+
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
@@ -8,7 +15,7 @@ import uk.gov.hmcts.ccd.data.caseaccess.CaseUserRepository;
 import uk.gov.hmcts.ccd.data.casedetails.CachedCaseDetailsRepository;
 import uk.gov.hmcts.ccd.data.casedetails.CaseAuditEventRepository;
 import uk.gov.hmcts.ccd.data.casedetails.CaseDetailsRepository;
-import uk.gov.hmcts.ccd.domain.model.aggregated.IDAMProperties;
+import uk.gov.hmcts.ccd.domain.model.aggregated.IDAMUser;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseDetails;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseEvent;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseState;
@@ -23,13 +30,6 @@ import uk.gov.hmcts.ccd.domain.service.stdapi.CallbackInvoker;
 import uk.gov.hmcts.ccd.endpoint.exceptions.CaseConcurrencyException;
 import uk.gov.hmcts.ccd.infrastructure.user.UserAuthorisation;
 import uk.gov.hmcts.ccd.infrastructure.user.UserAuthorisation.AccessLevel;
-
-import javax.inject.Inject;
-import javax.transaction.Transactional;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-
-import static uk.gov.hmcts.ccd.data.caseaccess.GlobalCaseRole.CREATOR;
 
 @Service
 class SubmitCaseTransaction {
@@ -71,9 +71,10 @@ class SubmitCaseTransaction {
     )
     public CaseDetails submitCase(Event event,
                                   CaseType caseType,
-                                  IDAMProperties idamUser,
+                                  IDAMUser idamUser,
                                   CaseEvent eventTrigger,
                                   CaseDetails newCaseDetails, Boolean ignoreWarning) {
+
         final LocalDateTime createdDate = LocalDateTime.now(ZoneOffset.UTC);
 
         newCaseDetails.setCreatedDate(createdDate);
@@ -103,7 +104,7 @@ class SubmitCaseTransaction {
     private CaseDetails saveAuditEventForCaseDetails(AboutToSubmitCallbackResponse response,
                                                      Event event,
                                                      CaseType caseType,
-                                                     IDAMProperties idamUser,
+                                                     IDAMUser idamUser,
                                                      CaseEvent eventTrigger,
                                                      CaseDetails newCaseDetails) {
 

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/createevent/DefaultCreateEventOperation.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/createevent/DefaultCreateEventOperation.java
@@ -25,7 +25,7 @@ import uk.gov.hmcts.ccd.data.definition.CachedCaseDefinitionRepository;
 import uk.gov.hmcts.ccd.data.definition.CaseDefinitionRepository;
 import uk.gov.hmcts.ccd.data.user.CachedUserRepository;
 import uk.gov.hmcts.ccd.data.user.UserRepository;
-import uk.gov.hmcts.ccd.domain.model.aggregated.IDAMProperties;
+import uk.gov.hmcts.ccd.domain.model.aggregated.IDAMUser;
 import uk.gov.hmcts.ccd.domain.model.callbacks.AfterSubmitCallbackResponse;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseDetails;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseEvent;
@@ -36,7 +36,12 @@ import uk.gov.hmcts.ccd.domain.model.std.CaseDataContent;
 import uk.gov.hmcts.ccd.domain.model.std.Event;
 import uk.gov.hmcts.ccd.domain.model.std.validator.EventValidator;
 import uk.gov.hmcts.ccd.domain.service.callbacks.EventTokenService;
-import uk.gov.hmcts.ccd.domain.service.common.*;
+import uk.gov.hmcts.ccd.domain.service.common.CaseDataService;
+import uk.gov.hmcts.ccd.domain.service.common.CaseService;
+import uk.gov.hmcts.ccd.domain.service.common.CaseTypeService;
+import uk.gov.hmcts.ccd.domain.service.common.EventTriggerService;
+import uk.gov.hmcts.ccd.domain.service.common.SecurityClassificationService;
+import uk.gov.hmcts.ccd.domain.service.common.UIDService;
 import uk.gov.hmcts.ccd.domain.service.stdapi.AboutToSubmitCallbackResponse;
 import uk.gov.hmcts.ccd.domain.service.stdapi.CallbackInvoker;
 import uk.gov.hmcts.ccd.domain.service.validate.ValidateCaseFieldsOperation;
@@ -230,7 +235,7 @@ public class DefaultCreateEventOperation implements CreateEventOperation {
                                               final CaseEvent eventTrigger,
                                               final CaseDetails caseDetails,
                                               final CaseType caseType) {
-        final IDAMProperties user = userRepository.getUserDetails();
+        final IDAMUser user = userRepository.getUser();
         final CaseState caseState = caseTypeService.findState(caseType, caseDetails.getState());
         final AuditEvent auditEvent = new AuditEvent();
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,6 +24,7 @@ liquibase.change-log=classpath:/db/changelog/db.changelog-master.xml
 #definitions cache parameters
 #ttl of cache map entry
 definition.cache.ttl.secs=${DEFINITION_CACHE_TTL_SEC:259200}
+daily.cache.ttl.secs=28800
 
 #max size of cache map in terms of number of entries
 definition.cache.max.size=${DEFINITION_CACHE_MAX_SIZE:5000}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-4030


### Change description ###
Introduced caching for retrieving IDAM user. There is an IDAM call made for every event to retrieve user's first name and last name. This can be cached for 8 hours as you wouldn't anticipate name changes every hour. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
