### PR TITLE
RDM-4316 fix broken callback retry mechanism

### DIFF
--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/callbacks/CallbackService.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/callbacks/CallbackService.java
@@ -47,7 +47,7 @@ public class CallbackService {
         this.defaultRetries = applicationParams.getCallbackRetries();
     }
 
-    // The retry will be on seconds T=1 and T=3 of the initial call fails at T=0
+    // The retry will be on seconds T=1 and T=3 if the initial call fails at T=0
     @Retryable(value = {CallbackException.class}, maxAttempts = 3, backoff = @Backoff(delay = 1000, multiplier = 3))
     public Optional<CallbackResponse> send(final String url,
                                            final List<Integer> callbackRetries,
@@ -71,7 +71,7 @@ public class CallbackService {
         throw new CallbackException("Unsuccessful callback to " + url);
     }
 
-    // The retry will be on seconds T=1 and T=3 of the initial call fails at T=0
+    // The retry will be on seconds T=1 and T=3 if the initial call fails at T=0
     @Retryable(value = {CallbackException.class}, maxAttempts = 3, backoff = @Backoff(delay = 1000, multiplier = 3))
     public <T> ResponseEntity<T> send(final String url,
                                       final List<Integer> callbackRetries,

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/stdapi/CallbackInvoker.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/stdapi/CallbackInvoker.java
@@ -57,7 +57,7 @@ public class CallbackInvoker {
         final Optional<CallbackResponse> callbackResponse = callbackService.send(
             caseEvent.getCallBackURLAboutToStartEvent(),
             caseEvent.getRetriesTimeoutAboutToStartEvent(),
-            caseEvent, caseDetails);
+            caseEvent, null, caseDetails, false);
 
         callbackResponse.ifPresent(response -> validateAndSetFromAboutToStartCallback(caseType,
                                                                                       caseDetails,
@@ -108,7 +108,7 @@ public class CallbackInvoker {
             wizardPage.getRetriesTimeoutMidEvent(),
             caseEvent,
             caseDetailsBefore,
-            caseDetails);
+            caseDetails, false);
 
         if (callbackResponseOptional.isPresent()) {
             CallbackResponse callbackResponse = callbackResponseOptional.get();

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/stdapi/CallbackInvoker.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/stdapi/CallbackInvoker.java
@@ -56,7 +56,6 @@ public class CallbackInvoker {
                                            final Boolean ignoreWarning) {
         final Optional<CallbackResponse> callbackResponse = callbackService.send(
             caseEvent.getCallBackURLAboutToStartEvent(),
-            caseEvent.getRetriesTimeoutAboutToStartEvent(),
             caseEvent, null, caseDetails, false);
 
         callbackResponse.ifPresent(response -> validateAndSetFromAboutToStartCallback(caseType,
@@ -73,7 +72,6 @@ public class CallbackInvoker {
 
         final Optional<CallbackResponse> callbackResponse = callbackService.send(
             eventTrigger.getCallBackURLAboutToSubmitEvent(),
-            eventTrigger.getRetriesTimeoutURLAboutToSubmitEvent(),
             eventTrigger, caseDetailsBefore, caseDetails, ignoreWarning);
 
         if (callbackResponse.isPresent()) {
@@ -90,7 +88,6 @@ public class CallbackInvoker {
                                                                                final CaseDetails caseDetailsBefore,
                                                                                final CaseDetails caseDetails) {
         return callbackService.send(eventTrigger.getCallBackURLSubmittedEvent(),
-                                    eventTrigger.getRetriesTimeoutURLSubmittedEvent(),
                                     eventTrigger,
                                     caseDetailsBefore,
                                     caseDetails,
@@ -105,7 +102,6 @@ public class CallbackInvoker {
                                               final Boolean ignoreWarning) {
 
         Optional<CallbackResponse> callbackResponseOptional = callbackService.send(wizardPage.getCallBackURLMidEvent(),
-            wizardPage.getRetriesTimeoutMidEvent(),
             caseEvent,
             caseDetailsBefore,
             caseDetails, false);

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/callbacks/CallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/callbacks/CallbackServiceTest.java
@@ -90,7 +90,7 @@ public class CallbackServiceTest {
         stubFor(post(urlMatching("/test-callback.*"))
             .willReturn(okJson(mapper.writeValueAsString(callbackResponse)).withStatus(200)));
 
-        final Optional<CallbackResponse> result = callbackService.send(testUrl, null, caseEvent, null, caseDetails, false);
+        final Optional<CallbackResponse> result = callbackService.send(testUrl, caseEvent, null, caseDetails, false);
         final CallbackResponse response = result.orElseThrow(() -> new AssertionError("Missing result"));
 
         assertTrue(response.getErrors().isEmpty());
@@ -114,7 +114,7 @@ public class CallbackServiceTest {
         stubFor(post(urlMatching("/test-callback.*"))
             .willReturn(okJson(mapper.writeValueAsString(callbackResponse)).withStatus(200).withFixedDelay(1500)));
 
-        final Optional<CallbackResponse> result = callbackService.send(testUrl, null, caseEvent, null, caseDetails, false);
+        final Optional<CallbackResponse> result = callbackService.send(testUrl, caseEvent, null, caseDetails, false);
 
         final CallbackResponse response = result.orElseThrow(() -> new AssertionError("Missing result"));
         verify(exactly(2), postRequestedFor(urlMatching("/test-callback.*")));
@@ -138,7 +138,7 @@ public class CallbackServiceTest {
         stubFor(post(urlMatching("/test-callback.*"))
             .willReturn(okJson(mapper.writeValueAsString(callbackResponse)).withStatus(200)));
 
-        final Optional<CallbackResponse> result = callbackService.send(testUrl, null, caseEvent, null, caseDetails, false);
+        final Optional<CallbackResponse> result = callbackService.send(testUrl, caseEvent, null, caseDetails, false);
         final CallbackResponse response = result.orElseThrow(() -> new AssertionError("Missing result"));
 
         assertThat(response.getErrors(), Matchers.contains("Test message"));
@@ -151,7 +151,7 @@ public class CallbackServiceTest {
         final CaseEvent caseEvent = new CaseEvent();
         caseEvent.setId("TEST-EVENT");
 
-        callbackService.send(testUrl, null, caseEvent, null, caseDetails, false);
+        callbackService.send(testUrl, caseEvent, null, caseDetails, false);
     }
 
     @Test(expected = CallbackException.class)
@@ -165,7 +165,7 @@ public class CallbackServiceTest {
         stubFor(post(urlMatching("/test-callback.*"))
             .willReturn(okJson(mapper.writeValueAsString(callbackResponse)).withStatus(500)));
 
-        callbackService.send(testUrl, null, caseEvent, null, caseDetails, false);
+        callbackService.send(testUrl, caseEvent, null, caseDetails, false);
     }
 
     @Test
@@ -180,7 +180,7 @@ public class CallbackServiceTest {
             .willReturn(okJson(mapper.writeValueAsString(callbackResponse)).withStatus(500)));
 
         try {
-            callbackService.send(testUrl, null, caseEvent, null, caseDetails, false);
+            callbackService.send(testUrl, caseEvent, null, caseDetails, false);
         } catch (Exception e) {
         }
         verify(exactly(3), postRequestedFor(urlMatching("/test-callbackGrrrr.*")));
@@ -197,7 +197,7 @@ public class CallbackServiceTest {
         stubFor(post(urlMatching("/test-callback.*"))
             .willReturn(okJson(mapper.writeValueAsString(callbackResponse)).withStatus(401)));
 
-        callbackService.send(testUrl, null, caseEvent, null, caseDetails, false);
+        callbackService.send(testUrl, caseEvent, null, caseDetails, false);
     }
 
     @Test
@@ -249,7 +249,7 @@ public class CallbackServiceTest {
         stubFor(post(urlMatching("/test-callback-submitted.*")).willReturn(
             okJson(mapper.writeValueAsString(callbackResponse)).withStatus(201)));
 
-        final ResponseEntity<String> result = callbackService.send(testUrl, Arrays.asList(3, 5), caseEvent, null, caseDetails,
+        final ResponseEntity<String> result = callbackService.send(testUrl, caseEvent, null, caseDetails,
             String.class);
 
         assertAll(
@@ -273,7 +273,7 @@ public class CallbackServiceTest {
             okJson(mapper.writeValueAsString(callbackResponse)).withStatus(500)));
 
         try {
-            callbackService.send(testUrl, Arrays.asList(3, 5), caseEvent, null, caseDetails, String.class);
+            callbackService.send(testUrl, caseEvent, null, caseDetails, String.class);
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -289,14 +289,13 @@ public class CallbackServiceTest {
 
         // Builds a new callback service to avoid wiremock exception to get in the way
         final CallbackService underTest = new CallbackService(Mockito.mock(SecurityUtils.class),
-                                                              restTemplate,
-                                                              applicationParams);
+                                                              restTemplate);
         final CaseDetails caseDetails = new CaseDetails();
         final CaseEvent caseEvent = new CaseEvent();
         caseEvent.setId("TEST-EVENT");
 
         try {
-            underTest.send(testUrl, null, caseEvent, null, caseDetails, String.class);
+            underTest.send(testUrl, caseEvent, null, caseDetails, String.class);
         } catch (CallbackException ex) {
             assertThat(ex.getMessage(), is("Unsuccessful callback to " + testUrl));
             throw ex;

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/stdapi/CallbackInvokerTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/stdapi/CallbackInvokerTest.java
@@ -97,12 +97,7 @@ class CallbackInvokerTest {
         wizardPage.setCallBackURLMidEvent(URL_MID_EVENT);
         wizardPage.setRetriesTimeoutMidEvent(RETRIES_MID_EVENT);
 
-        doReturn(Optional.empty()).when(callbackService).send(any(), any(), same(caseEvent), same(caseDetails));
-        doReturn(Optional.empty()).when(callbackService).send(any(),
-                                                              any(),
-                                                              same(caseEvent),
-                                                              same(caseDetailsBefore),
-                                                              same(caseDetails));
+        doReturn(Optional.empty()).when(callbackService).send(any(), any(), same(caseEvent), any(), same(caseDetails), anyBoolean());
         doReturn(Optional.empty()).when(callbackService).send(any(),
                                                               any(),
                                                               same(caseEvent),
@@ -126,7 +121,7 @@ class CallbackInvokerTest {
         void shouldSendCallback() {
             callbackInvoker.invokeAboutToStartCallback(caseEvent, caseType, caseDetails, IGNORE_WARNING);
 
-            verify(callbackService).send(URL_ABOUT_TO_START, RETRIES_ABOUT_TO_START, caseEvent, caseDetails);
+            verify(callbackService).send(URL_ABOUT_TO_START, RETRIES_ABOUT_TO_START, caseEvent, null, caseDetails, false);
         }
     }
 
@@ -372,7 +367,7 @@ class CallbackInvokerTest {
                 caseDetails,
                 IGNORE_WARNINGS);
 
-            verify(callbackService).send(URL_MID_EVENT, RETRIES_MID_EVENT, caseEvent, caseDetailsBefore, caseDetails);
+            verify(callbackService).send(URL_MID_EVENT, RETRIES_MID_EVENT, caseEvent, caseDetailsBefore, caseDetails, false);
         }
     }
 
@@ -398,7 +393,9 @@ class CallbackInvokerTest {
                 when(callbackService.send(caseEvent.getCallBackURLAboutToStartEvent(),
                                           caseEvent.getRetriesTimeoutAboutToStartEvent(),
                                           caseEvent,
-                                          caseDetails)).thenReturn(Optional.of(callbackResponse));
+                                          null,
+                                          caseDetails,
+                                          false)).thenReturn(Optional.of(callbackResponse));
 
                 callbackInvoker.invokeAboutToStartCallback(caseEvent, caseType, caseDetails, TRUE);
 
@@ -422,7 +419,9 @@ class CallbackInvokerTest {
                 when(callbackService.send(caseEvent.getCallBackURLAboutToStartEvent(),
                                           caseEvent.getRetriesTimeoutAboutToStartEvent(),
                                           caseEvent,
-                                          caseDetails)).thenReturn(Optional.of(callbackResponse));
+                                          null,
+                                          caseDetails,
+                                          false)).thenReturn(Optional.of(callbackResponse));
 
                 callbackInvoker.invokeAboutToStartCallback(caseEvent, caseType, caseDetails, TRUE);
 
@@ -446,7 +445,9 @@ class CallbackInvokerTest {
                 when(callbackService.send(caseEvent.getCallBackURLAboutToStartEvent(),
                                           caseEvent.getRetriesTimeoutAboutToStartEvent(),
                                           caseEvent,
-                                          caseDetails)).thenReturn(Optional.of(callbackResponse));
+                                          null,
+                                          caseDetails,
+                                          false)).thenReturn(Optional.of(callbackResponse));
                 final Map<String, JsonNode> data = new HashMap<>();
                 callbackResponse.setData(data);
 
@@ -652,7 +653,8 @@ class CallbackInvokerTest {
                     wizardPage.getRetriesTimeoutMidEvent(),
                     caseEvent,
                     caseDetailsBefore,
-                    caseDetails)).thenReturn(Optional.of(callbackResponse));
+                    caseDetails,
+                    false)).thenReturn(Optional.of(callbackResponse));
 
                 callbackInvoker.invokeMidEventCallback(wizardPage,
                     caseType,
@@ -681,7 +683,8 @@ class CallbackInvokerTest {
                     wizardPage.getRetriesTimeoutMidEvent(),
                     caseEvent,
                     caseDetailsBefore,
-                    caseDetails)).thenReturn(Optional.of(callbackResponse));
+                    caseDetails,
+                    false)).thenReturn(Optional.of(callbackResponse));
 
                 callbackInvoker.invokeMidEventCallback(wizardPage,
                     caseType,
@@ -707,7 +710,7 @@ class CallbackInvokerTest {
                     wizardPage.getRetriesTimeoutMidEvent(),
                     caseEvent,
                     caseDetailsBefore,
-                    caseDetails)).thenReturn(Optional.of(callbackResponse));
+                    caseDetails, false)).thenReturn(Optional.of(callbackResponse));
                 final Map<String, JsonNode> data = new HashMap<>();
                 callbackResponse.setData(data);
 

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/stdapi/CallbackInvokerTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/stdapi/CallbackInvokerTest.java
@@ -48,10 +48,6 @@ class CallbackInvokerTest {
     private static final String URL_ABOUT_TO_SUBMIT = "http://about-to-submit";
     private static final String URL_AFTER_SUBMIT = "http://after-submit";
     private static final String URL_MID_EVENT = "http://mid-event";
-    private static final List<Integer> RETRIES_ABOUT_TO_START = Collections.unmodifiableList(Arrays.asList(1, 2, 3));
-    private static final List<Integer> RETRIES_ABOUT_TO_SUBMIT = Collections.unmodifiableList(Arrays.asList(4, 5, 6));
-    private static final List<Integer> RETRIES_AFTER_SUBMIT = Collections.unmodifiableList(Arrays.asList(7, 8, 9));
-    private static final List<Integer> RETRIES_MID_EVENT = Collections.unmodifiableList(Arrays.asList(10, 11, 12));
     private static final Boolean IGNORE_WARNINGS = FALSE;
 
     @Mock
@@ -85,21 +81,16 @@ class CallbackInvokerTest {
 
         caseEvent = new CaseEvent();
         caseEvent.setCallBackURLAboutToStartEvent(URL_ABOUT_TO_START);
-        caseEvent.setRetriesTimeoutAboutToStartEvent(RETRIES_ABOUT_TO_START);
         caseEvent.setCallBackURLAboutToSubmitEvent(URL_ABOUT_TO_SUBMIT);
-        caseEvent.setRetriesTimeoutURLAboutToSubmitEvent(RETRIES_ABOUT_TO_SUBMIT);
         caseEvent.setCallBackURLSubmittedEvent(URL_AFTER_SUBMIT);
-        caseEvent.setRetriesTimeoutURLSubmittedEvent(RETRIES_AFTER_SUBMIT);
         caseType = new CaseType();
         caseDetailsBefore = new CaseDetails();
         caseDetails = new CaseDetails();
         wizardPage = new WizardPage();
         wizardPage.setCallBackURLMidEvent(URL_MID_EVENT);
-        wizardPage.setRetriesTimeoutMidEvent(RETRIES_MID_EVENT);
 
-        doReturn(Optional.empty()).when(callbackService).send(any(), any(), same(caseEvent), any(), same(caseDetails), anyBoolean());
+        doReturn(Optional.empty()).when(callbackService).send(any(), same(caseEvent), any(), same(caseDetails), anyBoolean());
         doReturn(Optional.empty()).when(callbackService).send(any(),
-                                                              any(),
                                                               same(caseEvent),
                                                               same(caseDetailsBefore),
                                                               same(caseDetails),
@@ -121,7 +112,7 @@ class CallbackInvokerTest {
         void shouldSendCallback() {
             callbackInvoker.invokeAboutToStartCallback(caseEvent, caseType, caseDetails, IGNORE_WARNING);
 
-            verify(callbackService).send(URL_ABOUT_TO_START, RETRIES_ABOUT_TO_START, caseEvent, null, caseDetails, false);
+            verify(callbackService).send(URL_ABOUT_TO_START, caseEvent, null, caseDetails, false);
         }
     }
 
@@ -141,7 +132,6 @@ class CallbackInvokerTest {
                                                             IGNORE_WARNING);
 
             verify(callbackService).send(URL_ABOUT_TO_SUBMIT,
-                                         RETRIES_ABOUT_TO_SUBMIT,
                                          caseEvent,
                                          caseDetailsBefore,
                                          caseDetails,
@@ -155,7 +145,6 @@ class CallbackInvokerTest {
             final String expectedState = "uNiCORn";
             doReturn(Optional.of(mockCallbackResponse(expectedState))).when(callbackService)
                                                                       .send(any(),
-                                                                            any(),
                                                                             same(caseEvent),
                                                                             same(caseDetailsBefore),
                                                                             same(caseDetails),
@@ -168,7 +157,6 @@ class CallbackInvokerTest {
                                                             IGNORE_WARNING);
 
             verify(callbackService).send(URL_ABOUT_TO_SUBMIT,
-                                         RETRIES_ABOUT_TO_SUBMIT,
                                          caseEvent,
                                          caseDetailsBefore,
                                          caseDetails,
@@ -181,7 +169,6 @@ class CallbackInvokerTest {
         void sendCallbackAndGetNoState() {
             doReturn(Optional.of(mockCallbackResponseWithNoState())).when(callbackService)
                                                                     .send(any(),
-                                                                          any(),
                                                                           same(caseEvent),
                                                                           same(caseDetailsBefore),
                                                                           same(caseDetails),
@@ -194,7 +181,6 @@ class CallbackInvokerTest {
                                                             IGNORE_WARNING);
 
             verify(callbackService).send(URL_ABOUT_TO_SUBMIT,
-                                         RETRIES_ABOUT_TO_SUBMIT,
                                          caseEvent,
                                          caseDetailsBefore,
                                          caseDetails,
@@ -208,7 +194,6 @@ class CallbackInvokerTest {
             final String expectedState = "uNiCORn";
             doReturn(Optional.of(mockCallbackResponseWithSignificantItem(expectedState))).when(callbackService)
                                                                                          .send(any(),
-                                                                                               any(),
                                                                                                same(caseEvent),
                                                                                                same(caseDetailsBefore),
                                                                                                same(caseDetails),
@@ -222,7 +207,6 @@ class CallbackInvokerTest {
                                                             IGNORE_WARNING);
 
             verify(callbackService).send(URL_ABOUT_TO_SUBMIT,
-                                         RETRIES_ABOUT_TO_SUBMIT,
                                          caseEvent,
                                          caseDetailsBefore,
                                          caseDetails,
@@ -239,7 +223,6 @@ class CallbackInvokerTest {
             final String expectedState = "uNiCORn";
             doReturn(Optional.of(mockCallbackResponseWithSignificantItem(expectedState))).when(callbackService)
                                                                                          .send(any(),
-                                                                                               any(),
                                                                                                same(caseEvent),
                                                                                                same(caseDetailsBefore),
                                                                                                same(caseDetails),
@@ -253,7 +236,6 @@ class CallbackInvokerTest {
                                                             IGNORE_WARNING);
 
             verify(callbackService).send(URL_ABOUT_TO_SUBMIT,
-                                         RETRIES_ABOUT_TO_SUBMIT,
                                          caseEvent,
                                          caseDetailsBefore,
                                          caseDetails,
@@ -271,7 +253,6 @@ class CallbackInvokerTest {
             CallbackResponse callbackResponse = mockCallbackResponseWithIncorrectSignificantItem(expectedState);
             doReturn(Optional.of(callbackResponse)).when(callbackService)
                                                    .send(any(),
-                                                         any(),
                                                          same(caseEvent),
                                                          same(caseDetailsBefore),
                                                          same(caseDetails),
@@ -285,7 +266,6 @@ class CallbackInvokerTest {
                                                             IGNORE_WARNING);
 
             verify(callbackService).send(URL_ABOUT_TO_SUBMIT,
-                                         RETRIES_ABOUT_TO_SUBMIT,
                                          caseEvent,
                                          caseDetailsBefore,
                                          caseDetails,
@@ -345,7 +325,6 @@ class CallbackInvokerTest {
             callbackInvoker.invokeSubmittedCallback(caseEvent, caseDetailsBefore, caseDetails);
 
             verify(callbackService).send(URL_AFTER_SUBMIT,
-                                         RETRIES_AFTER_SUBMIT,
                                          caseEvent,
                                          caseDetailsBefore,
                                          caseDetails,
@@ -367,7 +346,7 @@ class CallbackInvokerTest {
                 caseDetails,
                 IGNORE_WARNINGS);
 
-            verify(callbackService).send(URL_MID_EVENT, RETRIES_MID_EVENT, caseEvent, caseDetailsBefore, caseDetails, false);
+            verify(callbackService).send(URL_MID_EVENT, caseEvent, caseDetailsBefore, caseDetails, false);
         }
     }
 
@@ -391,7 +370,6 @@ class CallbackInvokerTest {
                                                                        caseDetails.getDataClassification())).thenReturn(
                     currentDataClassification);
                 when(callbackService.send(caseEvent.getCallBackURLAboutToStartEvent(),
-                                          caseEvent.getRetriesTimeoutAboutToStartEvent(),
                                           caseEvent,
                                           null,
                                           caseDetails,
@@ -417,7 +395,6 @@ class CallbackInvokerTest {
             void validateAndDoNotSetData() {
                 final CallbackResponse callbackResponse = new CallbackResponse();
                 when(callbackService.send(caseEvent.getCallBackURLAboutToStartEvent(),
-                                          caseEvent.getRetriesTimeoutAboutToStartEvent(),
                                           caseEvent,
                                           null,
                                           caseDetails,
@@ -443,7 +420,6 @@ class CallbackInvokerTest {
             void validateAndSetDataMetError() throws ApiException {
                 final CallbackResponse callbackResponse = new CallbackResponse();
                 when(callbackService.send(caseEvent.getCallBackURLAboutToStartEvent(),
-                                          caseEvent.getRetriesTimeoutAboutToStartEvent(),
                                           caseEvent,
                                           null,
                                           caseDetails,
@@ -499,7 +475,6 @@ class CallbackInvokerTest {
                 callbackResponse.setSecurityClassification(SecurityClassification.PRIVATE);
                 callbackResponse.setDataClassification(allFieldsDataClassification);
                 when(callbackService.send(caseEvent.getCallBackURLAboutToSubmitEvent(),
-                                          caseEvent.getRetriesTimeoutURLAboutToSubmitEvent(),
                                           caseEvent,
                                           caseDetailsBefore,
                                           caseDetails,
@@ -650,7 +625,6 @@ class CallbackInvokerTest {
                 when(caseDataService.getDefaultSecurityClassifications(caseType, data, caseDetails.getDataClassification())).thenReturn(
                     currentDataClassification);
                 when(callbackService.send(wizardPage.getCallBackURLMidEvent(),
-                    wizardPage.getRetriesTimeoutMidEvent(),
                     caseEvent,
                     caseDetailsBefore,
                     caseDetails,
@@ -680,7 +654,6 @@ class CallbackInvokerTest {
             void validateAndDoNotSetData() {
                 final CallbackResponse callbackResponse = new CallbackResponse();
                 when(callbackService.send(wizardPage.getCallBackURLMidEvent(),
-                    wizardPage.getRetriesTimeoutMidEvent(),
                     caseEvent,
                     caseDetailsBefore,
                     caseDetails,
@@ -707,7 +680,6 @@ class CallbackInvokerTest {
             void validateAndSetDataMetError() throws ApiException {
                 final CallbackResponse callbackResponse = new CallbackResponse();
                 when(callbackService.send(wizardPage.getCallBackURLMidEvent(),
-                    wizardPage.getRetriesTimeoutMidEvent(),
                     caseEvent,
                     caseDetailsBefore,
                     caseDetails, false)).thenReturn(Optional.of(callbackResponse));


### PR DESCRIPTION
Added retry with default backoff of 1, 3 secs if the initial request fails. 

After the chat we had with Stuart and Mario, we decided to use the Spring Retry until the requirements here are clarified.


https://tools.hmcts.net/jira/browse/RDM-4316

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```