### PR TITLE
RDM-4358: moved test from integration to unit test to avoid hazelcast…

### DIFF
--- a/src/test/java/uk/gov/hmcts/ccd/data/definition/CaseDefinitionRepositoryWireMockNotRunningTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/data/definition/CaseDefinitionRepositoryWireMockNotRunningTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.ccd.data.definition;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.hmcts.ccd.BaseTest;
@@ -45,17 +44,6 @@ public class CaseDefinitionRepositoryWireMockNotRunningTest extends BaseTest {
             assertThrows(ServiceException.class, () -> caseDefinitionRepository.getBaseTypes());
         assertThat(exception.getMessage(),
                    startsWith("Problem getting base types definition from definition store because of "));
-    }
-
-    @Test
-    @Ignore("temporarily. Will be fixed in RDM-4358")
-    public void shouldFailToGetClassificationForUserRole() {
-        final ServiceException
-            exception =
-            assertThrows(ServiceException.class,
-                         () -> caseDefinitionRepository.getUserRoleClassifications("nor_defined"));
-        assertThat(exception.getMessage(),
-                   startsWith("Error while retrieving classification for user role nor_defined because of "));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/ccd/data/definition/DefaultCaseDefinitionRepositoryTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/data/definition/DefaultCaseDefinitionRepositoryTest.java
@@ -12,7 +12,11 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.hmcts.ccd.ApplicationParams;
 import uk.gov.hmcts.ccd.data.SecurityUtils;
+import uk.gov.hmcts.ccd.endpoint.exceptions.ServiceException;
 
+import static org.hamcrest.core.StringStartsWith.startsWith;
+import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doReturn;
@@ -54,5 +58,14 @@ public class DefaultCaseDefinitionRepositoryTest {
         HttpClientErrorException exception = new HttpClientErrorException(HttpStatus.NOT_FOUND);
         doThrow(exception).when(restTemplate).exchange(anyString(), any(), any(), any(Class.class));
         caseDefinitionRepository.getBaseTypes();
+    }
+
+    @Test
+    public void shouldFailToGetClassificationForUserRole() {
+        HttpClientErrorException httpException = new HttpClientErrorException(HttpStatus.INTERNAL_SERVER_ERROR);
+        doThrow(httpException).when(restTemplate).exchange(anyString(), any(), any(), any(Class.class));
+
+        ServiceException exception = assertThrows(ServiceException.class, () -> caseDefinitionRepository.getUserRoleClassifications("nor_defined"));
+        assertThat(exception.getMessage(), startsWith("Error while retrieving classification for user role nor_defined because of "));
     }
 }


### PR DESCRIPTION
… error

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
