### PR TITLE
RDM 4372 Fix for error when complex type contains collections

### DIFF
--- a/src/main/java/uk/gov/hmcts/ccd/domain/model/aggregated/CaseViewFieldBuilder.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/model/aggregated/CaseViewFieldBuilder.java
@@ -58,7 +58,7 @@ public class CaseViewFieldBuilder {
 
     private static void fillEmptyNestedFieldACLs(CaseField field, List<AccessControlList> acls) {
         if (field.getFieldType().getType().equalsIgnoreCase(COMPLEX) || field.getFieldType().getType().equalsIgnoreCase(COLLECTION)) {
-            field.getFieldType().getComplexFields().forEach(nestedField -> {
+            field.getFieldType().getChildren().forEach(nestedField -> {
                 if (nestedField.getAccessControlLists() == null || nestedField.getAccessControlLists().isEmpty()) {
                     nestedField.setAccessControlLists(acls);
                 }

--- a/src/main/java/uk/gov/hmcts/ccd/domain/model/aggregated/CaseViewFieldBuilder.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/model/aggregated/CaseViewFieldBuilder.java
@@ -1,5 +1,8 @@
 package uk.gov.hmcts.ccd.domain.model.aggregated;
 
+import uk.gov.hmcts.ccd.domain.model.definition.CaseEventField;
+import uk.gov.hmcts.ccd.domain.model.definition.CaseField;
+
 import javax.inject.Named;
 import javax.inject.Singleton;
 import java.util.List;
@@ -8,12 +11,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static java.util.Optional.ofNullable;
-import static uk.gov.hmcts.ccd.domain.model.definition.FieldType.COLLECTION;
-import static uk.gov.hmcts.ccd.domain.model.definition.FieldType.COMPLEX;
-
-import uk.gov.hmcts.ccd.domain.model.definition.AccessControlList;
-import uk.gov.hmcts.ccd.domain.model.definition.CaseEventField;
-import uk.gov.hmcts.ccd.domain.model.definition.CaseField;
 
 @Named
 @Singleton
@@ -34,7 +31,8 @@ public class CaseViewFieldBuilder {
         field.setShowSummaryChangeOption(eventField.getShowSummaryChangeOption());
         field.setShowSummaryContentOption(eventField.getShowSummaryContentOption());
         field.setAccessControlLists(caseField.getAccessControlLists());
-        fillEmptyNestedFieldACLs(caseField, caseField.getAccessControlLists());
+
+        caseField.propagateACLsToNestedFields();
 
         return field;
     }
@@ -54,16 +52,5 @@ public class CaseViewFieldBuilder {
             .filter(eventField -> caseFieldMap.containsKey(eventField.getCaseFieldId()))
             .map(eventField -> build(caseFieldMap.get(eventField.getCaseFieldId()), eventField, data != null ? data.get(eventField.getCaseFieldId()) : null))
             .collect(Collectors.toList());
-    }
-
-    private static void fillEmptyNestedFieldACLs(CaseField field, List<AccessControlList> acls) {
-        if (field.getFieldType().getType().equalsIgnoreCase(COMPLEX) || field.getFieldType().getType().equalsIgnoreCase(COLLECTION)) {
-            field.getFieldType().getChildren().forEach(nestedField -> {
-                if (nestedField.getAccessControlLists() == null || nestedField.getAccessControlLists().isEmpty()) {
-                    nestedField.setAccessControlLists(acls);
-                }
-                fillEmptyNestedFieldACLs(nestedField, acls);
-            });
-        }
     }
 }

--- a/src/main/java/uk/gov/hmcts/ccd/domain/model/definition/FieldType.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/model/definition/FieldType.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.ccd.domain.model.definition;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
@@ -79,6 +80,7 @@ public class FieldType implements Serializable {
         this.complexFields = complexFields;
     }
 
+    @JsonIgnore
     public List<CaseField> getChildren() {
         if (type.equalsIgnoreCase(COMPLEX)) {
             return complexFields;

--- a/src/main/java/uk/gov/hmcts/ccd/domain/model/definition/FieldType.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/model/definition/FieldType.java
@@ -1,12 +1,14 @@
 package uk.gov.hmcts.ccd.domain.model.definition;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import static java.util.Collections.emptyList;
 
 public class FieldType implements Serializable {
 
@@ -75,6 +77,19 @@ public class FieldType implements Serializable {
 
     public void setComplexFields(List<CaseField> complexFields) {
         this.complexFields = complexFields;
+    }
+
+    public List<CaseField> getChildren() {
+        if (type.equalsIgnoreCase(COMPLEX)) {
+            return complexFields;
+        } else if (type.equalsIgnoreCase(COLLECTION)) {
+            if (collectionFieldType == null) {
+                return emptyList();
+            }
+            return collectionFieldType.complexFields;
+        } else {
+            return emptyList();
+        }
     }
 
     public String getId() {

--- a/src/test/java/uk/gov/hmcts/ccd/domain/model/aggregated/CaseViewFieldBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/model/aggregated/CaseViewFieldBuilderTest.java
@@ -289,5 +289,15 @@ public class CaseViewFieldBuilderTest {
             );
 
         }
+
+        @Test
+        @DisplayName("should propagateACLsToNestedFields to fix ACLs of the children")
+        void callsPropagateACLsToNestedFields() {
+            CaseField caseFieldMock = mock(CaseField.class);
+
+            fieldBuilder.build(caseFieldMock, EVENT_FIELD);
+
+            verify(caseFieldMock).propagateACLsToNestedFields();
+        }
     }
 }

--- a/src/test/java/uk/gov/hmcts/ccd/domain/model/aggregated/CaseViewFieldBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/model/aggregated/CaseViewFieldBuilderTest.java
@@ -277,10 +277,13 @@ public class CaseViewFieldBuilderTest {
                 () -> assertNotNull(caseViewField),
                 () -> assertThat(caseViewField.getAccessControlLists().size(), is(3)),
                 () -> assertThat(caseViewField.getFieldType().getComplexFields().get(0).getAccessControlLists().size(), is(3)),
-                () -> assertThat(caseViewField.getFieldType().getComplexFields().get(0).getFieldType().getCollectionFieldType().getComplexFields().get(0).getAccessControlLists().size(), is(3)),
-                () -> assertThat(caseViewField.getFieldType().getComplexFields().get(1).getFieldType().getCollectionFieldType().getComplexFields().get(0).getAccessControlLists().size(), is(3)),
+                () -> assertThat(caseViewField.getFieldType().getComplexFields().get(0).getFieldType().getCollectionFieldType().getComplexFields().get(0)
+                    .getAccessControlLists().size(), is(3)),
+                () -> assertThat(caseViewField.getFieldType().getComplexFields().get(1).getFieldType().getCollectionFieldType().getComplexFields().get(0)
+                    .getAccessControlLists().size(), is(3)),
                 () -> assertThat(caseViewField.getFieldType().getComplexFields().get(2).getAccessControlLists().size(), is(3)),
-                () -> assertThat(caseViewField.getFieldType().getComplexFields().get(1).getFieldType().getCollectionFieldType().getComplexFields().get(0).getAccessControlLists().size(), is(3)),
+                () -> assertThat(caseViewField.getFieldType().getComplexFields().get(1).getFieldType().getCollectionFieldType().getComplexFields().get(0)
+                    .getAccessControlLists().size(), is(3)),
                 () -> assertThat(caseViewField.getFieldType().getComplexFields().get(2).getFieldType().getComplexFields().get(0).getAccessControlLists().size(), is(3)),
                 () -> assertThat(caseViewField.getFieldType().getComplexFields().get(2).getFieldType().getComplexFields().get(1).getAccessControlLists().size(), is(3))
             );

--- a/src/test/java/uk/gov/hmcts/ccd/domain/model/aggregated/CaseViewFieldBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/model/aggregated/CaseViewFieldBuilderTest.java
@@ -250,10 +250,14 @@ public class CaseViewFieldBuilderTest {
         private CaseField address = newCaseField().withId(ADDRESS).withFieldType(addressFieldType).build();
 
         private CaseField familyName = newCaseField().withId(FAMILY_NAME).withFieldType(aFieldType().withId(TEXT_TYPE).withType(TEXT_TYPE).build()).build();
+        private FieldType nameFieldType =
+            aFieldType().withId(NAME + "-some-uid-value").withType(COLLECTION).withCollectionField(familyName).build();
+        private CaseField familyNames = newCaseField().withId(FAMILY_NAME).withFieldType(nameFieldType).build();
 
         // A complex family field formed of members collection of complex person - text name, text surname and yesNo adult fields,
         // family name(text) and an address (complex address type - collection of text address lines and a text postCode)
-        private FieldType familyFieldType = aFieldType().withId(FAMILY).withType(COMPLEX).withComplexField(familyName).withComplexField(members).withComplexField(address).build();
+        private FieldType familyFieldType =
+            aFieldType().withId(FAMILY).withType(COMPLEX).withComplexField(familyNames).withComplexField(members).withComplexField(address).build();
         private AccessControlList acl1 = anAcl().withRole("role1").withCreate(true).withRead(true).withUpdate(true).withDelete(false).build();
         private AccessControlList acl2 = anAcl().withRole("role2").withCreate(true).withRead(true).withUpdate(false).withDelete(true).build();
         private AccessControlList acl3 = anAcl().withRole("role3").withCreate(false).withRead(false).withUpdate(true).withDelete(false).build();
@@ -267,18 +271,16 @@ public class CaseViewFieldBuilderTest {
         @Test
         @DisplayName("should pass ACLs to the children")
         void createFrom() {
-            Map<String, String> data = new HashMap<>();
-            data.put(FAMILY, "{ \"Name\": \"Some Name\"}");
-
             CaseViewField caseViewField = fieldBuilder.build(family, EVENT_FIELD);
 
             assertAll(
                 () -> assertNotNull(caseViewField),
                 () -> assertThat(caseViewField.getAccessControlLists().size(), is(3)),
                 () -> assertThat(caseViewField.getFieldType().getComplexFields().get(0).getAccessControlLists().size(), is(3)),
-                () -> assertThat(caseViewField.getFieldType().getComplexFields().get(1).getAccessControlLists().size(), is(3)),
+                () -> assertThat(caseViewField.getFieldType().getComplexFields().get(0).getFieldType().getCollectionFieldType().getComplexFields().get(0).getAccessControlLists().size(), is(3)),
+                () -> assertThat(caseViewField.getFieldType().getComplexFields().get(1).getFieldType().getCollectionFieldType().getComplexFields().get(0).getAccessControlLists().size(), is(3)),
                 () -> assertThat(caseViewField.getFieldType().getComplexFields().get(2).getAccessControlLists().size(), is(3)),
-                () -> assertThat(caseViewField.getFieldType().getComplexFields().get(1).getFieldType().getComplexFields().get(0).getAccessControlLists().size(), is(3)),
+                () -> assertThat(caseViewField.getFieldType().getComplexFields().get(1).getFieldType().getCollectionFieldType().getComplexFields().get(0).getAccessControlLists().size(), is(3)),
                 () -> assertThat(caseViewField.getFieldType().getComplexFields().get(2).getFieldType().getComplexFields().get(0).getAccessControlLists().size(), is(3)),
                 () -> assertThat(caseViewField.getFieldType().getComplexFields().get(2).getFieldType().getComplexFields().get(1).getAccessControlLists().size(), is(3))
             );

--- a/src/test/java/uk/gov/hmcts/ccd/domain/model/definition/CaseFieldTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/model/definition/CaseFieldTest.java
@@ -1,0 +1,81 @@
+package uk.gov.hmcts.ccd.domain.model.definition;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static uk.gov.hmcts.ccd.domain.model.definition.FieldType.COLLECTION;
+import static uk.gov.hmcts.ccd.domain.model.definition.FieldType.COMPLEX;
+import static uk.gov.hmcts.ccd.domain.service.common.TestBuildersUtil.AccessControlListBuilder.anAcl;
+import static uk.gov.hmcts.ccd.domain.service.common.TestBuildersUtil.CaseFieldBuilder.newCaseField;
+import static uk.gov.hmcts.ccd.domain.service.common.TestBuildersUtil.FieldTypeBuilder.aFieldType;
+
+class CaseFieldTest {
+
+    private static final String TEXT_TYPE = "Text";
+    private static final String FAMILY = "Family";
+    private static final String MEMBERS = "Members";
+    private static final String PERSON = "Person";
+    private static final String NAME = "Name";
+    private static final String SURNAME = "Surname";
+    private static final String FAMILY_NAME = "Family Name";
+
+    private CaseField name = newCaseField().withId(NAME).withFieldType(aFieldType().withId(TEXT_TYPE).withType(TEXT_TYPE).build()).build();
+    private CaseField surname = newCaseField().withId(SURNAME).withFieldType(aFieldType().withId(TEXT_TYPE).withType(TEXT_TYPE).build()).build();
+    private FieldType personFieldType = aFieldType().withId(PERSON).withType(COMPLEX).withComplexField(name).withComplexField(surname).build();
+    private CaseField person = newCaseField().withId(PERSON).withFieldType(personFieldType).build();
+
+    private FieldType membersFieldType = aFieldType().withId(MEMBERS + "-some-uid-value").withType(COLLECTION).withCollectionField(person).build();
+    private CaseField members = newCaseField().withId(MEMBERS).withFieldType(membersFieldType).build();
+
+    private CaseField familyName = newCaseField().withId(FAMILY_NAME).withFieldType(aFieldType().withId(TEXT_TYPE).withType(TEXT_TYPE).build()).build();
+    private FieldType nameFieldType =
+        aFieldType().withId(NAME + "-some-uid-value").withType(COLLECTION).withCollectionField(familyName).build();
+    private CaseField familyNames = newCaseField().withId(FAMILY_NAME).withFieldType(nameFieldType).build();
+
+    private FieldType familyFieldType =
+        aFieldType().withId(FAMILY).withType(COMPLEX).withComplexField(familyNames).withComplexField(members).build();
+    private AccessControlList acl1 = anAcl().withRole("role1").withCreate(true).withRead(true).withUpdate(true).withDelete(false).build();
+    private AccessControlList acl2 = anAcl().withRole("role2").withCreate(true).withRead(true).withUpdate(false).withDelete(true).build();
+    private AccessControlList acl3 = anAcl().withRole("role3").withCreate(false).withRead(false).withUpdate(true).withDelete(false).build();
+    private CaseField family = newCaseField().withId(FAMILY).withFieldType(familyFieldType).withAcl(acl1).withAcl(acl2).withAcl(acl3).build();
+
+    @Nested
+    @DisplayName("propagateACLsToNestedFields test")
+    class CaseFieldSetChildrenACLsTest {
+
+        @Test
+        void propagateACLsToNestedFields() {
+
+            family.propagateACLsToNestedFields();
+
+            CaseField familyNames = family.getFieldType().getChildren().stream()
+                .filter(e -> e.getId().equals(FAMILY_NAME)).findFirst().get();
+            CaseField familyName = familyNames.getFieldType().getChildren().stream()
+                .filter(e -> e.getId().equals(FAMILY_NAME)).findFirst().get();
+
+            CaseField members = family.getFieldType().getChildren().stream()
+                .filter(e -> e.getId().equals(MEMBERS)).findFirst().get();
+            CaseField person = members.getFieldType().getChildren().stream()
+                .filter(e -> e.getId().equals(PERSON)).findFirst().get();
+
+            CaseField name = person.getFieldType().getChildren().stream()
+                .filter(e -> e.getId().equals(NAME)).findFirst().get();
+            CaseField surname = person.getFieldType().getChildren().stream()
+                .filter(e -> e.getId().equals(SURNAME)).findFirst().get();
+
+            assertAll(
+                () -> assertThat(family.getAccessControlLists().size(), is(3)),
+                () -> assertThat(familyName.getAccessControlLists().size(), is(3)),
+                () -> assertThat(familyNames.getAccessControlLists().size(), is(3)),
+                () -> assertThat(members.getAccessControlLists().size(), is(3)),
+                () -> assertThat(person.getAccessControlLists().size(), is(3)),
+                () -> assertThat(name.getAccessControlLists().size(), is(3)),
+                () -> assertThat(surname.getAccessControlLists().size(), is(3)));
+        }
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/ccd/domain/model/definition/FieldTypeTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/model/definition/FieldTypeTest.java
@@ -1,0 +1,71 @@
+package uk.gov.hmcts.ccd.domain.model.definition;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+class FieldTypeTest {
+
+    @Test
+    void getChildrenOfTextType() {
+        FieldType fieldType = new FieldType();
+        fieldType.setType("Text");
+
+        List<CaseField> children = fieldType.getChildren();
+
+        assertThat(children, is(emptyList()));
+    }
+
+    @Test
+    void getChildrenOfCollectionType() {
+        CaseField caseField1 = new CaseField();
+        caseField1.setId("caseField1");
+        CaseField caseField2 = new CaseField();
+        caseField2.setId("caseField2");
+
+        FieldType collectionFieldType = new FieldType();
+        collectionFieldType.setComplexFields(asList(caseField1, caseField2));
+        FieldType fieldType = new FieldType();
+        fieldType.setType("Collection");
+        fieldType.setCollectionFieldType(collectionFieldType);
+
+        List<CaseField> children = fieldType.getChildren();
+
+        assertThat(children.size(), is(2));
+        assertTrue(children.stream().anyMatch(e -> e.getId().equals(caseField1.getId())));
+        assertTrue(children.stream().anyMatch(e -> e.getId().equals(caseField2.getId())));
+    }
+
+    @Test
+    void getChildrenOfInvalidCollectionType() {
+        FieldType fieldType = new FieldType();
+        fieldType.setType("Collection");
+
+        List<CaseField> children = fieldType.getChildren();
+
+        assertThat(children, is(emptyList()));
+    }
+
+    @Test
+    void getChildrenOfComplexType() {
+        CaseField caseField1 = new CaseField();
+        caseField1.setId("caseField1");
+        CaseField caseField2 = new CaseField();
+        caseField2.setId("caseField2");
+        FieldType fieldType = new FieldType();
+        fieldType.setType("Complex");
+        fieldType.setComplexFields(asList(caseField1, caseField2));
+
+        List<CaseField> children = fieldType.getChildren();
+
+        assertThat(children.size(), is(2));
+        assertTrue(children.stream().anyMatch(e -> e.getId().equals(caseField1.getId())));
+        assertTrue(children.stream().anyMatch(e -> e.getId().equals(caseField2.getId())));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/ccd/domain/model/definition/FieldTypeTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/model/definition/FieldTypeTest.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.ccd.domain.model.definition;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -10,62 +12,67 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-class FieldTypeTest {
+public class FieldTypeTest {
 
-    @Test
-    void getChildrenOfTextType() {
-        FieldType fieldType = new FieldType();
-        fieldType.setType("Text");
+    @Nested
+    @DisplayName("getChildren test")
+    class FieldTypeGetChildrenTest {
 
-        List<CaseField> children = fieldType.getChildren();
+        @Test
+        public void getChildrenOfTextType() {
+            FieldType fieldType = new FieldType();
+            fieldType.setType("Text");
 
-        assertThat(children, is(emptyList()));
-    }
+            List<CaseField> children = fieldType.getChildren();
 
-    @Test
-    void getChildrenOfCollectionType() {
-        CaseField caseField1 = new CaseField();
-        caseField1.setId("caseField1");
-        CaseField caseField2 = new CaseField();
-        caseField2.setId("caseField2");
+            assertThat(children, is(emptyList()));
+        }
 
-        FieldType collectionFieldType = new FieldType();
-        collectionFieldType.setComplexFields(asList(caseField1, caseField2));
-        FieldType fieldType = new FieldType();
-        fieldType.setType("Collection");
-        fieldType.setCollectionFieldType(collectionFieldType);
+        @Test
+        public void getChildrenOfCollectionType() {
+            CaseField caseField1 = new CaseField();
+            caseField1.setId("caseField1");
+            CaseField caseField2 = new CaseField();
+            caseField2.setId("caseField2");
 
-        List<CaseField> children = fieldType.getChildren();
+            FieldType collectionFieldType = new FieldType();
+            collectionFieldType.setComplexFields(asList(caseField1, caseField2));
+            FieldType fieldType = new FieldType();
+            fieldType.setType("Collection");
+            fieldType.setCollectionFieldType(collectionFieldType);
 
-        assertThat(children.size(), is(2));
-        assertTrue(children.stream().anyMatch(e -> e.getId().equals(caseField1.getId())));
-        assertTrue(children.stream().anyMatch(e -> e.getId().equals(caseField2.getId())));
-    }
+            List<CaseField> children = fieldType.getChildren();
 
-    @Test
-    void getChildrenOfInvalidCollectionType() {
-        FieldType fieldType = new FieldType();
-        fieldType.setType("Collection");
+            assertThat(children.size(), is(2));
+            assertTrue(children.stream().anyMatch(e -> e.getId().equals(caseField1.getId())));
+            assertTrue(children.stream().anyMatch(e -> e.getId().equals(caseField2.getId())));
+        }
 
-        List<CaseField> children = fieldType.getChildren();
+        @Test
+        public void getChildrenOfInvalidCollectionType() {
+            FieldType fieldType = new FieldType();
+            fieldType.setType("Collection");
 
-        assertThat(children, is(emptyList()));
-    }
+            List<CaseField> children = fieldType.getChildren();
 
-    @Test
-    void getChildrenOfComplexType() {
-        CaseField caseField1 = new CaseField();
-        caseField1.setId("caseField1");
-        CaseField caseField2 = new CaseField();
-        caseField2.setId("caseField2");
-        FieldType fieldType = new FieldType();
-        fieldType.setType("Complex");
-        fieldType.setComplexFields(asList(caseField1, caseField2));
+            assertThat(children, is(emptyList()));
+        }
 
-        List<CaseField> children = fieldType.getChildren();
+        @Test
+        public void getChildrenOfComplexType() {
+            CaseField caseField1 = new CaseField();
+            caseField1.setId("caseField1");
+            CaseField caseField2 = new CaseField();
+            caseField2.setId("caseField2");
+            FieldType fieldType = new FieldType();
+            fieldType.setType("Complex");
+            fieldType.setComplexFields(asList(caseField1, caseField2));
 
-        assertThat(children.size(), is(2));
-        assertTrue(children.stream().anyMatch(e -> e.getId().equals(caseField1.getId())));
-        assertTrue(children.stream().anyMatch(e -> e.getId().equals(caseField2.getId())));
+            List<CaseField> children = fieldType.getChildren();
+
+            assertThat(children.size(), is(2));
+            assertTrue(children.stream().anyMatch(e -> e.getId().equals(caseField1.getId())));
+            assertTrue(children.stream().anyMatch(e -> e.getId().equals(caseField2.getId())));
+        }
     }
 }

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/common/TestBuildersUtil.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/common/TestBuildersUtil.java
@@ -64,6 +64,7 @@ import java.util.function.Consumer;
 import static com.google.common.collect.Lists.newArrayList;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
+import static uk.gov.hmcts.ccd.domain.model.definition.FieldType.COMPLEX;
 
 public class TestBuildersUtil {
     private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -1004,7 +1005,8 @@ public class TestBuildersUtil {
         }
 
         public FieldTypeBuilder withCollectionField(CaseField complexField) {
-            complexFields.add(complexField);
+            fieldType.setCollectionFieldType(FieldTypeBuilder.aFieldType().withComplexField(complexField)
+                .withType(COMPLEX).build());
             return this;
         }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-4372


### Change description ###
A small change to get children when the case when a complex type contains collections.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
