### PR TITLE
Added a TF variable for setting custom webapp domain

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -95,7 +95,7 @@ module "ccd-data-store-api" {
   subscription = "${var.subscription}"
   is_frontend = false
   common_tags  = "${var.common_tags}"
-  additional_host_name = "debugparam"
+  additional_host_name = "${var.additional_host_name}"
   asp_name = "${(var.asp_name == "use_shared") ? local.sharedAppServicePlan : var.asp_name}"
   asp_rg = "${(var.asp_rg == "use_shared") ? local.sharedASPResourceGroup : var.asp_rg}"
   website_local_cache_sizeinmb = 2000

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -210,3 +210,8 @@ variable "appinsights_instrumentation_key" {
   description = "Instrumentation key of the App Insights instance this webapp should use. Module will create own App Insights resource if this is not provided"
   default = ""
 }
+
+variable "additional_host_name" {
+  description = "A custom domain name for this webapp."
+  default = ""
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Removed an invalid value for `external_host_name` and setting it via a TF variable.
This is to enable the following PR to be merged: https://github.com/hmcts/cnp-module-webapp/pull/145


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
