### PR TITLE
Revert "Lock postgresql image in Helm"

### DIFF
--- a/charts/ccd-data-store-api/values.yaml
+++ b/charts/ccd-data-store-api/values.yaml
@@ -46,5 +46,3 @@ java:
     CCD_DEFAULTPRINTURL: https://return-case-doc-ccd.nonprod.platform.hmcts.net/jurisdictions/:jid/case-types/:ctid/cases/:cid
   postgresql:
     postgresqlDatabase: ccd_data_store
-    image:
-      tag: 10.7.0-r68


### PR DESCRIPTION
This reverts commit 0ad5f6f9d85e643c54f617ca8f49c52cd4c65db5.

chart-java 2.0.5 provides a proper fix




### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```