### PR TITLE
RDM-5147 - setting MaxStatementQueryLimitInMS to default value.

### DIFF
--- a/lib/AI-Agent.xml
+++ b/lib/AI-Agent.xml
@@ -5,7 +5,8 @@
         <BuiltIn enabled="true">
             <HTTP enabled="true"/>
             <JDBC enabled="true"/>
-            <MaxStatementQueryLimitInMS>1000</MaxStatementQueryLimitInMS>
+            <!-- Set SQL query duration above which query plan is reported. Default is 10000 ms. -->
+            <MaxStatementQueryLimitInMS>10000</MaxStatementQueryLimitInMS>
         </BuiltIn>
         <Class name="uk.gov.hmcts.ccd.data.casedetails.CaseAuditEventRepository">
             <Method name="set"/>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDM-5147

### Change description ###

Set SQL query duration (MaxStatementQueryLimitInMS) above which query plan is reported. Default is 10000 ms. This should fix the error occurring on some transactions `ERROR: current transaction is aborted, commands ignored until end of transaction block ERROR:`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
