### PR TITLE
Rdm 4522 full solution

### DIFF
--- a/src/main/java/uk/gov/hmcts/ccd/ApplicationParams.java
+++ b/src/main/java/uk/gov/hmcts/ccd/ApplicationParams.java
@@ -17,7 +17,10 @@ import uk.gov.hmcts.ccd.endpoint.exceptions.ServiceException;
 @Singleton
 public class ApplicationParams {
     @Value("#{'${ccd.callback.retries}'.split(',')}")
-    private List<Integer> callbackRetries;
+    private List<Integer> callbackRetryIntervalsInSeconds;
+
+    @Value("${http.client.read.timeout}")
+    private Integer callbackReadTimeoutInMillis;
 
     @Value("${ccd.token.secret}")
     private String tokenSecret;
@@ -207,8 +210,12 @@ public class ApplicationParams {
         return tokenSecret;
     }
 
-    public List<Integer> getCallbackRetries() {
-        return callbackRetries;
+    public List<Integer> getCallbackRetryIntervalsInSeconds() {
+        return callbackRetryIntervalsInSeconds;
+    }
+
+    public Integer getCallbackReadTimeoutInMillis() {
+        return callbackReadTimeoutInMillis;
     }
 
     public String getValidDMDomain() {

--- a/src/main/java/uk/gov/hmcts/ccd/RestTemplateConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/ccd/RestTemplateConfiguration.java
@@ -49,7 +49,7 @@ class RestTemplateConfiguration {
     @Bean(name = "restTemplate")
     public RestTemplate restTemplate() {
         final RestTemplate restTemplate = new RestTemplate();
-        HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory(getHttpClient());
+        HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory(httpClient());
         requestFactory.setReadTimeout(readTimeout);
         LOG.info("readTimeout: {}", readTimeout);
         restTemplate.setRequestFactory(requestFactory);
@@ -79,7 +79,8 @@ class RestTemplateConfiguration {
         }
     }
 
-    private HttpClient getHttpClient() {
+    @Bean(name = "httpClient")
+    public HttpClient httpClient() {
         return getHttpClient(connectionTimeout);
     }
 
@@ -99,15 +100,15 @@ class RestTemplateConfiguration {
         final RequestConfig
             config =
             RequestConfig.custom()
-                         .setConnectTimeout(timeout)
-                         .setConnectionRequestTimeout(timeout)
-                         .setSocketTimeout(timeout)
-                         .build();
+                .setConnectTimeout(timeout)
+                .setConnectionRequestTimeout(timeout)
+                .setSocketTimeout(timeout)
+                .build();
 
         return HttpClientBuilder.create()
-                                .useSystemProperties()
-                                .setDefaultRequestConfig(config)
-                                .setConnectionManager(cm)
-                                .build();
+            .useSystemProperties()
+            .setDefaultRequestConfig(config)
+            .setConnectionManager(cm)
+            .build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/callbacks/CallbackService.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/callbacks/CallbackService.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.ccd.domain.service.callbacks;
 
+import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,12 +9,11 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Retryable;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
-
+import uk.gov.hmcts.ccd.ApplicationParams;
 import uk.gov.hmcts.ccd.data.SecurityUtils;
 import uk.gov.hmcts.ccd.domain.model.callbacks.CallbackRequest;
 import uk.gov.hmcts.ccd.domain.model.callbacks.CallbackResponse;
@@ -22,29 +22,71 @@ import uk.gov.hmcts.ccd.domain.model.definition.CaseEvent;
 import uk.gov.hmcts.ccd.endpoint.exceptions.ApiException;
 import uk.gov.hmcts.ccd.endpoint.exceptions.CallbackException;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
+import static java.util.Optional.ofNullable;
 import static org.springframework.util.CollectionUtils.isEmpty;
-
-// RDM-4316 discarded timeout/backoff value in case event definition until requirements are cleared
 
 @Service
 public class CallbackService {
     private static final Logger LOG = LoggerFactory.getLogger(CallbackService.class);
+    public static final int CALLBACK_RETRY_INTERVAL_MULTIPLIER = 3;
 
     private final SecurityUtils securityUtils;
     private final RestTemplate restTemplate;
+    private final List<Integer> defaultCallbackRetryIntervalsInSeconds;
+    private final Integer defaultCallbackTimeoutInMillis;
+
+    static class CallbackRetryContext {
+        private final Integer callbackRetryInterval;
+        private final Integer callbackRetryTimeout;
+
+        CallbackRetryContext(final Integer callbackRetryInterval, final Integer callbackRetryTimeout) {
+            this.callbackRetryInterval = callbackRetryInterval;
+            this.callbackRetryTimeout = callbackRetryTimeout;
+        }
+
+        Integer getCallbackRetryInterval() {
+            return callbackRetryInterval;
+        }
+
+        Integer getCallbackRetryTimeout() {
+            return callbackRetryTimeout;
+        }
+
+    }
 
     @Autowired
     public CallbackService(final SecurityUtils securityUtils,
-                           @Qualifier("restTemplate") final RestTemplate restTemplate) {
+                           @Qualifier("restTemplate") final RestTemplate restTemplate,
+                           final ApplicationParams applicationParams) {
         this.securityUtils = securityUtils;
         this.restTemplate = restTemplate;
+        this.defaultCallbackRetryIntervalsInSeconds = applicationParams.getCallbackRetryIntervalsInSeconds();
+        this.defaultCallbackTimeoutInMillis = applicationParams.getCallbackReadTimeoutInMillis();
     }
 
-    // The retry will be on seconds T=1 and T=3 if the initial call fails at T=0
-    @Retryable(value = {CallbackException.class}, maxAttempts = 3, backoff = @Backoff(delay = 1000, multiplier = 3))
     public Optional<CallbackResponse> send(final String url,
+                                           final List<Integer> callbackRetryTimeouts,
+                                           final CaseEvent caseEvent,
+                                           final CaseDetails caseDetails) {
+        return send(url, callbackRetryTimeouts, caseEvent, null, caseDetails);
+    }
+
+    public Optional<CallbackResponse> send(final String url,
+                                           final List<Integer> callbackRetryTimeouts,
+                                           final CaseEvent caseEvent,
+                                           final CaseDetails caseDetailsBefore,
+                                           final CaseDetails caseDetails) {
+
+        return send(url, callbackRetryTimeouts, caseEvent, caseDetailsBefore, caseDetails, false);
+    }
+
+    @SuppressWarnings("javasecurity:S5145")
+    public Optional<CallbackResponse> send(final String url,
+                                           final List<Integer> callbackRetryTimeouts,
                                            final CaseEvent caseEvent,
                                            final CaseDetails caseDetailsBefore,
                                            final CaseDetails caseDetails,
@@ -53,48 +95,48 @@ public class CallbackService {
         if (url == null || url.isEmpty()) {
             return Optional.empty();
         }
-        final CallbackRequest callbackRequest = new CallbackRequest(caseDetails, caseDetailsBefore, caseEvent.getId(), ignoreWarning);
-        final Optional<ResponseEntity<CallbackResponse>> responseEntity = sendRequest(url, CallbackResponse.class, callbackRequest);
-        return responseEntity.map(re -> Optional.of(re.getBody())).orElseThrow(() -> {
-            LOG.warn("Unsuccessful callback to {} for caseType {} and event {}", url, caseDetails.getCaseTypeId(), caseEvent.getId());
-            return new CallbackException("Callback to service has been unsuccessful for event " + caseEvent.getName());
-        });
+
+        final CallbackRequest callbackRequest = new CallbackRequest(caseDetails,
+            caseDetailsBefore,
+            caseEvent.getId(),
+            ignoreWarning);
+
+        List<CallbackRetryContext> retryContextList = buildCallbackRetryContexts(ofNullable(callbackRetryTimeouts).orElse(Lists.newArrayList()));
+
+        for (CallbackRetryContext retryContext : retryContextList) {
+            sleep(retryContext.getCallbackRetryInterval());
+            final Optional<ResponseEntity<CallbackResponse>> responseEntity = sendRequest(url,
+                CallbackResponse.class,
+                callbackRequest,
+                retryContext.getCallbackRetryTimeout());
+            if (responseEntity.isPresent()) {
+                return Optional.of(responseEntity.get().getBody());
+            }
+        }
+        LOG.debug("Unsuccessful callback to {} for caseType {} and event {}", url, caseDetails.getCaseTypeId(), caseEvent.getId());
+        throw new CallbackException("Unsuccessful callback to " + url);
     }
 
-    // The retry will be on seconds T=1 and T=3 if the initial call fails at T=0
-    @Retryable(value = {CallbackException.class}, maxAttempts = 3, backoff = @Backoff(delay = 1000, multiplier = 3))
     public <T> ResponseEntity<T> send(final String url,
+                                      final List<Integer> callbackRetryTimeouts,
                                       final CaseEvent caseEvent,
                                       final CaseDetails caseDetailsBefore,
                                       final CaseDetails caseDetails,
                                       final Class<T> clazz) {
 
         final CallbackRequest callbackRequest = new CallbackRequest(caseDetails, caseDetailsBefore, caseEvent.getId());
-        final Optional<ResponseEntity<T>> requestEntity = sendRequest(url, clazz, callbackRequest);
-        return requestEntity.orElseThrow(() -> {
-            LOG.warn("Unsuccessful callback to {} for caseType {} and event {}", url, caseDetails.getCaseTypeId(), caseEvent.getId());
-            return new CallbackException("Callback to service has been unsuccessful for event " + caseEvent.getName());
-        });
-    }
 
-    private <T> Optional<ResponseEntity<T>> sendRequest(final String url,
-                                                        final Class<T> clazz,
-                                                        final CallbackRequest callbackRequest) {
-        try {
-            LOG.debug("Invoking callback {}", url);
-            final HttpHeaders httpHeaders = new HttpHeaders();
-            httpHeaders.add("Content-Type", "application/json");
-            final HttpHeaders securityHeaders = securityUtils.authorizationHeaders();
-            if (null != securityHeaders) {
-                securityHeaders.forEach((key, values) -> httpHeaders.put(key, values));
+        List<CallbackRetryContext> retryContextList = buildCallbackRetryContexts(ofNullable(callbackRetryTimeouts).orElse(Lists.newArrayList()));
+
+        for (CallbackRetryContext retryContext : retryContextList) {
+            sleep(retryContext.getCallbackRetryInterval());
+            final Optional<ResponseEntity<T>> requestEntity = sendRequest(url, clazz, callbackRequest, retryContext.getCallbackRetryTimeout());
+            if (requestEntity.isPresent()) {
+                return requestEntity.get();
             }
-            final HttpEntity requestEntity = new HttpEntity(callbackRequest, httpHeaders);
-            return Optional.ofNullable(restTemplate.exchange(url, HttpMethod.POST, requestEntity, clazz));
-        } catch (RestClientException e) {
-            LOG.warn("Unable to connect to callback service {} because of {} {}", url, e.getClass().getSimpleName(), e.getMessage());
-            LOG.debug("", e);  // debug stack trace
-            return Optional.empty();
         }
+        // Sent so many requests and still got nothing, throw exception here
+        throw new CallbackException("Unsuccessful callback to " + url);
     }
 
     public void validateCallbackErrorsAndWarnings(final CallbackResponse callbackResponse,
@@ -105,5 +147,76 @@ public class CallbackService {
                 .withErrors(callbackResponse.getErrors())
                 .withWarnings(callbackResponse.getWarnings());
         }
+    }
+
+    private List<CallbackRetryContext> buildCallbackRetryContexts(final List<Integer> callbackRetryTimeouts) {
+        List<CallbackRetryContext> retryContextList = Lists.newArrayList();
+        if (!callbackRetryTimeouts.isEmpty()) {
+            retryContextList.add(new CallbackRetryContext(0, callbackRetryTimeouts.remove(0)));
+            if (!callbackRetryTimeouts.isEmpty()) {
+                retryContextList.add(new CallbackRetryContext(1, callbackRetryTimeouts.remove(0)));
+                for (int i = 0; i < callbackRetryTimeouts.size(); i++) {
+                    retryContextList.add(
+                        new CallbackRetryContext(
+                            getLastElement(retryContextList).getCallbackRetryInterval() * CALLBACK_RETRY_INTERVAL_MULTIPLIER,
+                            callbackRetryTimeouts.get(i)));
+                }
+            }
+        } else {
+            this.defaultCallbackRetryIntervalsInSeconds.forEach(cbRetryInterval -> retryContextList.add(new CallbackRetryContext(cbRetryInterval, defaultCallbackTimeoutInMillis)));
+        }
+        return retryContextList;
+    }
+
+    private CallbackRetryContext getLastElement(final List<CallbackRetryContext> retryContextList) {
+        return retryContextList.get(retryContextList.size() - 1);
+    }
+
+    @SuppressWarnings({"squid:S2139","squid:S00112"})
+    private void sleep(final Integer timeout) {
+        try {
+            TimeUnit.SECONDS.sleep((long) timeout);
+        } catch (Exception e) {
+            LOG.warn("Error while performing a sleep of timeout={}", timeout, e);
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+
+    private <T> Optional<ResponseEntity<T>> sendRequest(final String url,
+                                                        final Class<T> clazz,
+                                                        final CallbackRequest callbackRequest,
+                                                        final Integer timeout) {
+        try {
+            LOG.info("Trying {} with timeout interval {}", url, timeout);
+
+            final HttpHeaders httpHeaders = new HttpHeaders();
+            httpHeaders.add("Content-Type", "application/json");
+            final HttpHeaders securityHeaders = securityUtils.authorizationHeaders();
+            if (null != securityHeaders) {
+                securityHeaders.forEach((key, values) -> httpHeaders.put(key, values));
+            }
+            final HttpEntity requestEntity = new HttpEntity(callbackRequest, httpHeaders);
+
+            LOG.info("readTimeout: {}", timeout);
+
+            final HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory();
+            requestFactory.setReadTimeout(secondsToMilliseconds(timeout));
+            restTemplate.setRequestFactory(requestFactory);
+
+            return ofNullable(
+                restTemplate.exchange(url, HttpMethod.POST, requestEntity, clazz));
+        } catch (RestClientException e) {
+            LOG.info("Unable to connect to callback service {} because of {} {}",
+                url,
+                e.getClass().getSimpleName(),
+                e.getMessage());
+            LOG.debug("", e);  // debug stack trace
+            return Optional.empty();
+        }
+    }
+
+    private int secondsToMilliseconds(final Integer timeout) {
+        return (int) TimeUnit.SECONDS.toMillis(timeout);
     }
 }

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/callbacks/RestTemplateProvider.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/callbacks/RestTemplateProvider.java
@@ -1,0 +1,37 @@
+package uk.gov.hmcts.ccd.domain.service.callbacks;
+
+import org.apache.http.client.HttpClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+public class RestTemplateProvider {
+    private static final Logger LOG = LoggerFactory.getLogger(RestTemplateProvider.class);
+    private final HttpClient httpClient;
+
+    @Autowired
+    public RestTemplateProvider(@Qualifier("httpClient") final HttpClient httpClient) {
+        this.httpClient = httpClient;
+    }
+
+
+    public RestTemplate provide(Integer timeoutInSeconds) {
+        LOG.info("Building rest template with read timeoutInSeconds interval {}", timeoutInSeconds);
+        final HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory(httpClient);
+        requestFactory.setReadTimeout(secondsToMilliseconds(timeoutInSeconds));
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.setRequestFactory(requestFactory);
+        return restTemplate;
+    }
+
+    private int secondsToMilliseconds(final Integer timeout) {
+        return (int) TimeUnit.SECONDS.toMillis(timeout);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/stdapi/CallbackInvoker.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/stdapi/CallbackInvoker.java
@@ -72,13 +72,14 @@ public class CallbackInvoker {
                                                                      final CaseType caseType,
                                                                      final Boolean ignoreWarning) {
 
-        final Optional<CallbackResponse> callbackResponse = callbackService.send(
+        final Optional<CallbackResponse> callbackResponse = Optional.ofNullable(callbackService.send(
             eventTrigger.getCallBackURLAboutToSubmitEvent(),
             eventTrigger.getRetriesTimeoutURLAboutToSubmitEvent(),
             eventTrigger,
             caseDetailsBefore,
             caseDetails,
-            ignoreWarning);
+            CallbackResponse.class,
+            Optional.ofNullable(ignoreWarning).isPresent()).getBody());
 
         if (callbackResponse.isPresent()) {
             return validateAndSetFromAboutToSubmitCallback(caseType,
@@ -98,7 +99,8 @@ public class CallbackInvoker {
             eventTrigger,
             caseDetailsBefore,
             caseDetails,
-            AfterSubmitCallbackResponse.class);
+            AfterSubmitCallbackResponse.class,
+            false);
     }
 
     public CaseDetails invokeMidEventCallback(final WizardPage wizardPage,

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/stdapi/CallbackInvoker.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/stdapi/CallbackInvoker.java
@@ -56,12 +56,14 @@ public class CallbackInvoker {
                                            final Boolean ignoreWarning) {
         final Optional<CallbackResponse> callbackResponse = callbackService.send(
             caseEvent.getCallBackURLAboutToStartEvent(),
-            caseEvent, null, caseDetails, false);
+            caseEvent.getRetriesTimeoutAboutToStartEvent(),
+            caseEvent,
+            caseDetails);
 
         callbackResponse.ifPresent(response -> validateAndSetFromAboutToStartCallback(caseType,
-                                                                                      caseDetails,
-                                                                                      ignoreWarning,
-                                                                                      response));
+            caseDetails,
+            ignoreWarning,
+            response));
     }
 
     public AboutToSubmitCallbackResponse invokeAboutToSubmitCallback(final CaseEvent eventTrigger,
@@ -72,13 +74,17 @@ public class CallbackInvoker {
 
         final Optional<CallbackResponse> callbackResponse = callbackService.send(
             eventTrigger.getCallBackURLAboutToSubmitEvent(),
-            eventTrigger, caseDetailsBefore, caseDetails, ignoreWarning);
+            eventTrigger.getRetriesTimeoutURLAboutToSubmitEvent(),
+            eventTrigger,
+            caseDetailsBefore,
+            caseDetails,
+            ignoreWarning);
 
         if (callbackResponse.isPresent()) {
             return validateAndSetFromAboutToSubmitCallback(caseType,
-                                                           caseDetails,
-                                                           ignoreWarning,
-                                                           callbackResponse.get());
+                caseDetails,
+                ignoreWarning,
+                callbackResponse.get());
         }
 
         return new AboutToSubmitCallbackResponse();
@@ -88,10 +94,11 @@ public class CallbackInvoker {
                                                                                final CaseDetails caseDetailsBefore,
                                                                                final CaseDetails caseDetails) {
         return callbackService.send(eventTrigger.getCallBackURLSubmittedEvent(),
-                                    eventTrigger,
-                                    caseDetailsBefore,
-                                    caseDetails,
-                                    AfterSubmitCallbackResponse.class);
+            eventTrigger.getRetriesTimeoutURLSubmittedEvent(),
+            eventTrigger,
+            caseDetailsBefore,
+            caseDetails,
+            AfterSubmitCallbackResponse.class);
     }
 
     public CaseDetails invokeMidEventCallback(final WizardPage wizardPage,
@@ -102,9 +109,10 @@ public class CallbackInvoker {
                                               final Boolean ignoreWarning) {
 
         Optional<CallbackResponse> callbackResponseOptional = callbackService.send(wizardPage.getCallBackURLMidEvent(),
+            wizardPage.getRetriesTimeoutMidEvent(),
             caseEvent,
             caseDetailsBefore,
-            caseDetails, false);
+            caseDetails);
 
         if (callbackResponseOptional.isPresent()) {
             CallbackResponse callbackResponse = callbackResponseOptional.get();
@@ -142,10 +150,10 @@ public class CallbackInvoker {
             validateAndSetData(caseType, caseDetails, callbackResponse.getData());
             if (callbackResponseHasCaseAndDataClassification(callbackResponse)) {
                 securityValidationService.setClassificationFromCallbackIfValid(callbackResponse,
-                                                                               caseDetails,
-                                                                               deduceDefaultClassificationForExistingFields(
-                                                                                   caseType,
-                                                                                   caseDetails));
+                    caseDetails,
+                    deduceDefaultClassificationForExistingFields(
+                        caseType,
+                        caseDetails));
             }
             final Optional<String> newCaseState = filterCaseState(callbackResponse.getData());
             newCaseState.ifPresent(caseDetails::setState);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -50,7 +50,7 @@ ccd.user-profile.host=${USER_PROFILE_HOST:http://localhost:4453}
 ccd.token.secret=${DATA_STORE_TOKEN_SECRET:AAAAAAAAAA}
 
 #callback timeouts - comma separated integers in seconds
-ccd.callback.retries=1,5,10
+ccd.callback.retries=0, 1, 3
 
 ccd.case.search.wildcards.allowed=false
 

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/callbacks/CallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/callbacks/CallbackServiceTest.java
@@ -1,19 +1,22 @@
 package uk.gov.hmcts.ccd.domain.service.callbacks;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
-import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
-import static com.github.tomakehurst.wiremock.client.WireMock.post;
-import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
-import static com.github.tomakehurst.wiremock.client.WireMock.verify;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.BDDMockito.given;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.server.ServerErrorException;
 import uk.gov.hmcts.ccd.ApplicationParams;
 import uk.gov.hmcts.ccd.data.SecurityUtils;
 import uk.gov.hmcts.ccd.domain.model.callbacks.CallbackResponse;
@@ -25,290 +28,228 @@ import uk.gov.hmcts.ccd.endpoint.exceptions.CallbackException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import javax.inject.Inject;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static uk.gov.hmcts.ccd.domain.service.common.TestBuildersUtil.CallbackResponseBuilder.aCallbackResponse;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mockito;
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.web.client.RestTemplate;
-
-@ActiveProfiles("test")
-@RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@TestPropertySource(properties =
-    {
-        "ccd.callback.timeouts=1,2,3"
-    })
-@AutoConfigureWireMock(port = 0)
-@DirtiesContext
 public class CallbackServiceTest {
     private static final ObjectMapper mapper = new ObjectMapper();
 
-    @Inject
+    @Mock
+    private SecurityUtils securityUtils;
+    @Mock
+    private RestTemplate restTemplate;
+    @Mock
+    private ApplicationParams applicationParams;
+
     private CallbackService callbackService;
 
-    @Value("${wiremock.server.port}")
-    protected Integer wiremockPort;
+    private List<Integer> defaultCallbackRetryIntervals = Lists.newArrayList(0, 1, 3);
+    private Integer defaultCallbackReadTimeout = 1000;
+    private final String testUrl = "http://localhost:/test-callback";
+    private final CaseDetails caseDetails = new CaseDetails();
+    private final CaseEvent caseEvent = new CaseEvent();
+    private final CallbackResponse callbackResponse = aCallbackResponse().build();
+    private final ResponseEntity<CallbackResponse> response = ResponseEntity.ok(callbackResponse);
 
-    @Before
+    @BeforeEach
     public void setUp() {
-        // IDAM
-        final SecurityUtils securityUtils = Mockito.mock(SecurityUtils.class);
-        Mockito.when(securityUtils.authorizationHeaders()).thenReturn(new HttpHeaders());
-        ReflectionTestUtils.setField(callbackService, "securityUtils", securityUtils);
-    }
+        MockitoAnnotations.initMocks(this);
 
-    @Test
-    public void happyPathWithNoErrorsOrWarnings() throws Exception {
-        final String testUrl = "http://localhost:" + wiremockPort + "/test-callback";
-
-        final CaseDetails caseDetails = new CaseDetails();
         caseDetails.setState("test state");
         caseDetails.setCaseTypeId("test case type");
 
-        final CaseEvent caseEvent = new CaseEvent();
         caseEvent.setId("TEST-EVENT");
 
-        final CallbackResponse callbackResponse = new CallbackResponse();
         callbackResponse.setData(caseDetails.getData());
 
-        stubFor(post(urlMatching("/test-callback.*"))
-            .willReturn(okJson(mapper.writeValueAsString(callbackResponse)).withStatus(200)));
-
-        final Optional<CallbackResponse> result = callbackService.send(testUrl, caseEvent, null, caseDetails, false);
-        final CallbackResponse response = result.orElseThrow(() -> new AssertionError("Missing result"));
-
-        assertTrue(response.getErrors().isEmpty());
+        doReturn(new HttpHeaders()).when(securityUtils).authorizationHeaders();
+        doReturn(response).when(restTemplate).exchange(anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(CallbackResponse.class));
+        doReturn(defaultCallbackRetryIntervals).when(applicationParams).getCallbackRetryIntervalsInSeconds();
+        doReturn(defaultCallbackReadTimeout).when(applicationParams).getCallbackReadTimeoutInMillis();
+        callbackService = new CallbackService(securityUtils, restTemplate, applicationParams);
     }
 
-    @org.junit.Ignore // TODO investigating socket issues in Azure
-    @Test
-    public void shouldRetryIfCallbackRespondsLate() throws Exception {
-        final String testUrl = "http://localhost:" + wiremockPort + "/test-callback";
+    @Nested
+    @DisplayName("Default Retry Context")
+    class DefaultRetryContext {
+        @Test
+        @DisplayName("Should return with no errors or warnings")
+        public void shouldReturnWithNoErrorsOrWarnings() {
+            final Optional<CallbackResponse> result = callbackService.send(testUrl, null, caseEvent, caseDetails);
+            final CallbackResponse response = result.orElseThrow(() -> new AssertionError("Missing result"));
 
-        final CaseDetails caseDetails = new CaseDetails();
-        caseDetails.setState("test state");
-        caseDetails.setCaseTypeId("test case type");
-
-        final CaseEvent caseEvent = new CaseEvent();
-        caseEvent.setId("TEST-EVENT");
-
-        final CallbackResponse callbackResponse = new CallbackResponse();
-        callbackResponse.setData(caseDetails.getData());
-
-        stubFor(post(urlMatching("/test-callback.*"))
-            .willReturn(okJson(mapper.writeValueAsString(callbackResponse)).withStatus(200).withFixedDelay(1500)));
-
-        final Optional<CallbackResponse> result = callbackService.send(testUrl, caseEvent, null, caseDetails, false);
-
-        final CallbackResponse response = result.orElseThrow(() -> new AssertionError("Missing result"));
-        verify(exactly(2), postRequestedFor(urlMatching("/test-callback.*")));
-        assertTrue(response.getErrors().isEmpty());
-    }
-
-    @Test
-    public void failurePathWithErrors() throws Exception {
-        final String testUrl = "http://localhost:" + wiremockPort + "/test-callback";
-
-        final CaseDetails caseDetails = new CaseDetails();
-        caseDetails.setState("test state");
-        caseDetails.setCaseTypeId("test case type");
-
-        final CaseEvent caseEvent = new CaseEvent();
-        caseEvent.setId("TEST-EVENT");
-
-        final CallbackResponse callbackResponse = new CallbackResponse();
-        callbackResponse.setErrors(Collections.singletonList("Test message"));
-        callbackResponse.setData(caseDetails.getData());
-        stubFor(post(urlMatching("/test-callback.*"))
-            .willReturn(okJson(mapper.writeValueAsString(callbackResponse)).withStatus(200)));
-
-        final Optional<CallbackResponse> result = callbackService.send(testUrl, caseEvent, null, caseDetails, false);
-        final CallbackResponse response = result.orElseThrow(() -> new AssertionError("Missing result"));
-
-        assertThat(response.getErrors(), Matchers.contains("Test message"));
-    }
-
-    @Test(expected = CallbackException.class)
-    public void notFoundFailurePath() throws Exception {
-        final String testUrl = "http://localhost";
-        final CaseDetails caseDetails = new CaseDetails();
-        final CaseEvent caseEvent = new CaseEvent();
-        caseEvent.setId("TEST-EVENT");
-
-        callbackService.send(testUrl, caseEvent, null, caseDetails, false);
-    }
-
-    @Test(expected = CallbackException.class)
-    public void serverError() throws Exception {
-        final String testUrl = "http://localhost:" + wiremockPort + "/test-callback";
-        final CallbackResponse callbackResponse = new CallbackResponse();
-        final CaseDetails caseDetails = new CaseDetails();
-        final CaseEvent caseEvent = new CaseEvent();
-        caseEvent.setId("TEST-EVENT");
-
-        stubFor(post(urlMatching("/test-callback.*"))
-            .willReturn(okJson(mapper.writeValueAsString(callbackResponse)).withStatus(500)));
-
-        callbackService.send(testUrl, caseEvent, null, caseDetails, false);
-    }
-
-    @Test
-    public void retryOnServerError() throws Exception {
-        final String testUrl = "http://localhost:" + wiremockPort + "/test-callbackGrrrr";
-        final CallbackResponse callbackResponse = new CallbackResponse();
-        final CaseDetails caseDetails = new CaseDetails();
-        final CaseEvent caseEvent = new CaseEvent();
-        caseEvent.setId("TEST-EVENT");
-
-        stubFor(post(urlMatching("/test-callbackGrrrr.*"))
-            .willReturn(okJson(mapper.writeValueAsString(callbackResponse)).withStatus(500)));
-
-        Instant start = Instant.now();
-        try {
-            callbackService.send(testUrl, caseEvent, null, caseDetails, false);
-        } catch (Exception e) {
+            Assertions.assertAll(
+                () -> assertTrue(response.getErrors().isEmpty()),
+                () -> verify(restTemplate).setRequestFactory(any(HttpComponentsClientHttpRequestFactory.class)),
+                () -> verify(restTemplate).exchange(anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(CallbackResponse.class)),
+                () -> verifyNoMoreInteractions(restTemplate)
+            );
         }
-        final Duration between = Duration.between(start, Instant.now());
-        assertThat((int) between.toMillis(), greaterThan(4000));
-        verify(exactly(3), postRequestedFor(urlMatching("/test-callbackGrrrr.*")));
+
+        @Test
+        @DisplayName("Should retry if callback responds late")
+        public void shouldRetryIfCallbackRespondsLate() {
+            doThrow(RestClientException.class)
+                .doThrow(RestClientException.class)
+                .doReturn(response)
+                .when(restTemplate).exchange(anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(CallbackResponse.class));
+
+            Instant start = Instant.now();
+            callbackService.send(testUrl, null, caseEvent, caseDetails);
+
+            final Duration between = Duration.between(start, Instant.now());
+            Assertions.assertAll(
+                () -> verify(restTemplate, times(3)).setRequestFactory(any(HttpComponentsClientHttpRequestFactory.class)),
+                () -> verify(restTemplate, times(3)).exchange(anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(CallbackResponse.class)),
+                () -> verifyNoMoreInteractions(restTemplate),
+                () -> assertThat((int) between.toMillis(), greaterThan(4000))
+            );
+        }
     }
 
-    @Test(expected = CallbackException.class)
-    public void authorisationError() throws Exception {
-        final String testUrl = "http://localhost:" + wiremockPort + "/test-callback";
-        final CallbackResponse callbackResponse = new CallbackResponse();
-        final CaseDetails caseDetails = new CaseDetails();
-        final CaseEvent caseEvent = new CaseEvent();
-        caseEvent.setId("TEST-EVENT");
+    @Nested
+    @DisplayName("Custom Retry Context")
+    class CustomRetryContext {
 
-        stubFor(post(urlMatching("/test-callback.*"))
-            .willReturn(okJson(mapper.writeValueAsString(callbackResponse)).withStatus(401)));
+        @Test
+        @DisplayName("Should return with no errors or warnings and no retries configured")
+        public void shouldReturnWithNoRetriesConfigured() {
+            final Optional<CallbackResponse> result = callbackService.send(testUrl, Lists.newArrayList(500), caseEvent, caseDetails);
+            final CallbackResponse response = result.orElseThrow(() -> new AssertionError("Missing result"));
 
-        callbackService.send(testUrl, caseEvent, null, caseDetails, false);
+            Assertions.assertAll(
+                () -> assertTrue(response.getErrors().isEmpty()),
+                () -> assertTrue(response.getWarnings().isEmpty()),
+                () -> verify(restTemplate).setRequestFactory(any(HttpComponentsClientHttpRequestFactory.class)),
+                () -> verify(restTemplate).exchange(anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(CallbackResponse.class)),
+                () -> verifyNoMoreInteractions(restTemplate)
+            );
+        }
+
+        @Test
+        @DisplayName("Should return with no errors or warnings and callback respond on second try")
+        public void shouldReturnWithOneRetries() {
+            doThrow(RestClientException.class)
+                .doReturn(response)
+                .when(restTemplate).exchange(anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(CallbackResponse.class));
+
+            final Optional<CallbackResponse> result = callbackService.send(testUrl, Lists.newArrayList(500, 1000), caseEvent, caseDetails);
+            final CallbackResponse response = result.orElseThrow(() -> new AssertionError("Missing result"));
+
+            Assertions.assertAll(
+                () -> assertTrue(response.getErrors().isEmpty()),
+                () -> assertTrue(response.getWarnings().isEmpty()),
+                () -> verify(restTemplate, times(2)).setRequestFactory(any(HttpComponentsClientHttpRequestFactory.class)),
+                () -> verify(restTemplate, times(2)).exchange(anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(CallbackResponse.class)),
+                () -> verifyNoMoreInteractions(restTemplate)
+            );
+        }
+
+        @Test
+        @DisplayName("Should return with no errors or warnings and callback respond on third retry")
+        public void shouldRetryIfCallbackRespondsAfterTwoRetries() {
+            doThrow(RestClientException.class)
+                .doThrow(RestClientException.class)
+                .doReturn(response)
+                .when(restTemplate).exchange(anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(CallbackResponse.class));
+
+            final Optional<CallbackResponse> result = callbackService.send(testUrl, Lists.newArrayList(500, 1000, 1500), caseEvent, caseDetails);
+            final CallbackResponse response = result.orElseThrow(() -> new AssertionError("Missing result"));
+
+            Assertions.assertAll(
+                () -> assertTrue(response.getErrors().isEmpty()),
+                () -> assertTrue(response.getWarnings().isEmpty()),
+                () -> verify(restTemplate, times(3)).setRequestFactory(any(HttpComponentsClientHttpRequestFactory.class)),
+                () -> verify(restTemplate, times(3)).exchange(anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(CallbackResponse.class)),
+                () -> verifyNoMoreInteractions(restTemplate)
+            );
+        }
     }
 
     @Test
-    public void validateCallbackErrorsAndWarningsHappyPath() throws Exception {
-        final CallbackResponse callbackResponse = new CallbackResponse();
+    public void shouldReturnWithErrorsOrWarningsIfExist() {
+        callbackResponse.setErrors(Collections.singletonList("Test message"));
+
+        final Optional<CallbackResponse> result = callbackService.send(testUrl, null, caseEvent, caseDetails);
+
+        final CallbackResponse response = result.orElseThrow(() -> new AssertionError("Missing result"));
+
+        assertThat(response.getErrors(), contains("Test message"));
+    }
+
+    @Test
+    public void shouldFailIfCallbackCallFailsForeverWithRestClientException() {
+        doThrow(RestClientException.class)
+            .when(restTemplate).exchange(anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(CallbackResponse.class));
+
+        CallbackException callbackException = assertThrows(CallbackException.class, () -> callbackService.send(testUrl, null, caseEvent, caseDetails));
+        assertThat(callbackException.getMessage(), is(equalTo("Unsuccessful callback to http://localhost:/test-callback")));
+    }
+
+    @Test
+    public void shouldFailIfCallbackCallFailsFirstTimeWithNonRestClientException() {
+        doThrow(ServerErrorException.class)
+            .doReturn(response)
+            .when(restTemplate).exchange(anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(CallbackResponse.class));
+
+        assertThrows(ServerErrorException.class, () -> callbackService.send(testUrl, null, caseEvent, caseDetails));
+    }
+
+    @Test
+    public void shouldPassValidationIfNoCallbackErrorsAndWarnings()  {
         callbackService.validateCallbackErrorsAndWarnings(callbackResponse, false);
     }
 
-    @Test(expected = ApiException.class)
-    public void validateCallbackErrorsAndWarningsWithWarnings() throws Exception {
+    @Test
+    public void shouldFailValidationIfWarningsAndDoNotIgnoreWarnings() {
         final String TEST_WARNING_1 = "WARNING 1";
         final String TEST_WARNING_2 = "WARNING 2";
 
-        final CallbackResponse callbackResponse = new CallbackResponse();
         final List<String> warnings = new ArrayList<>();
         warnings.add(TEST_WARNING_1);
         warnings.add(TEST_WARNING_2);
-
         callbackResponse.setWarnings(warnings);
-        callbackService.validateCallbackErrorsAndWarnings(callbackResponse, false);
+
+        ApiException apiException = assertThrows(ApiException.class, () -> callbackService.validateCallbackErrorsAndWarnings(callbackResponse, false));
+        assertThat(apiException.getMessage(), is(equalTo("Unable to proceed because there are one or more callback Errors or Warnings")));
     }
 
-    @Test(expected = ApiException.class)
-    public void validateCallbackErrorsAndWarningsWithErrorsAndIgnore() throws Exception {
+    @Test
+    public void shouldPassValidationIfWarningsAndIgnoreWarnings() {
+        final String TEST_WARNING_1 = "WARNING 1";
+        final String TEST_WARNING_2 = "WARNING 2";
+
+        final List<String> warnings = new ArrayList<>();
+        warnings.add(TEST_WARNING_1);
+        warnings.add(TEST_WARNING_2);
+        callbackResponse.setWarnings(warnings);
+
+        callbackService.validateCallbackErrorsAndWarnings(callbackResponse, true);
+    }
+
+    @Test
+    public void shouldFailValidationIfErrorsAndIgnoreWarnings() {
         final CallbackResponse callbackResponse = new CallbackResponse();
         callbackResponse.setErrors(Collections.singletonList("an error"));
-        callbackResponse.setWarnings(Collections.singletonList("a warning"));
-        callbackService.validateCallbackErrorsAndWarnings(callbackResponse, true);
-    }
-
-    @Test
-    public void validateCallbackErrorsAndWarningsWithWarningsAndIgnore() throws Exception {
-        final CallbackResponse callbackResponse = new CallbackResponse();
-        callbackService.validateCallbackErrorsAndWarnings(callbackResponse, true);
-
-        final List<String> warnings = Collections.singletonList("Test");
-        callbackResponse.setWarnings(warnings);
-        callbackService.validateCallbackErrorsAndWarnings(callbackResponse, true);
-    }
-
-    @Test
-    public void shouldGetBodyInGeneric() throws Exception {
-        final String testUrl = "http://localhost:" + wiremockPort + "/test-callback-submitted";
-        final CallbackResponse callbackResponse = new CallbackResponse();
-        final CaseDetails caseDetails = new CaseDetails();
-        final CaseEvent caseEvent = new CaseEvent();
-        caseEvent.setId("TEST-EVENT");
-
-        stubFor(post(urlMatching("/test-callback-submitted.*")).willReturn(
-            okJson(mapper.writeValueAsString(callbackResponse)).withStatus(201)));
-
-        final ResponseEntity<String> result = callbackService.send(testUrl, caseEvent, null, caseDetails,
-            String.class);
-
-        assertAll(
-            () -> assertThat(result.getStatusCodeValue(), is(201)),
-            () -> JSONAssert.assertEquals(
-                "{\"data\":null,\"errors\":[],\"warnings\":[],\"data_classification\":null,\"security_classification\":null}",
-                result.getBody(),
-                JSONCompareMode.LENIENT)
-        );
-    }
-
-    @Test
-    public void shouldRetryOnError() throws Exception {
-        final String testUrl = "http://localhost:" + wiremockPort + "/test-callback-invaliddd";
-        final CallbackResponse callbackResponse = new CallbackResponse();
-        final CaseDetails caseDetails = new CaseDetails();
-        final CaseEvent caseEvent = new CaseEvent();
-        caseEvent.setId("TEST-EVENT");
-
-        stubFor(post(urlMatching("/test-callback-invaliddd.*")).willReturn(
-            okJson(mapper.writeValueAsString(callbackResponse)).withStatus(500)));
-
-        Instant start = Instant.now();
-        try {
-            callbackService.send(testUrl, caseEvent, null, caseDetails, String.class);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        final Duration between = Duration.between(start, Instant.now());
-        assertThat((int) between.toMillis(), greaterThan(4000));
-        verify(exactly(3), postRequestedFor(urlMatching("/test-callback-invaliddd.*")));
-    }
-
-    @Test(expected = CallbackException.class)
-    public void shouldThrowCallbackException_whenSendInvalidUrlGetGenericBody() throws Exception {
-        final String testUrl = "http://localhost/invalid-test-callback";
-        final RestTemplate restTemplate = Mockito.mock(RestTemplate.class);
-        final ApplicationParams applicationParams = Mockito.mock(ApplicationParams.class);
-        given(applicationParams.getCallbackRetries()).willReturn(Arrays.asList(3, 5));
-
-        // Builds a new callback service to avoid wiremock exception to get in the way
-        final CallbackService underTest = new CallbackService(Mockito.mock(SecurityUtils.class), restTemplate);
-        final CaseDetails caseDetails = new CaseDetails();
-        final CaseEvent caseEvent = new CaseEvent();
-        caseEvent.setId("TEST-EVENT");
-
-        try {
-            underTest.send(testUrl, caseEvent, null, caseDetails, String.class);
-        } catch (CallbackException ex) {
-            assertThat(ex.getMessage(), is("Callback to service has been unsuccessful for event " + caseEvent.getName()));
-            throw ex;
-        }
+        ApiException apiException = assertThrows(ApiException.class, () -> callbackService.validateCallbackErrorsAndWarnings(callbackResponse, true));
+        assertThat(apiException.getMessage(), is(equalTo("Unable to proceed because there are one or more callback Errors or Warnings")));
     }
 }

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/callbacks/CallbackServiceWireMockTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/callbacks/CallbackServiceWireMockTest.java
@@ -88,7 +88,7 @@ public class CallbackServiceWireMockTest {
             .willReturn(okJson(mapper.writeValueAsString(callbackResponse)).withStatus(200).withFixedDelay(499)));
 
         Instant start = Instant.now();
-        callbackService.send(testUrl, null, caseEvent, null, caseDetails, false);
+        callbackService.send(testUrl, null, caseEvent, null, caseDetails, CallbackResponse.class, false);
 
         final Duration between = Duration.between(start, Instant.now());
         // 0s retryInterval + 0.5s readTimeout + 1s retryInterval + 0.5s readTimeout + 3s retryInterval + 0.5s readTimeout
@@ -115,7 +115,7 @@ public class CallbackServiceWireMockTest {
 
         List<Integer> callbackRetryTimeoutsInMillis = Lists.newArrayList(500, 1000, 1500);
         Instant start = Instant.now();
-        callbackService.send(testUrl, callbackRetryTimeoutsInMillis, caseEvent, null, caseDetails, String.class);
+        callbackService.send(testUrl, callbackRetryTimeoutsInMillis, caseEvent, null, caseDetails, String.class, false);
 
         final Duration between = Duration.between(start, Instant.now());
         // 0s retryInterval + 0.5s readTimeout + 1s retryInterval + 1s readTimeout + 3s retryInterval + 1.5s readTimeout

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/callbacks/CallbackServiceWireMockTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/callbacks/CallbackServiceWireMockTest.java
@@ -1,0 +1,125 @@
+package uk.gov.hmcts.ccd.domain.service.callbacks;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.google.common.collect.Lists;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.gov.hmcts.ccd.data.SecurityUtils;
+import uk.gov.hmcts.ccd.domain.model.callbacks.CallbackResponse;
+import uk.gov.hmcts.ccd.domain.model.definition.CaseDetails;
+import uk.gov.hmcts.ccd.domain.model.definition.CaseEvent;
+
+import javax.inject.Inject;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.assertThat;
+
+@ActiveProfiles("test")
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties =
+    {
+        "http.client.read.timeout=500"
+    })
+@AutoConfigureWireMock(port = 0)
+@DirtiesContext
+public class CallbackServiceWireMockTest {
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    @Inject
+    private CallbackService callbackService;
+
+    @Value("${wiremock.server.port}")
+    protected Integer wiremockPort;
+
+    private final CallbackResponse callbackResponse = new CallbackResponse();
+    private final CaseDetails caseDetails = new CaseDetails();
+    private final CaseEvent caseEvent = new CaseEvent();
+    private String testUrl;
+
+    @Before
+    public void setUp() {
+        // IDAM
+        final SecurityUtils securityUtils = Mockito.mock(SecurityUtils.class);
+        Mockito.when(securityUtils.authorizationHeaders()).thenReturn(new HttpHeaders());
+        ReflectionTestUtils.setField(callbackService, "securityUtils", securityUtils);
+        testUrl = "http://localhost:" + wiremockPort + "/test-callbackGrrrr";
+        WireMock.resetAllScenarios();
+        WireMock.resetAllRequests();
+    }
+
+    @Test
+    public void shouldRetryOnErrorWithIgnoreWarningAndDefaultRetryContext() throws Exception {
+
+        stubFor(post(urlMatching("/test-callbackGrrrr.*"))
+            .inScenario("CallbackRetry")
+            .willReturn(okJson(mapper.writeValueAsString(callbackResponse)).withStatus(500).withFixedDelay(501))
+            .willSetStateTo("FirstFailedAttempt"));
+        stubFor(post(urlMatching("/test-callbackGrrrr.*"))
+            .inScenario("CallbackRetry")
+            .whenScenarioStateIs("FirstFailedAttempt")
+            .willReturn(okJson(mapper.writeValueAsString(callbackResponse)).withStatus(500).withFixedDelay(501))
+            .willSetStateTo("SecondFailedAttempt"));
+        stubFor(post(urlMatching("/test-callbackGrrrr.*"))
+            .inScenario("CallbackRetry")
+            .whenScenarioStateIs("SecondFailedAttempt")
+            .willReturn(okJson(mapper.writeValueAsString(callbackResponse)).withStatus(200).withFixedDelay(499)));
+
+        Instant start = Instant.now();
+        callbackService.send(testUrl, null, caseEvent, null, caseDetails, false);
+
+        final Duration between = Duration.between(start, Instant.now());
+        // 0s retryInterval + 0.5s readTimeout + 1s retryInterval + 0.5s readTimeout + 3s retryInterval + 0.5s readTimeout
+        assertThat((int) between.toMillis(), greaterThan(5500));
+        verify(exactly(3), postRequestedFor(urlMatching("/test-callbackGrrrr.*")));
+    }
+
+    @Test
+    public void shouldRetryOnErrorWithResponseClassAndCustomRetryContext() throws Exception {
+
+        stubFor(post(urlMatching("/test-callbackGrrrr.*"))
+            .inScenario("CallbackRetry")
+            .willReturn(okJson(mapper.writeValueAsString(callbackResponse)).withStatus(500).withFixedDelay(501))
+            .willSetStateTo("FirstFailedAttempt"));
+        stubFor(post(urlMatching("/test-callbackGrrrr.*"))
+            .inScenario("CallbackRetry")
+            .whenScenarioStateIs("FirstFailedAttempt")
+            .willReturn(okJson(mapper.writeValueAsString(callbackResponse)).withStatus(500).withFixedDelay(1001))
+            .willSetStateTo("SecondFailedAttempt"));
+        stubFor(post(urlMatching("/test-callbackGrrrr.*"))
+            .inScenario("CallbackRetry")
+            .whenScenarioStateIs("SecondFailedAttempt")
+            .willReturn(okJson(mapper.writeValueAsString(callbackResponse)).withStatus(200).withFixedDelay(1499)));
+
+        List<Integer> callbackRetryTimeoutsInMillis = Lists.newArrayList(500, 1000, 1500);
+        Instant start = Instant.now();
+        callbackService.send(testUrl, callbackRetryTimeoutsInMillis, caseEvent, null, caseDetails, String.class);
+
+        final Duration between = Duration.between(start, Instant.now());
+        // 0s retryInterval + 0.5s readTimeout + 1s retryInterval + 1s readTimeout + 3s retryInterval + 1.5s readTimeout
+        assertThat((int) between.toMillis(), greaterThan(7000));
+        verify(exactly(3), postRequestedFor(urlMatching("/test-callbackGrrrr.*")));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/callbacks/RestTemplateProviderTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/callbacks/RestTemplateProviderTest.java
@@ -1,0 +1,132 @@
+package uk.gov.hmcts.ccd.domain.service.callbacks;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.apache.http.HttpStatus.SC_OK;
+import static org.apache.http.protocol.HTTP.CONTENT_TYPE;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.PUT;
+import static wiremock.org.apache.http.entity.ContentType.TEXT_PLAIN;
+
+@ActiveProfiles("test")
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@TestPropertySource(properties = {"http.client.connection.timeout=1500",
+    "http.client.max.total=1",
+    "http.client.read.timeout=1500",
+    "http.client.seconds.idle.connection=1",
+    "http.client.max.client_per_route=2",
+    "http.client.validate.after.inactivity=1"})
+@AutoConfigureWireMock(port = 0)
+@DirtiesContext
+public class RestTemplateProviderTest {
+
+    @Value("${wiremock.server.port}")
+    protected Integer wiremockPort;
+
+    private static final String RESPONSE_BODY = "Of course la la land";
+    private static final String URL = "/ng/itb";
+    private static final String MIME_TYPE = TEXT_PLAIN.getMimeType();
+
+    @Autowired
+    private RestTemplateProvider restTemplateProvider;
+
+    @Test
+    public void restTemplateShouldBeUsable() {
+
+        RestTemplate restTemplate = restTemplateProvider.provide(5);
+
+        assertNotNull(restTemplate);
+
+        stubResponse();
+
+        final RequestEntity<String>
+            request =
+            new RequestEntity<>(PUT, URI.create("http://localhost:" + wiremockPort + URL));
+
+        final ResponseEntity<String> response = restTemplate.exchange(request, String.class);
+        assertResponse(response);
+    }
+
+    @Test(expected = ResourceAccessException.class)
+    public void shouldTimeOut() {
+        RestTemplate restTemplate = restTemplateProvider.provide(1);
+        assertNotNull(restTemplate);
+        stubFor(get(urlEqualTo(URL)).willReturn(aResponse().withStatus(SC_OK).withFixedDelay(2000)));
+
+        final RequestEntity<String>
+            request =
+            new RequestEntity<>(GET, URI.create("http://localhost:" + wiremockPort + URL));
+
+        restTemplate.exchange(request, String.class);
+    }
+
+    @Test
+    public void shouldBeAbleToUseMultipleTimes() throws Exception {
+        stubResponse();
+
+        // rest template 1 will respond immediately
+        final RequestEntity<String> request = new RequestEntity<>(PUT, URI.create("http://localhost:" + wiremockPort + URL));
+        RestTemplate restTemplate = restTemplateProvider.provide(3);
+        ResponseEntity<String> response = restTemplate.exchange(request, String.class);
+        assertResponse(response);
+
+        stubResponse(2);
+
+        // rest template 2 should fail as read timeout 1 seconds and fixed delay 2 s
+        RestTemplate restTemplate2 = restTemplateProvider.provide(1);
+        assertThrows(ResourceAccessException.class, () -> restTemplate2.exchange(request, String.class));
+
+        stubResponse(2);
+
+        // rest template 1 should still pass as read timeout 3 s and fixed delay 2 s
+        response = restTemplate.exchange(request, String.class);
+        assertResponse(response);
+    }
+
+    private void stubResponse(int fixedDelayInSeconds) {
+        stubFor(put(urlEqualTo(URL)).willReturn(aResponse().withStatus(SC_OK)
+            .withHeader(CONTENT_TYPE, MIME_TYPE)
+            .withBody(RESPONSE_BODY)
+            .withFixedDelay(fixedDelayInSeconds * 1000)));
+    }
+
+    private void stubResponse() {
+        stubFor(put(urlEqualTo(URL)).willReturn(aResponse().withStatus(SC_OK)
+            .withHeader(CONTENT_TYPE, MIME_TYPE)
+            .withBody(RESPONSE_BODY)));
+    }
+
+
+    private void assertResponse(final ResponseEntity<String> response) {
+        assertThat(response.getBody(), is(RESPONSE_BODY));
+        assertThat(response.getHeaders().get(CONTENT_TYPE), contains(MIME_TYPE));
+        assertThat(response.getStatusCode().value(), is(SC_OK));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/stdapi/CallbackInvokerTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/stdapi/CallbackInvokerTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.*;
+import org.springframework.http.ResponseEntity;
 import uk.gov.hmcts.ccd.data.casedetails.SecurityClassification;
 import uk.gov.hmcts.ccd.domain.model.callbacks.AfterSubmitCallbackResponse;
 import uk.gov.hmcts.ccd.domain.model.callbacks.CallbackResponse;
@@ -103,11 +104,12 @@ class CallbackInvokerTest {
             same(caseEvent),
             same(caseDetailsBefore),
             same(caseDetails));
-        doReturn(Optional.empty()).when(callbackService).send(any(),
+        doReturn(ResponseEntity.of(Optional.empty())).when(callbackService).send(any(),
             any(),
             same(caseEvent),
             same(caseDetailsBefore),
             same(caseDetails),
+            any(),
             anyBoolean());
 
         inOrder = inOrder(callbackService,
@@ -150,6 +152,7 @@ class CallbackInvokerTest {
                 caseEvent,
                 caseDetailsBefore,
                 caseDetails,
+                CallbackResponse.class,
                 IGNORE_WARNING);
             assertThat(response.getState().isPresent(), is(false));
         }
@@ -158,12 +161,13 @@ class CallbackInvokerTest {
         @DisplayName("should send callback and get state")
         void sendCallbackAndGetState() {
             final String expectedState = "uNiCORn";
-            doReturn(Optional.of(mockCallbackResponse(expectedState))).when(callbackService)
+            doReturn(ResponseEntity.of(Optional.of(mockCallbackResponse(expectedState)))).when(callbackService)
                 .send(any(),
                     any(),
                     same(caseEvent),
                     same(caseDetailsBefore),
                     same(caseDetails),
+                    eq(CallbackResponse.class),
                     anyBoolean());
             final AboutToSubmitCallbackResponse response =
                 callbackInvoker.invokeAboutToSubmitCallback(caseEvent,
@@ -177,6 +181,7 @@ class CallbackInvokerTest {
                 caseEvent,
                 caseDetailsBefore,
                 caseDetails,
+                CallbackResponse.class,
                 true);
             assertThat(response.getState().get(), is(expectedState));
         }
@@ -184,12 +189,13 @@ class CallbackInvokerTest {
         @Test
         @DisplayName("should send callback and get no state")
         void sendCallbackAndGetNoState() {
-            doReturn(Optional.of(mockCallbackResponseWithNoState())).when(callbackService)
+            doReturn(ResponseEntity.of(Optional.of(mockCallbackResponseWithNoState()))).when(callbackService)
                 .send(any(),
                     any(),
                     same(caseEvent),
                     same(caseDetailsBefore),
                     same(caseDetails),
+                    eq(CallbackResponse.class),
                     anyBoolean());
             final AboutToSubmitCallbackResponse response =
                 callbackInvoker.invokeAboutToSubmitCallback(caseEvent,
@@ -203,6 +209,7 @@ class CallbackInvokerTest {
                 caseEvent,
                 caseDetailsBefore,
                 caseDetails,
+                CallbackResponse.class,
                 true);
             assertThat(response.getState().isPresent(), is(false));
         }
@@ -211,12 +218,13 @@ class CallbackInvokerTest {
         @DisplayName("should send callback and get state and significant Item")
         void sendCallbackAndGetStateAndSignificantDocument() {
             final String expectedState = "uNiCORn";
-            doReturn(Optional.of(mockCallbackResponseWithSignificantItem(expectedState))).when(callbackService)
+            doReturn(ResponseEntity.of(Optional.of(mockCallbackResponseWithSignificantItem(expectedState)))).when(callbackService)
                 .send(any(),
                     any(),
                     same(caseEvent),
                     same(caseDetailsBefore),
                     same(caseDetails),
+                    eq(CallbackResponse.class),
                     anyBoolean());
 
             final AboutToSubmitCallbackResponse response =
@@ -231,6 +239,7 @@ class CallbackInvokerTest {
                 caseEvent,
                 caseDetailsBefore,
                 caseDetails,
+                CallbackResponse.class,
                 true);
             assertThat(response.getState().get(), is(expectedState));
             assertEquals("description", response.getSignificantItem().getDescription());
@@ -242,12 +251,13 @@ class CallbackInvokerTest {
         @DisplayName("should send callback and get state and significant Item")
         void sendCallbackAndGetStateAndSignificantDocumentWithInvalidURL() {
             final String expectedState = "uNiCORn";
-            doReturn(Optional.of(mockCallbackResponseWithSignificantItem(expectedState))).when(callbackService)
+            doReturn(ResponseEntity.of(Optional.of(mockCallbackResponseWithSignificantItem(expectedState)))).when(callbackService)
                 .send(any(),
                     any(),
                     same(caseEvent),
                     same(caseDetailsBefore),
                     same(caseDetails),
+                    eq(CallbackResponse.class),
                     anyBoolean());
 
             final AboutToSubmitCallbackResponse response =
@@ -262,6 +272,7 @@ class CallbackInvokerTest {
                 caseEvent,
                 caseDetailsBefore,
                 caseDetails,
+                CallbackResponse.class,
                 true);
             assertThat(response.getState().get(), is(expectedState));
             assertEquals("description", response.getSignificantItem().getDescription());
@@ -274,12 +285,13 @@ class CallbackInvokerTest {
         void sendCallbackAndGetStateAndIncorrectSignificantDocument() {
             final String expectedState = "uNiCORn";
             CallbackResponse callbackResponse = mockCallbackResponseWithIncorrectSignificantItem(expectedState);
-            doReturn(Optional.of(callbackResponse)).when(callbackService)
+            doReturn(ResponseEntity.of(Optional.of(callbackResponse))).when(callbackService)
                 .send(any(),
                     any(),
                     same(caseEvent),
                     same(caseDetailsBefore),
                     same(caseDetails),
+                    eq(CallbackResponse.class),
                     anyBoolean());
             final AboutToSubmitCallbackResponse
                 response =
@@ -294,6 +306,7 @@ class CallbackInvokerTest {
                 caseEvent,
                 caseDetailsBefore,
                 caseDetails,
+                CallbackResponse.class,
                 true);
             assertThat(response.getState().get(), is(expectedState));
             assertNull(response.getSignificantItem());
@@ -354,7 +367,8 @@ class CallbackInvokerTest {
                 caseEvent,
                 caseDetailsBefore,
                 caseDetails,
-                AfterSubmitCallbackResponse.class);
+                AfterSubmitCallbackResponse.class,
+                false);
         }
     }
 
@@ -483,6 +497,7 @@ class CallbackInvokerTest {
             final Map<String, JsonNode> newFieldsDataClassification = Maps.newHashMap();
             final Map<String, JsonNode> allFieldsDataClassification = Maps.newHashMap();
             final CallbackResponse callbackResponse = new CallbackResponse();
+            final ResponseEntity<CallbackResponse> responseEntity = ResponseEntity.<CallbackResponse>of(Optional.of(callbackResponse));
             final Map<String, JsonNode> data = new HashMap<>();
 
             @BeforeEach
@@ -502,7 +517,8 @@ class CallbackInvokerTest {
                     caseEvent,
                     caseDetailsBefore,
                     caseDetails,
-                    TRUE)).thenReturn(Optional.of(callbackResponse));
+                    CallbackResponse.class,
+                    TRUE)).thenReturn(responseEntity);
                 when(caseSanitiser.sanitise(eq(caseType), eq(caseDetails.getData()))).thenReturn(data);
                 when(caseDataService.getDefaultSecurityClassifications(eq(caseType),
                     eq(caseDetails.getData()),


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-4522


### Change description ###
Allow configuration of callback timeout and number of retries

The latest addition is to build RestTemplate on each callback call.

https://stackoverflow.com/questions/37125694/how-to-set-requestconfiguration-per-request-using-resttemplate

`In contrast, the RestTemplate calls createRequest(URI, HttpMethod) (defined in HttpAccessor) which uses the ClientHttpRequestFactory. In other words: there is no option to set a request configuration per request. 
I'm not sure why Spring left this option out, it seems a reasonable functional requirement (or maybe I'm still missing something)...`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
