### PR TITLE
Rdm 5138

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -108,7 +108,7 @@ variable "database_storage_mb" {
 
 variable "authorised-services" {
   type    = "string"
-  default = "ccd_data,ccd_gw,ccd_ps,probate_backend,divorce_ccd_submission,sscs,sscs_bulkscan,cmc,cmc_claim_store,cmc_claim_external_api,jui_webapp,pui_webapp,bulk_scan_orchestrator,fpl_case_service,iac,finrem_ccd_data_migrator,finrem_case_orchestration,employment_tribunals,ethos_repl_service"
+  default = "ccd_data,ccd_gw,ccd_ps,probate_backend,divorce_ccd_submission,sscs,sscs_bulkscan,cmc,cmc_claim_store,cmc_claim_external_api,jui_webapp,pui_webapp,bulk_scan_orchestrator,fpl_case_service,iac,finrem_ccd_data_migrator,finrem_case_orchestration,employment_tribunals,ethos_repl_service,ccpay_bubble"
 }
 
 variable "idam_api_url" {

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CachedCaseDetailsRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CachedCaseDetailsRepository.java
@@ -92,6 +92,11 @@ public class CachedCaseDetailsRepository implements CaseDetailsRepository {
     }
 
     @Override
+    public Optional<CaseDetails> lockByReference(final String reference) {
+        return caseDetailsRepository.lockByReference(reference);
+    }
+
+    @Override
     public CaseDetails lockCase(final Long caseReference) {
         return caseDetailsRepository.lockCase(caseReference);
     }

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CachedCaseDetailsRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CachedCaseDetailsRepository.java
@@ -1,21 +1,24 @@
 package uk.gov.hmcts.ccd.data.casedetails;
 
-import javax.inject.Inject;
+import static com.google.common.collect.Maps.newHashMap;
+import static java.lang.String.format;
+import static java.util.Optional.ofNullable;
+
+import uk.gov.hmcts.ccd.data.casedetails.search.MetaData;
+import uk.gov.hmcts.ccd.data.casedetails.search.PaginatedSearchMetadata;
+import uk.gov.hmcts.ccd.domain.model.definition.CaseDetails;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static com.google.common.collect.Maps.newHashMap;
-import static java.lang.String.format;
+import javax.inject.Inject;
 
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.web.context.annotation.RequestScope;
-import uk.gov.hmcts.ccd.data.casedetails.search.MetaData;
-import uk.gov.hmcts.ccd.data.casedetails.search.PaginatedSearchMetadata;
-import uk.gov.hmcts.ccd.domain.model.definition.CaseDetails;
 
 @Service
 @Qualifier(CachedCaseDetailsRepository.QUALIFIER)
@@ -51,16 +54,13 @@ public class CachedCaseDetailsRepository implements CaseDetailsRepository {
 
     @Override
     public CaseDetails findById(final Long id) {
-        return idToCaseDetails.computeIfAbsent(id, key -> Optional.ofNullable(caseDetailsRepository.findById(id)))
-                              .orElse(null);
+        return idToCaseDetails.computeIfAbsent(id, key -> ofNullable(caseDetailsRepository.findById(id))).orElse(null);
     }
 
     @Override
     public CaseDetails findByReference(final Long caseReference) {
-        final Function<String, Optional<CaseDetails>> findFunction = key -> Optional.ofNullable(
-            caseDetailsRepository.findByReference(caseReference));
-        return referenceToCaseDetails.computeIfAbsent(caseReference.toString(), findFunction)
-                                     .orElse(null);
+        final Function<String, Optional<CaseDetails>> findFunction = key -> ofNullable(caseDetailsRepository.findByReference(caseReference));
+        return referenceToCaseDetails.computeIfAbsent(caseReference.toString(), findFunction).orElse(null);
     }
 
     @Override
@@ -70,64 +70,32 @@ public class CachedCaseDetailsRepository implements CaseDetailsRepository {
 
     @Override
     public Optional<CaseDetails> findByReference(String jurisdiction, String reference) {
-        return referenceToCaseDetails.computeIfAbsent(reference,
-                                                      key -> caseDetailsRepository.findByReference(jurisdiction,
-                                                                                                     reference));
+        return referenceToCaseDetails.computeIfAbsent(reference, key -> caseDetailsRepository.findByReference(jurisdiction, reference));
     }
 
     @Override
     public Optional<CaseDetails> findByReference(String reference) {
-        return referenceToCaseDetails.computeIfAbsent(reference,
-                                                      key -> caseDetailsRepository.findByReference(reference));
+        return referenceToCaseDetails.computeIfAbsent(reference, key -> caseDetailsRepository.findByReference(reference));
     }
 
     @Override
-    public Optional<CaseDetails> lockByReference(String jurisdiction, Long reference) {
-        return lockByReference(jurisdiction, reference.toString());
-    }
-
-    @Override
-    public Optional<CaseDetails> lockByReference(String jurisdiction, String reference) {
-        return caseDetailsRepository.lockByReference(jurisdiction, reference);
-    }
-
-    @Override
-    public Optional<CaseDetails> lockByReference(final String reference) {
-        return caseDetailsRepository.lockByReference(reference);
-    }
-
-    @Override
-    public CaseDetails lockCase(final Long caseReference) {
-        return caseDetailsRepository.lockCase(caseReference);
-    }
-
-    @Override
-    public CaseDetails findUniqueCase(final String jurisdictionId,
-                                      final String caseTypeId,
-                                      final String caseReference) {
+    public CaseDetails findUniqueCase(final String jurisdictionId, final String caseTypeId, final String caseReference) {
         return findHashToCaseDetails.computeIfAbsent(format(FIND_HASH_FORMAT, jurisdictionId, caseTypeId, caseReference),
-                                                            hash -> caseDetailsRepository.findUniqueCase(jurisdictionId, caseTypeId, caseReference));
+            hash -> caseDetailsRepository.findUniqueCase(jurisdictionId, caseTypeId, caseReference));
     }
 
     @Override
     public List<CaseDetails> findByMetaDataAndFieldData(final MetaData metadata, final Map<String, String> dataSearchParams) {
-        return metaAndFieldDataHashToCaseDetails.computeIfAbsent(format(META_AND_FIELD_DATA_HASH_FORMAT,
-                                                                        metadata.hashCode(),
-                                                                        getMapHashCode(dataSearchParams)),
-                                                                        hash -> caseDetailsRepository.findByMetaDataAndFieldData(
-                                                                            metadata,
-                                                                            dataSearchParams));
+        return metaAndFieldDataHashToCaseDetails.computeIfAbsent(
+            format(META_AND_FIELD_DATA_HASH_FORMAT, metadata.hashCode(), getMapHashCode(dataSearchParams)),
+            hash -> caseDetailsRepository.findByMetaDataAndFieldData(metadata, dataSearchParams));
     }
 
     @Override
     public PaginatedSearchMetadata getPaginatedSearchMetadata(MetaData metadata, Map<String, String> dataSearchParams) {
-        return hashToPaginatedSearchMetadata.computeIfAbsent(format(META_AND_FIELD_DATA_HASH_FORMAT,
-                                                                    metadata.hashCode(),
-                                                                    getMapHashCode(dataSearchParams)),
-                                                             hash -> caseDetailsRepository.getPaginatedSearchMetadata(
-                                                                 metadata,
-                                                                 dataSearchParams
-                                                             ));
+        return hashToPaginatedSearchMetadata.computeIfAbsent(
+            format(META_AND_FIELD_DATA_HASH_FORMAT, metadata.hashCode(), getMapHashCode(dataSearchParams)),
+            hash -> caseDetailsRepository.getPaginatedSearchMetadata(metadata, dataSearchParams));
     }
 
     private String getMapHashCode(Map<String, String> dataSearchParams) {

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CaseDetailsEntity.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CaseDetailsEntity.java
@@ -82,8 +82,6 @@ public class CaseDetailsEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = SECURITY_CLASSIFICATION_FIELD_COL, nullable = false)
     private SecurityClassification securityClassification;
-    @Column(name = "locked_by_user_id")
-    private Integer lockedBy;
     @Column(name = "data", nullable = false)
     @Convert(converter = uk.gov.hmcts.ccd.data.JSONBConverter.class)
     private JsonNode data;
@@ -101,7 +99,6 @@ public class CaseDetailsEntity {
     public void setId(Long uuid) {
         this.id = uuid;
     }
-
 
     public Long getReference() {
         return reference;
@@ -157,14 +154,6 @@ public class CaseDetailsEntity {
 
     public void setSecurityClassification(SecurityClassification securityClassification) {
         this.securityClassification = securityClassification;
-    }
-
-    public Integer getLockedBy() {
-        return lockedBy;
-    }
-
-    public void setLockedBy(Integer lockedBy) {
-        this.lockedBy = lockedBy;
     }
 
     public JsonNode getData() {

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CaseDetailsEntity.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CaseDetailsEntity.java
@@ -91,6 +91,9 @@ public class CaseDetailsEntity {
     @Convert(converter = uk.gov.hmcts.ccd.data.JSONBConverter.class)
     private JsonNode dataClassification;
 
+    @Version
+    private Integer version;
+
     public Long getId() {
         return id;
     }
@@ -178,5 +181,13 @@ public class CaseDetailsEntity {
 
     public void setDataClassification(JsonNode dataClassification) {
         this.dataClassification = dataClassification;
+    }
+
+    public Integer getVersion() {
+        return version;
+    }
+
+    public void setVersion(final Integer version) {
+        this.version = version;
     }
 }

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CaseDetailsMapper.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CaseDetailsMapper.java
@@ -32,6 +32,7 @@ public class CaseDetailsMapper {
         caseDetails.setLastModified(caseDetailsEntity.getLastModified());
         caseDetails.setState(caseDetailsEntity.getState());
         caseDetails.setSecurityClassification(caseDetailsEntity.getSecurityClassification());
+        caseDetails.setVersion(caseDetailsEntity.getVersion());
         if (caseDetailsEntity.getData() != null) {
             caseDetails.setData(mapper.convertValue(caseDetailsEntity.getData(), STRING_JSON_MAP_TYPE));
             caseDetails.setDataClassification(mapper.convertValue(caseDetailsEntity.getDataClassification(), STRING_JSON_MAP_TYPE));
@@ -52,6 +53,7 @@ public class CaseDetailsMapper {
         newCaseDetailsEntity.setCaseType(caseDetails.getCaseTypeId());
         newCaseDetailsEntity.setState(caseDetails.getState());
         newCaseDetailsEntity.setSecurityClassification(caseDetails.getSecurityClassification());
+        newCaseDetailsEntity.setVersion(caseDetails.getVersion());
         if (caseDetails.getData() == null) {
             newCaseDetailsEntity.setData(mapper.createObjectNode());
         } else {

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CaseDetailsRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CaseDetailsRepository.java
@@ -1,12 +1,12 @@
 package uk.gov.hmcts.ccd.data.casedetails;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
 import uk.gov.hmcts.ccd.data.casedetails.search.MetaData;
 import uk.gov.hmcts.ccd.data.casedetails.search.PaginatedSearchMetadata;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseDetails;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 public interface CaseDetailsRepository {
     CaseDetails set(CaseDetails caseDetails);
@@ -18,12 +18,6 @@ public interface CaseDetailsRepository {
     Optional<CaseDetails> findByReference(String jurisdiction, String reference);
 
     Optional<CaseDetails> findByReference(String reference);
-
-    Optional<CaseDetails> lockByReference(String jurisdiction, Long reference);
-
-    Optional<CaseDetails> lockByReference(String jurisdiction, String reference);
-
-    Optional<CaseDetails> lockByReference(String reference);
 
     /**
      *
@@ -42,15 +36,6 @@ public interface CaseDetailsRepository {
      */
     @Deprecated
     CaseDetails findByReference(Long caseReference);
-
-    /**
-     *
-     * @param caseReference Public case reference
-     * @return Case details
-     * @deprecated Use {@link CaseDetailsRepository#lockByReference(String, Long)} instead.
-     */
-    @Deprecated
-    CaseDetails lockCase(Long caseReference);
 
     /**
      *

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CaseDetailsRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CaseDetailsRepository.java
@@ -23,6 +23,8 @@ public interface CaseDetailsRepository {
 
     Optional<CaseDetails> lockByReference(String jurisdiction, String reference);
 
+    Optional<CaseDetails> lockByReference(String reference);
+
     /**
      *
      * @param id Internal case ID

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/DefaultCaseDetailsRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/DefaultCaseDetailsRepository.java
@@ -7,7 +7,6 @@ import uk.gov.hmcts.ccd.data.casedetails.search.MetaData;
 import uk.gov.hmcts.ccd.data.casedetails.search.PaginatedSearchMetadata;
 import uk.gov.hmcts.ccd.data.casedetails.search.SearchQueryFactoryOperation;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseDetails;
-import uk.gov.hmcts.ccd.endpoint.exceptions.BadRequestException;
 import uk.gov.hmcts.ccd.endpoint.exceptions.CaseConcurrencyException;
 import uk.gov.hmcts.ccd.endpoint.exceptions.ResourceNotFoundException;
 
@@ -22,8 +21,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.persistence.EntityManager;
-import javax.persistence.LockModeType;
-import javax.persistence.LockTimeoutException;
 import javax.persistence.OptimisticLockException;
 import javax.persistence.PersistenceContext;
 import javax.persistence.PersistenceException;
@@ -75,7 +72,7 @@ public class DefaultCaseDetailsRepository implements CaseDetailsRepository {
             em.flush();
         } catch (StaleObjectStateException | OptimisticLockException e) {
             LOG.info("Optimistic Lock Exception: Case data has been altered", e);
-            throw new CaseConcurrencyException("The case data has been altered outside of this transaction");
+            throw new CaseConcurrencyException("The case data has been altered outside of this transaction.");
         } catch (PersistenceException e) {
             LOG.warn("Failed to store case details", e);
             if (e.getCause() instanceof ConstraintViolationException) {
@@ -103,29 +100,6 @@ public class DefaultCaseDetailsRepository implements CaseDetailsRepository {
     @Override
     public Optional<CaseDetails> findByReference(String caseReference) {
         return findByReference(null, caseReference);
-    }
-
-    @Override
-    public Optional<CaseDetails> lockByReference(String jurisdiction, Long reference) {
-        return lockByReference(jurisdiction, reference.toString());
-    }
-
-    @Override
-    public Optional<CaseDetails> lockByReference(String jurisdiction, String reference) {
-        return lockByReference(reference);
-    }
-
-    @Override
-    public Optional<CaseDetails> lockByReference(final String reference) {
-        return find(null, null, reference).map(caseDetails -> {
-            try {
-                em.lock(caseDetails, LockModeType.OPTIMISTIC);
-            } catch (LockTimeoutException lte) {
-                throw new BadRequestException("This particular record is being updated by someone else. "
-                    + "Please click cancel and start over after a short while...");
-            }
-            return this.caseDetailsMapper.entityToModel(caseDetails);
-        });
     }
 
     /**
@@ -163,17 +137,6 @@ public class DefaultCaseDetailsRepository implements CaseDetailsRepository {
                                       final String caseTypeId,
                                       final String reference) {
         return findByReference(jurisdiction, reference).orElse(null);
-    }
-
-    /**
-     * @param reference Case unique 16-digit reference
-     * @return Case details if found; throw NotFound exception otherwise
-     * @deprecated Use {@link DefaultCaseDetailsRepository#lockByReference(String, Long)} instead
-     */
-    @Override
-    @Deprecated
-    public CaseDetails lockCase(final Long reference) {
-        return lockByReference(null, reference).orElseThrow(() -> new ResourceNotFoundException("No case found"));
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/ccd/domain/model/callbacks/EventTokenProperties.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/model/callbacks/EventTokenProperties.java
@@ -8,6 +8,7 @@ public final class EventTokenProperties {
     public static final String CASE_ID = "case-id";
     public static final String CASE_VERSION = "case-version";
     public static final String CASE_STATE = "case-state";
+    public static final String ENTITY_VERSION = "entity-version";
 
     private final String uid;
     private final String caseId;
@@ -16,6 +17,7 @@ public final class EventTokenProperties {
     private final String caseTypeId;
     private final String version;
     private final String caseState;
+    private final String entityVersion;
 
     public EventTokenProperties(final String uid,
                                 final String caseId,
@@ -23,7 +25,8 @@ public final class EventTokenProperties {
                                 final String eventId,
                                 final String caseTypeId,
                                 final String version,
-                                final String caseState) {
+                                final String caseState,
+                                final String entityVersion) {
         this.uid = uid;
         this.caseId = caseId;
         this.jurisdictionId = jurisdictionId;
@@ -31,6 +34,7 @@ public final class EventTokenProperties {
         this.caseTypeId = caseTypeId;
         this.version = version;
         this.caseState = caseState;
+        this.entityVersion = entityVersion;
     }
 
     public String getCaseId() {
@@ -59,5 +63,9 @@ public final class EventTokenProperties {
 
     public String getCaseState() {
         return caseState;
+    }
+
+    public String getEntityVersion() {
+        return entityVersion;
     }
 }

--- a/src/main/java/uk/gov/hmcts/ccd/domain/model/definition/CaseDetails.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/model/definition/CaseDetails.java
@@ -38,6 +38,9 @@ public class CaseDetails implements Cloneable {
     @JsonIgnore
     private Long reference;
 
+    @JsonProperty("version")
+    private Integer version;
+
     private String jurisdiction;
 
     @JsonProperty("case_type_id")
@@ -118,6 +121,14 @@ public class CaseDetails implements Cloneable {
     @JsonSetter("id")
     public void setReference(Long reference) {
         this.reference = reference;
+    }
+
+    public Integer getVersion() {
+        return version;
+    }
+
+    public void setVersion(final Integer version) {
+        this.version = version;
     }
 
     public String getCaseTypeId() {

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/createevent/CreateCaseEventService.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/createevent/CreateCaseEventService.java
@@ -108,7 +108,7 @@ public class CreateCaseEventService {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public CreateCaseEventResult createCaseEvent(String caseReference, CaseDataContent content) {
 
-        final CaseDetails caseDetails = lockCaseDetails(caseReference);
+        final CaseDetails caseDetails = getCaseDetails(caseReference);
         final CaseType caseType = caseDefinitionRepository.getCaseType(caseDetails.getCaseTypeId());
         final CaseEvent eventTrigger = findAndValidateCaseEvent(caseType, content.getEvent());
         final CaseDetails caseDetailsBefore = caseService.clone(caseDetails);
@@ -160,11 +160,11 @@ public class CreateCaseEventService {
         }
     }
 
-    private CaseDetails lockCaseDetails(final String caseReference) {
+    private CaseDetails getCaseDetails(final String caseReference) {
         if (!uidService.validateUID(caseReference)) {
             throw new BadRequestException("Case reference is not valid");
         }
-        return caseDetailsRepository.lockByReference(caseReference)
+        return caseDetailsRepository.findByReference(caseReference)
             .orElseThrow(() -> new ResourceNotFoundException(format("Case with reference %s could not be found", caseReference)));
     }
 

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/createevent/CreateCaseEventService.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/createevent/CreateCaseEventService.java
@@ -37,6 +37,7 @@ import uk.gov.hmcts.ccd.endpoint.exceptions.ValidationException;
 import uk.gov.hmcts.ccd.infrastructure.user.UserAuthorisation;
 
 import javax.inject.Inject;
+
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Map;

--- a/src/main/java/uk/gov/hmcts/ccd/endpoint/std/CaseSearchEndpoint.java
+++ b/src/main/java/uk/gov/hmcts/ccd/endpoint/std/CaseSearchEndpoint.java
@@ -13,13 +13,15 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.SwaggerDefinition;
+import io.swagger.annotations.Tag;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.ccd.ApplicationParams;
@@ -34,7 +36,10 @@ import uk.gov.hmcts.ccd.endpoint.exceptions.BadSearchRequest;
 @RequestMapping(path = "/",
                 consumes = MediaType.APPLICATION_JSON_VALUE,
                 produces = MediaType.APPLICATION_JSON_VALUE)
-@Api(value = "/", description = "New ElasticSearch based search API")
+@Api(tags = {"Elastic Based Search API"})
+@SwaggerDefinition(tags = {
+    @Tag(name = "Elastic Based Search API", description = "New ElasticSearch based search API")
+})
 @Slf4j
 public class CaseSearchEndpoint {
 
@@ -51,7 +56,7 @@ public class CaseSearchEndpoint {
         this.objectMapperService = objectMapperService;
     }
 
-    @RequestMapping(value = "/searchCases", method = RequestMethod.POST)
+    @PostMapping(value = "/searchCases")
     @ApiOperation("Search cases according to the provided ElasticSearch query. Supports searching across multiple case types.")
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = "List of case data for the given search request")

--- a/src/main/java/uk/gov/hmcts/ccd/endpoint/std/DraftsEndpoint.java
+++ b/src/main/java/uk/gov/hmcts/ccd/endpoint/std/DraftsEndpoint.java
@@ -25,7 +25,10 @@ import uk.gov.hmcts.ccd.domain.service.upsertdraft.UpsertDraftOperation;
 @RequestMapping(path = "/",
     consumes = MediaType.APPLICATION_JSON_VALUE,
     produces = MediaType.APPLICATION_JSON_VALUE)
-@Api(value = "/", description = "Drafts API")
+@Api(tags = {"Drafts API"})
+@SwaggerDefinition(tags = {
+    @Tag(name = "Drafts API", description = "The API for saving, updating, finding or deleting draft case data")
+})
 public class DraftsEndpoint {
     private static final Logger LOG = LoggerFactory.getLogger(DraftsEndpoint.class);
 
@@ -42,7 +45,7 @@ public class DraftsEndpoint {
         this.draftGateway = draftGateway;
     }
 
-    @RequestMapping(value = "/caseworkers/{uid}/jurisdictions/{jid}/case-types/{ctid}/event-trigger/{etid}/drafts", method = RequestMethod.POST)
+    @PostMapping(value = "/caseworkers/{uid}/jurisdictions/{jid}/case-types/{ctid}/event-trigger/{etid}/drafts")
     @ResponseStatus(HttpStatus.CREATED)
     @ApiOperation(
         value = "Save draft as a caseworker."
@@ -65,7 +68,7 @@ public class DraftsEndpoint {
         return upsertDraftOperation.executeSave(caseTypeId, caseDataContent);
     }
 
-    @RequestMapping(value = "/caseworkers/{uid}/jurisdictions/{jid}/case-types/{ctid}/event-trigger/{etid}/drafts/{did}", method = RequestMethod.PUT)
+    @PutMapping(value = "/caseworkers/{uid}/jurisdictions/{jid}/case-types/{ctid}/event-trigger/{etid}/drafts/{did}")
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(
         value = "Update draft as a caseworker."
@@ -91,8 +94,7 @@ public class DraftsEndpoint {
     }
 
     @Transactional
-    @RequestMapping(value = "/caseworkers/{uid}/jurisdictions/{jid}/case-types/{ctid}/drafts/{did}",
-        method = RequestMethod.GET)
+    @GetMapping(value = "/caseworkers/{uid}/jurisdictions/{jid}/case-types/{ctid}/drafts/{did}")
     @ApiOperation(value = "Fetch a draft for display")
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = "A displayable draft")
@@ -108,8 +110,7 @@ public class DraftsEndpoint {
     }
 
     @Transactional
-    @RequestMapping(value = "/caseworkers/{uid}/jurisdictions/{jid}/case-types/{ctid}/drafts/{did}",
-        method = RequestMethod.DELETE)
+    @DeleteMapping(value = "/caseworkers/{uid}/jurisdictions/{jid}/case-types/{ctid}/drafts/{did}")
     @ApiOperation(value = "Delete a given draft")
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = "A draft deleted successfully")
@@ -122,5 +123,4 @@ public class DraftsEndpoint {
         final Duration between = Duration.between(start, Instant.now());
         LOG.info("deleteDraft has been completed in {} millisecs...", between.toMillis());
     }
-
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -108,6 +108,8 @@ management.endpoint.metrics.cache.time-to-live=1000ms
 logging.level.uk.gov.hmcts.ccd.domain.service=${DATA_STORE_DEFAULT_LOG_LEVEL:INFO}
 logging.level.uk.gov.hmcts.ccd=${DATA_STORE_DEFAULT_LOG_LEVEL:INFO}
 # logging.level.org.springframework.web=DEBUG
+#logging.level.org.hibernate=INFO
+#logging.level.org.hibernate.type.descriptor.sql=trace
 
 spring.application.name=ccd-data-store
 

--- a/src/main/resources/db/changelog/db.changelog-RDM-5138.xml
+++ b/src/main/resources/db/changelog/db.changelog-RDM-5138.xml
@@ -6,6 +6,7 @@
         <addColumn tableName="case_data">
             <column name="version" type="integer" defaultValue="1"/>
         </addColumn>
+        <dropColumn tableName="case_data" columnName="locked_by_user_id"/>
     </changeSet>
 
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-RDM-5138.xml
+++ b/src/main/resources/db/changelog/db.changelog-RDM-5138.xml
@@ -1,0 +1,12 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="RDM-5138" author="fatih.ozceylan@hmcts.net">
+        <addColumn tableName="case_data">
+            <column name="version" type="integer" defaultValue="1"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>
+

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -28,4 +28,5 @@
     <include file="db/changelog/db.changelog-RDM-4970.xml"/>
     <include file="db/changelog/db.changelog-RDM-5110.xml"/>
     <include file="db/changelog/db.changelog-RDM-5190.xml"/>
+    <include file="db/changelog/db.changelog-RDM-5138.xml"/>
 </databaseChangeLog>

--- a/src/test/java/uk/gov/hmcts/ccd/BaseTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/BaseTest.java
@@ -185,6 +185,7 @@ public abstract class BaseTest {
                 fail("Incorrect JSON structure: " + dataClassification);
             }
         }
+        caseDetails.setVersion(resultSet.getInt("version"));
         return caseDetails;
     }
 

--- a/src/test/java/uk/gov/hmcts/ccd/data/casedetails/CachedCaseDetailsRepositoryTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/data/casedetails/CachedCaseDetailsRepositoryTest.java
@@ -1,7 +1,5 @@
 package uk.gov.hmcts.ccd.data.casedetails;
 
-import java.util.*;
-
 import static java.lang.String.valueOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -11,6 +9,16 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+import uk.gov.hmcts.ccd.data.casedetails.search.MetaData;
+import uk.gov.hmcts.ccd.data.casedetails.search.PaginatedSearchMetadata;
+import uk.gov.hmcts.ccd.domain.model.definition.CaseDetails;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -18,9 +26,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import uk.gov.hmcts.ccd.data.casedetails.search.MetaData;
-import uk.gov.hmcts.ccd.data.casedetails.search.PaginatedSearchMetadata;
-import uk.gov.hmcts.ccd.domain.model.definition.CaseDetails;
 
 class CachedCaseDetailsRepositoryTest {
 
@@ -77,28 +82,13 @@ class CachedCaseDetailsRepositoryTest {
         );
     }
 
-    @Test
-    @DisplayName("Should call lock method of case details repository")
-    void lockCase() {
-        doReturn(caseDetails).when(caseDetailsRepository).lockCase(CASE_REFERENCE);
-
-        CaseDetails returned = cachedRepository.lockCase(CASE_REFERENCE);
-
-        assertAll(
-            () -> assertThat(returned, is(caseDetails)),
-            () -> verify(caseDetailsRepository, times(1)).lockCase(CASE_REFERENCE)
-        );
-    }
-
-
     @Nested
     @DisplayName("Paginated search metadata")
     class GetPaginatedSearchMetadata {
         @Test
         @DisplayName("should initially retrieve paginated search metadata from decorated repository")
         void getPaginatedSearchMetaData() {
-            doReturn(paginatedSearchMetadata).when(caseDetailsRepository).getPaginatedSearchMetadata(metaData,
-                                                                                                     dataSearchParams);
+            doReturn(paginatedSearchMetadata).when(caseDetailsRepository).getPaginatedSearchMetadata(metaData, dataSearchParams);
 
             PaginatedSearchMetadata returned = cachedRepository.getPaginatedSearchMetadata(metaData, dataSearchParams);
 
@@ -111,16 +101,14 @@ class CachedCaseDetailsRepositoryTest {
         @Test
         @DisplayName("should cache paginated search metadata for subsequent calls")
         void getPaginatedSearchMetaDataAgain() {
-            doReturn(paginatedSearchMetadata).when(caseDetailsRepository).getPaginatedSearchMetadata(metaData,
-                                                                                                     dataSearchParams);
+            doReturn(paginatedSearchMetadata).when(caseDetailsRepository).getPaginatedSearchMetadata(metaData, dataSearchParams);
 
             cachedRepository.getPaginatedSearchMetadata(metaData, dataSearchParams);
 
             verify(caseDetailsRepository, times(1)).getPaginatedSearchMetadata(metaData, dataSearchParams);
 
             PaginatedSearchMetadata newPaginatedSearchMetadata = new PaginatedSearchMetadata();
-            doReturn(newPaginatedSearchMetadata).when(caseDetailsRepository).getPaginatedSearchMetadata(metaData,
-                                                                                                        dataSearchParams);
+            doReturn(newPaginatedSearchMetadata).when(caseDetailsRepository).getPaginatedSearchMetadata(metaData, dataSearchParams);
             PaginatedSearchMetadata returned = cachedRepository.getPaginatedSearchMetadata(metaData, dataSearchParams);
 
             assertAll(
@@ -136,8 +124,7 @@ class CachedCaseDetailsRepositoryTest {
         @Test
         @DisplayName("should initially retrieve case details list from decorated repository")
         void findByMetaDataAndFieldData() {
-            doReturn(caseDetailsList).when(caseDetailsRepository).findByMetaDataAndFieldData(metaData,
-                                                                                             dataSearchParams);
+            doReturn(caseDetailsList).when(caseDetailsRepository).findByMetaDataAndFieldData(metaData, dataSearchParams);
 
             List<CaseDetails> returned = cachedRepository.findByMetaDataAndFieldData(metaData, dataSearchParams);
 
@@ -150,16 +137,14 @@ class CachedCaseDetailsRepositoryTest {
         @Test
         @DisplayName("should cache case details list for subsequent calls")
         void findByMetaDataAndFieldDataAgain() {
-            doReturn(caseDetailsList).when(caseDetailsRepository).findByMetaDataAndFieldData(metaData,
-                                                                                             dataSearchParams);
+            doReturn(caseDetailsList).when(caseDetailsRepository).findByMetaDataAndFieldData(metaData, dataSearchParams);
 
             cachedRepository.findByMetaDataAndFieldData(metaData, dataSearchParams);
 
             verify(caseDetailsRepository, times(1)).findByMetaDataAndFieldData(metaData, dataSearchParams);
 
             List<CaseDetails> newCaseDetailsList = Arrays.asList(new CaseDetails(), new CaseDetails());
-            doReturn(newCaseDetailsList).when(caseDetailsRepository).findByMetaDataAndFieldData(metaData,
-                                                                                                dataSearchParams);
+            doReturn(newCaseDetailsList).when(caseDetailsRepository).findByMetaDataAndFieldData(metaData, dataSearchParams);
             List<CaseDetails> returned = cachedRepository.findByMetaDataAndFieldData(metaData, dataSearchParams);
 
             assertAll(
@@ -194,8 +179,7 @@ class CachedCaseDetailsRepositoryTest {
 
             verify(caseDetailsRepository, times(1)).findUniqueCase(JURISDICTION_ID, CASE_TYPE_ID, valueOf(CASE_REFERENCE));
 
-            doReturn(new CaseDetails()).when(caseDetailsRepository).findUniqueCase(JURISDICTION_ID, CASE_TYPE_ID,
-                                                                                   valueOf(CASE_REFERENCE));
+            doReturn(new CaseDetails()).when(caseDetailsRepository).findUniqueCase(JURISDICTION_ID, CASE_TYPE_ID, valueOf(CASE_REFERENCE));
             CaseDetails returned = cachedRepository.findUniqueCase(JURISDICTION_ID, CASE_TYPE_ID, valueOf(CASE_REFERENCE));
 
             assertAll(
@@ -282,11 +266,10 @@ class CachedCaseDetailsRepositoryTest {
         @Test
         @DisplayName("should initially retrieve case details from decorated repository")
         void findById() {
-            doReturn(Optional.of(caseDetails)).when(caseDetailsRepository)
-                                              .findById(JURISDICTION_ID, CASE_ID);
+            doReturn(Optional.of(caseDetails)).when(caseDetailsRepository).findById(JURISDICTION_ID, CASE_ID);
 
             final CaseDetails returned = cachedRepository.findById(JURISDICTION_ID, CASE_ID)
-                                                         .orElseThrow(() -> new AssertionError("Not found"));
+                .orElseThrow(() -> new AssertionError("Not found"));
 
             assertAll(
                 () -> assertThat(returned, is(caseDetails)),
@@ -297,18 +280,16 @@ class CachedCaseDetailsRepositoryTest {
         @Test
         @DisplayName("should cache case details for subsequent calls")
         void findByIdAgain() {
-            doReturn(Optional.of(caseDetails)).when(caseDetailsRepository)
-                                              .findById(JURISDICTION_ID, CASE_ID);
+            doReturn(Optional.of(caseDetails)).when(caseDetailsRepository).findById(JURISDICTION_ID, CASE_ID);
 
             cachedRepository.findById(JURISDICTION_ID, CASE_ID);
 
             verify(caseDetailsRepository, times(1)).findById(JURISDICTION_ID, CASE_ID);
 
-            doReturn(Optional.of(new CaseDetails())).when(caseDetailsRepository)
-                                                    .findById(JURISDICTION_ID, CASE_ID);
+            doReturn(Optional.of(new CaseDetails())).when(caseDetailsRepository).findById(JURISDICTION_ID, CASE_ID);
 
             final CaseDetails returned = cachedRepository.findById(JURISDICTION_ID, CASE_ID)
-                                                         .orElseThrow(() -> new AssertionError("Not found"));
+                .orElseThrow(() -> new AssertionError("Not found"));
 
             assertAll(
                 () -> assertThat(returned, is(caseDetails)),
@@ -323,11 +304,10 @@ class CachedCaseDetailsRepositoryTest {
         @Test
         @DisplayName("should initially retrieve case details from decorated repository")
         void findByReference() {
-            doReturn(Optional.of(caseDetails)).when(caseDetailsRepository)
-                                              .findByReference(JURISDICTION_ID, CASE_REFERENCE_STR);
+            doReturn(Optional.of(caseDetails)).when(caseDetailsRepository).findByReference(JURISDICTION_ID, CASE_REFERENCE_STR);
 
             final CaseDetails returned = cachedRepository.findByReference(JURISDICTION_ID, CASE_REFERENCE_STR)
-                                                         .orElseThrow(() -> new AssertionError("Not found"));
+                .orElseThrow(() -> new AssertionError("Not found"));
 
             assertAll(
                 () -> assertThat(returned, is(caseDetails)),
@@ -338,18 +318,16 @@ class CachedCaseDetailsRepositoryTest {
         @Test
         @DisplayName("should cache case details for subsequent calls")
         void findByReferenceAgain() {
-            doReturn(Optional.of(caseDetails)).when(caseDetailsRepository)
-                                              .findByReference(JURISDICTION_ID, CASE_REFERENCE_STR);
+            doReturn(Optional.of(caseDetails)).when(caseDetailsRepository).findByReference(JURISDICTION_ID, CASE_REFERENCE_STR);
 
             cachedRepository.findByReference(JURISDICTION_ID, CASE_REFERENCE_STR);
 
             verify(caseDetailsRepository, times(1)).findByReference(JURISDICTION_ID, CASE_REFERENCE_STR);
 
-            doReturn(Optional.of(new CaseDetails())).when(caseDetailsRepository)
-                                                    .findByReference(JURISDICTION_ID, CASE_REFERENCE_STR);
+            doReturn(Optional.of(new CaseDetails())).when(caseDetailsRepository).findByReference(JURISDICTION_ID, CASE_REFERENCE_STR);
 
             final CaseDetails returned = cachedRepository.findByReference(JURISDICTION_ID, CASE_REFERENCE_STR)
-                                                         .orElseThrow(() -> new AssertionError("Not found"));
+                .orElseThrow(() -> new AssertionError("Not found"));
 
             assertAll(
                 () -> assertThat(returned, is(caseDetails)),
@@ -364,11 +342,10 @@ class CachedCaseDetailsRepositoryTest {
         @Test
         @DisplayName("should initially retrieve case details from decorated repository")
         void findByReference() {
-            doReturn(Optional.of(caseDetails)).when(caseDetailsRepository)
-                                              .findByReference(CASE_REFERENCE_STR);
+            doReturn(Optional.of(caseDetails)).when(caseDetailsRepository).findByReference(CASE_REFERENCE_STR);
 
             final CaseDetails returned = cachedRepository.findByReference(CASE_REFERENCE_STR)
-                                                         .orElseThrow(() -> new AssertionError("Not found"));
+                .orElseThrow(() -> new AssertionError("Not found"));
 
             assertAll(
                 () -> assertThat(returned, is(caseDetails)),
@@ -379,41 +356,20 @@ class CachedCaseDetailsRepositoryTest {
         @Test
         @DisplayName("should cache case details for subsequent calls")
         void findByReferenceAgain() {
-            doReturn(Optional.of(caseDetails)).when(caseDetailsRepository)
-                                              .findByReference(CASE_REFERENCE_STR);
+            doReturn(Optional.of(caseDetails)).when(caseDetailsRepository).findByReference(CASE_REFERENCE_STR);
 
             cachedRepository.findByReference(CASE_REFERENCE_STR);
 
             verify(caseDetailsRepository, times(1)).findByReference(CASE_REFERENCE_STR);
 
-            doReturn(Optional.of(new CaseDetails())).when(caseDetailsRepository)
-                                                    .findByReference(CASE_REFERENCE_STR);
+            doReturn(Optional.of(new CaseDetails())).when(caseDetailsRepository).findByReference(CASE_REFERENCE_STR);
 
             final CaseDetails returned = cachedRepository.findByReference(CASE_REFERENCE_STR)
-                                                         .orElseThrow(() -> new AssertionError("Not found"));
+                .orElseThrow(() -> new AssertionError("Not found"));
 
             assertAll(
                 () -> assertThat(returned, is(caseDetails)),
                 () -> verifyNoMoreInteractions(caseDetailsRepository)
-            );
-        }
-    }
-
-    @Nested
-    @DisplayName("lockByReference(String, String)")
-    class LockByReferenceAsString {
-        @Test
-        @DisplayName("should delegate to decorated repository")
-        void findByReference() {
-            doReturn(Optional.of(caseDetails)).when(caseDetailsRepository)
-                                              .lockByReference(JURISDICTION_ID, CASE_REFERENCE_STR);
-
-            final CaseDetails returned = cachedRepository.lockByReference(JURISDICTION_ID, CASE_REFERENCE_STR)
-                                                         .orElseThrow(() -> new AssertionError("Not found"));
-
-            assertAll(
-                () -> assertThat(returned, is(caseDetails)),
-                () -> verify(caseDetailsRepository, times(1)).lockByReference(JURISDICTION_ID, CASE_REFERENCE_STR)
             );
         }
     }

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/createevent/CreateCaseEventServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/createevent/CreateCaseEventServiceTest.java
@@ -139,7 +139,7 @@ class CreateCaseEventServiceTest {
         doReturn(true).when(caseTypeService).isJurisdictionValid(JURISDICTION_ID, caseType);
         doReturn(eventTrigger).when(eventTriggerService).findCaseEvent(caseType, EVENT_ID);
         doReturn(true).when(uidService).validateUID(CASE_REFERENCE);
-        doReturn(caseDetails).when(caseDetailsRepository).lockCase(Long.valueOf(CASE_REFERENCE));
+        doReturn(Optional.of(caseDetails)).when(caseDetailsRepository).lockByReference(CASE_REFERENCE);
         doReturn(true).when(eventTriggerService).isPreStateValid(PRE_STATE_ID, eventTrigger);
         doReturn(caseDetails).when(caseDetailsRepository).set(caseDetails);
         doReturn(postState).when(caseTypeService).findState(caseType, POST_STATE);

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/createevent/CreateCaseEventServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/createevent/CreateCaseEventServiceTest.java
@@ -139,7 +139,7 @@ class CreateCaseEventServiceTest {
         doReturn(true).when(caseTypeService).isJurisdictionValid(JURISDICTION_ID, caseType);
         doReturn(eventTrigger).when(eventTriggerService).findCaseEvent(caseType, EVENT_ID);
         doReturn(true).when(uidService).validateUID(CASE_REFERENCE);
-        doReturn(Optional.of(caseDetails)).when(caseDetailsRepository).lockByReference(CASE_REFERENCE);
+        doReturn(Optional.of(caseDetails)).when(caseDetailsRepository).findByReference(CASE_REFERENCE);
         doReturn(true).when(eventTriggerService).isPreStateValid(PRE_STATE_ID, eventTrigger);
         doReturn(caseDetails).when(caseDetailsRepository).set(caseDetails);
         doReturn(postState).when(caseTypeService).findState(caseType, POST_STATE);

--- a/src/test/java/uk/gov/hmcts/ccd/endpoint/std/CaseDetailsEndpointIT.java
+++ b/src/test/java/uk/gov/hmcts/ccd/endpoint/std/CaseDetailsEndpointIT.java
@@ -2468,7 +2468,7 @@ public class CaseDetailsEndpointIT extends WireMockBaseTest {
         caseDetailsToSave.setToken(token);
 
         // Simulate case alteration by other actor to fail event token version check
-        template.update("UPDATE case_data SET data = '{}' WHERE reference = ?", CASE_REFERENCE);
+        template.update("UPDATE case_data SET data = '{}', version = 2 WHERE reference = ?", CASE_REFERENCE);
 
         mockMvc.perform(post(URL)
             .contentType(JSON_CONTENT_TYPE)
@@ -2500,7 +2500,7 @@ public class CaseDetailsEndpointIT extends WireMockBaseTest {
         caseDetailsToSave.setToken(token);
 
         // Simulate case alteration by other actor to fail event token version check
-        template.update("UPDATE case_data SET data = '{}' WHERE reference = ?", CASE_REFERENCE);
+        template.update("UPDATE case_data SET data = '{}', version = 2 WHERE reference = ?", CASE_REFERENCE);
 
         mockMvc.perform(post(URL)
             .contentType(JSON_CONTENT_TYPE)
@@ -2516,7 +2516,7 @@ public class CaseDetailsEndpointIT extends WireMockBaseTest {
 
     @Test
     @Sql(executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD, scripts = {"classpath:sql/insert_cases.sql"})
-    public void shouldReturn409WhenPostCreateCaseEventWithCaseStateConflictForCaseWorker() throws Exception {
+    public void shouldReturn422WhenPostCreateCaseEventWithCaseStateConflictForCaseWorker() throws Exception {
         final String CASE_REFERENCE = "1504259907353545";
         final String SUMMARY = "Case event summary";
         final String DESCRIPTION = "Case event description";
@@ -2531,13 +2531,13 @@ public class CaseDetailsEndpointIT extends WireMockBaseTest {
                                                 UID, JURISDICTION, CASE_TYPE, CASE_REFERENCE, PRE_STATES_EVENT_ID);
         caseDetailsToSave.setToken(token);
 
-        // Simulate case state alteration by other actor to fail event token version check
-        template.update("UPDATE case_data SET state = 'CaseStopped' WHERE reference = ?", CASE_REFERENCE);
+        // Simulate case state alteration by other actor to fail event token version check - no effect since it's checked at save step
+        template.update("UPDATE case_data SET state = 'CaseStopped', version = 2 WHERE reference = ?", CASE_REFERENCE);
 
         mockMvc.perform(post(URL)
             .contentType(JSON_CONTENT_TYPE)
             .content(mapper.writeValueAsBytes(caseDetailsToSave))
-        ).andExpect(status().is(409))
+        ).andExpect(status().is(422))
             .andReturn();
 
         // No database entry created
@@ -2548,7 +2548,7 @@ public class CaseDetailsEndpointIT extends WireMockBaseTest {
 
     @Test
     @Sql(executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD, scripts = {"classpath:sql/insert_cases.sql"})
-    public void shouldReturn409WhenPostCreateCaseEventWithCaseStateConflictForCitizen() throws Exception {
+    public void shouldReturn422WhenPostCreateCaseEventWithCaseStateConflictForCitizen() throws Exception {
         final String CASE_REFERENCE = "1504259907353545";
         final String SUMMARY = "Case event summary";
         final String DESCRIPTION = "Case event description";
@@ -2563,13 +2563,13 @@ public class CaseDetailsEndpointIT extends WireMockBaseTest {
                                                 UID, JURISDICTION, CASE_TYPE, CASE_REFERENCE, PRE_STATES_EVENT_ID);
         caseDetailsToSave.setToken(token);
 
-        // Simulate case state alteration by other actor to fail event token version check
-        template.update("UPDATE case_data SET state = 'CaseStopped' WHERE reference = ?", CASE_REFERENCE);
+        // Simulate case state alteration by other actor to fail event token version check - no effect since it's checked at save step
+        template.update("UPDATE case_data SET state = 'CaseStopped', version = 2 WHERE reference = ?", CASE_REFERENCE);
 
         mockMvc.perform(post(URL)
             .contentType(JSON_CONTENT_TYPE)
             .content(mapper.writeValueAsBytes(caseDetailsToSave))
-        ).andExpect(status().is(409))
+        ).andExpect(status().is(422))
             .andReturn();
 
         // No database entry created


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RDM-5138

Multiple users accessing and updating the same case despite the warnings displayed as headers were having a race condition which allowed both to be able to save. With these updates, the version at the time the event initiated is used for validation at the time of the save. So if someone succeeds in saving the data before you, you'll get a nice case has been altered error and won't be able to save the changes before seeing the altered version of the case and restarting the event.

This caused small behaviour changes in tests as the dirtiness of the record is validated at the final phase of the update


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```