### PR TITLE
Fix deprecation issues and use component for vault

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -74,7 +74,7 @@ withPipeline(type, product, component) {
 
     overrideVaultEnvironments(vaultOverrides)
     loadVaultSecrets(secrets)
-    enableDbMigration()
+    enableDbMigration('ccd')
     enableDockerBuild()
     installCharts()
 }

--- a/charts/ccd-data-store-api/Chart.yaml
+++ b/charts/ccd-data-store-api/Chart.yaml
@@ -1,7 +1,7 @@
 description: Helm chart for the HMCTS CCD Data Store
 name: ccd-data-store-api
 home: https://github.com/hmcts/ccd-data-store-api
-version: 1.1.0
+version: 1.1.1
 maintainers:
   - name: HMCTS CCD Dev Team
     email: ccd-devops@HMCTS.NET

--- a/charts/ccd-data-store-api/values.aat.template.yaml
+++ b/charts/ccd-data-store-api/values.aat.template.yaml
@@ -7,7 +7,7 @@ java:
     ccd:
       resourceGroup: ccd-shared
       secrets:
-      - ccd-data-store-api-POSTGRES-PASS
+      - data-store-api-POSTGRES-PASS
       - ccd-data-store-api-draftStoreEncryptionSecret
       - ccd-ELASTIC-SEARCH-URL
       - ccd-ELASTIC-SEARCH-DATA-NODES-URL

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -187,43 +187,43 @@ module "data-store-db" {
 ////////////////////////////////
 
 resource "azurerm_key_vault_secret" "POSTGRES-USER" {
-  name = "${local.app_full_name}-POSTGRES-USER"
+  name = "${var.component}-POSTGRES-USER"
   value = "${module.data-store-db.user_name}"
   key_vault_id = "${data.azurerm_key_vault.ccd_shared_key_vault.id}"
 }
 
 resource "azurerm_key_vault_secret" "POSTGRES-PASS" {
-  name = "${local.app_full_name}-POSTGRES-PASS"
+  name = "${var.component}-POSTGRES-PASS"
   value = "${module.data-store-db.postgresql_password}"
   key_vault_id = "${data.azurerm_key_vault.ccd_shared_key_vault.id}"
 }
 
 resource "azurerm_key_vault_secret" "POSTGRES_HOST" {
-  name = "${local.app_full_name}-POSTGRES-HOST"
+  name = "${var.component}-POSTGRES-HOST"
   value = "${module.data-store-db.host_name}"
   key_vault_id = "${data.azurerm_key_vault.ccd_shared_key_vault.id}"
 }
 
 resource "azurerm_key_vault_secret" "POSTGRES_PORT" {
-  name = "${local.app_full_name}-POSTGRES-PORT"
+  name = "${var.component}-POSTGRES-PORT"
   value = "${module.data-store-db.postgresql_listen_port}"
   key_vault_id = "${data.azurerm_key_vault.ccd_shared_key_vault.id}"
 }
 
 resource "azurerm_key_vault_secret" "POSTGRES_DATABASE" {
-  name = "${local.app_full_name}-POSTGRES-DATABASE"
+  name = "${var.component}-POSTGRES-DATABASE"
   value = "${module.data-store-db.postgresql_database}"
   key_vault_id = "${data.azurerm_key_vault.ccd_shared_key_vault.id}"
 }
 
 resource "azurerm_key_vault_secret" "ccd_draft_encryption_key" {
-  name = "${local.app_full_name}-draftStoreEncryptionSecret"
+  name = "${var.component}-draftStoreEncryptionSecret"
   value = "${random_string.draft_encryption_key.result}"
   key_vault_id = "${data.azurerm_key_vault.ccd_shared_key_vault.id}"
 }
 
 resource "azurerm_key_vault_secret" "draft-store-key" {
-  name = "${local.app_full_name}-draft-key"
+  name = "${var.component}-draft-key"
   value = "${random_string.draft_encryption_key.result}"
   key_vault_id = "${data.azurerm_key_vault.ccd_shared_key_vault.id}"
 }

--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -1,11 +1,3 @@
-output "microserviceName" {
-  value = "${local.app_full_name}"
-}
-
-output "vaultName" {
-  value = "${local.vaultName}"
-}
-
 output "idam_url" {
   value = "${var.idam_api_url}"
 }

--- a/src/main/resources/bootstrap.yaml
+++ b/src/main/resources/bootstrap.yaml
@@ -4,8 +4,8 @@ spring:
       paths: /mnt/secrets/s2s,/mnt/secrets/ccd
       aliases:
         s2s.microservicekey-ccd-data: DATA_STORE_IDAM_KEY
-        ccd.ccd-data-store-api-draft-key: CCD_DRAFT_ENCRYPTION_KEY
+        ccd.data-store-api-draft-key: CCD_DRAFT_ENCRYPTION_KEY
         ccd.ccd-ELASTIC-SEARCH-URL: ELASTIC_SEARCH_HOSTS
         ccd.ccd-ELASTIC-SEARCH-DATA-NODES-URL: ELASTIC_SEARCH_DATA_NODES_HOSTS
         ccd.ccd-ELASTIC-SEARCH-PASSWORD: ELASTIC_SEARCH_PASSWORD
-        ccd.ccd-data-store-api-POSTGRES-PASS: spring.datasource.password
+        ccd.data-store-api-POSTGRES-PASS: spring.datasource.password


### PR DESCRIPTION
## JIRA link (if applicable) ###
-


### Change description ###
https://github.com/hmcts/cnp-jenkins-library/pull/533 changed to using the component for looking up the vault prefix, it was expected that all teams were doing this, inside of your own vault there is no need to prefix the secret with the product.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
