### PR TITLE
RDM-5784: One dependency in ccd-data-store-api has been declared as u…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -211,6 +211,8 @@ dependencies {
     compile group: 'com.sun.mail', name: 'mailapi', version: '1.6.1'
     compile group: 'commons-lang', name: 'commons-lang', version: '2.6'
     compile group: 'commons-validator', name: 'commons-validator', version: '1.6'
+    // CVE-2019-10086 force update of commons-beanutils.
+    compile group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'
     compile group: 'com.jayway.jsonpath', name: 'json-path', version: '2.4.0'
     compile group: 'org.awaitility', name: 'awaitility', version: '3.1.6'
 

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -2,6 +2,14 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
 
     <suppress>
+        <notes>
+            Commons BeanUtils: has been updated to
+            http://commons.apache.org/proper/commons-beanutils/index.html
+        </notes>
+        <cve>CVE-2019-10086</cve>
+    </suppress>
+
+    <suppress>
         <notes>See https://github.com/jeremylong/DependencyCheck/issues/1146 for Embedded Tomcat</notes>
         <cve>CVE-2017-12617</cve>
     </suppress>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -3,8 +3,8 @@
 
     <suppress>
         <notes>
-            We've upgraded to Commons BeanUtils 1.9.2 but the dependecy check keeps flagging CVEs, thus mark as false positive.
-            has been updated it to the latest version 1.9.4 . More info: http://commons.apache.org/proper/commons-beanutils/index.html
+            We've upgraded to Commons BeanUtils 1.9.4 but the dependecy check keeps flagging CVEs, thus mark as false positive.
+            More info: http://commons.apache.org/proper/commons-beanutils/index.html
         </notes>
         <cve>CVE-2019-10086</cve>
     </suppress>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -3,8 +3,8 @@
 
     <suppress>
         <notes>
-            Commons BeanUtils: has been updated to
-            http://commons.apache.org/proper/commons-beanutils/index.html
+            We've upgraded to Commons BeanUtils 1.9.2 but the dependecy check keeps flagging CVEs, thus mark as false positive.
+            has been updated it to the latest version 1.9.4 . More info: http://commons.apache.org/proper/commons-beanutils/index.html
         </notes>
         <cve>CVE-2019-10086</cve>
     </suppress>


### PR DESCRIPTION
RDM-5784: One dependency in ccd-data-store-api has been declared as unsafe.

    [RDM-5784] (https://tools.hmcts.net/jira/browse/RDM-5784).

