### PR TITLE
DO NOT MERGE RDM-5708 Quick fix to check whether the cause of ConstraintViolationE…

### DIFF
--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/DefaultCaseDetailsRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/DefaultCaseDetailsRepository.java
@@ -40,6 +40,7 @@ public class DefaultCaseDetailsRepository implements CaseDetailsRepository {
 
     private static final Logger LOG = LoggerFactory.getLogger(DefaultCaseDetailsRepository.class);
     public static final String QUALIFIER = "default";
+    public static final String CASE_DATA_REFERENCE_KEY = "case_data_reference_key";
 
     private final CaseDetailsMapper caseDetailsMapper;
 
@@ -75,7 +76,7 @@ public class DefaultCaseDetailsRepository implements CaseDetailsRepository {
             throw new CaseConcurrencyException("The case data has been altered outside of this transaction.");
         } catch (PersistenceException e) {
             LOG.warn("Failed to store case details", e);
-            if (e.getCause() instanceof ConstraintViolationException && ((ConstraintViolationException) e.getCause()).getConstraintName().equals("case_data_reference_key")) {
+            if (e.getCause() instanceof ConstraintViolationException && ((ConstraintViolationException) e.getCause()).getConstraintName().equals(CASE_DATA_REFERENCE_KEY)) {
                 throw new CaseConcurrencyException(e.getMessage());
             } else {
                 throw e;

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/DefaultCaseDetailsRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/DefaultCaseDetailsRepository.java
@@ -75,8 +75,10 @@ public class DefaultCaseDetailsRepository implements CaseDetailsRepository {
             throw new CaseConcurrencyException("The case data has been altered outside of this transaction.");
         } catch (PersistenceException e) {
             LOG.warn("Failed to store case details", e);
-            if (e.getCause() instanceof ConstraintViolationException) {
+            if (e.getCause() instanceof ConstraintViolationException && ((ConstraintViolationException) e.getCause()).getConstraintName().equals("case_data_reference_key")) {
                 throw new CaseConcurrencyException(e.getMessage());
+            } else {
+                throw e;
             }
         }
         return caseDetailsMapper.entityToModel(mergedEntity);

--- a/src/main/resources/db/changelog/db.changelog-RDM-4396.xml
+++ b/src/main/resources/db/changelog/db.changelog-RDM-4396.xml
@@ -8,7 +8,7 @@
              endDelimiter="\nGO"
              splitStatements="true"
              stripComments="true">
-            CREATE INDEX idx_case_data_case_external_id ON public.case_data USING BTREE ((TRIM(UPPER(data#>>'{externalId}'))));
+            CREATE UNIQUE INDEX idx_case_data_case_external_id ON public.case_data USING BTREE ((TRIM(UPPER(data#>>'{externalId}'))));
         </sql>
     </changeSet>
 </databaseChangeLog>

--- a/src/test/resources/mappings/bookcase-definition.json
+++ b/src/test/resources/mappings/bookcase-definition.json
@@ -437,6 +437,31 @@
             "type": "Document",
             "id": "Document"
           }
+        },
+        {
+          "id": "externalId",
+          "case_type_id": "TestAddressBookCase",
+          "label": "External Id",
+          "security_classification": "PUBLIC",
+          "acls": [
+            {
+              "role": "caseworker-probate-public",
+              "create": true,
+              "read": true,
+              "update": true,
+              "delete": false
+            },
+            {
+              "role": "caseworker-probate-private",
+              "create": true,
+              "read": true,
+              "update": true,
+              "delete": false
+            }],
+          "field_type": {
+            "type": "Text",
+            "id": "externalId"
+          }
         }
       ]
     }


### PR DESCRIPTION
…xception is case_data_reference_key and only then throw CaseConcurrencyException to preserve current logic. This is to fix CMC problem with a duplicate external id (unique index) being passed with a new case which is then rejected with ConstraintViolationException causing a retry of case creation.

DO NOT MERGE. This is an initial PR that needs to be discussed further.

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-5708


### Change description ###
Quick fix to check whether the cause of ConstraintViolationException is case_data_reference_key and only then throw CaseConcurrencyException to preserve current logic. This is to fix CMC problem with a duplicate external id (unique index) being passed with a new case which is then rejected with ConstraintViolationException causing a retry of case creation.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
