### PR TITLE
Fetch case events by case reference efficiently

### DIFF
--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CaseAuditEventEntity.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CaseAuditEventEntity.java
@@ -36,10 +36,10 @@ import static uk.gov.hmcts.ccd.data.casedetails.CaseAuditEventEntity.FIND_BY_ID_
         FIND_BY_ID_HQL
     ),
     @NamedQuery(name = CaseAuditEventEntity.FIND_BY_CASE_REFERENCE, query =
-        "SELECT cae FROM CaseAuditEventEntity cae " +
-        "JOIN CaseDetailsEntity cd ON cae.caseDataId = cd.id " +
-        "WHERE cd.reference = :" + CaseAuditEventEntity.CASE_REFERENCE + " " +
-        "ORDER BY cae.createdDate DESC"
+        "SELECT cae FROM CaseAuditEventEntity cae "
+        + "JOIN CaseDetailsEntity cd ON cae.caseDataId = cd.id "
+        + "WHERE cd.reference = :" + CaseAuditEventEntity.CASE_REFERENCE + " "
+        + "ORDER BY cae.createdDate DESC"
     )
 })
 @Table(name = "case_event")

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CaseAuditEventEntity.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CaseAuditEventEntity.java
@@ -34,6 +34,12 @@ import static uk.gov.hmcts.ccd.data.casedetails.CaseAuditEventEntity.FIND_BY_ID_
     ),
     @NamedQuery(name = CaseAuditEventEntity.FIND_BY_ID, query =
         FIND_BY_ID_HQL
+    ),
+    @NamedQuery(name = CaseAuditEventEntity.FIND_BY_CASE_REFERENCE, query =
+        "SELECT cae FROM CaseAuditEventEntity cae " +
+        "JOIN CaseDetailsEntity cd ON cae.caseDataId = cd.id " +
+        "WHERE cd.reference = :" + CaseAuditEventEntity.CASE_REFERENCE + " " +
+        "ORDER BY cae.createdDate DESC"
     )
 })
 @Table(name = "case_event")
@@ -52,9 +58,13 @@ public class CaseAuditEventEntity {
 
     static final String FIND_BY_ID = "CaseAuditEventEntity_FIND_BY_ID";
 
+    static final String FIND_BY_CASE_REFERENCE = "CaseAuditEventEntity_FIND_BY_CASE_REFERENCE";
+
     static final String CASE_DATA_ID = "CASE_DATA_ID";
 
     static final String EVENT_ID = "EVENT_ID";
+
+    static final String CASE_REFERENCE = "CASE_REFERENCE";
 
     @Id
     @Column(name = "id")

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CaseAuditEventRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CaseAuditEventRepository.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.ccd.data.casedetails;
 
+import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseDetails;
@@ -43,6 +44,13 @@ public class CaseAuditEventRepository {
     public List<AuditEvent> findByCase(final CaseDetails caseDetails) {
         final Query query = em.createNamedQuery(CaseAuditEventEntity.FIND_BY_CASE);
         query.setParameter(CaseAuditEventEntity.CASE_DATA_ID, Long.valueOf(caseDetails.getId()));
+
+        return caseAuditEventMapper.entityToModel(query.getResultList());
+    }
+
+    public List<AuditEvent> findByCaseReference(final long caseReference) {
+        final Query query = em.createNamedQuery(CaseAuditEventEntity.FIND_BY_CASE_REFERENCE);
+        query.setParameter(CaseAuditEventEntity.CASE_REFERENCE, caseReference);
 
         return caseAuditEventMapper.entityToModel(query.getResultList());
     }

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CaseAuditEventRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CaseAuditEventRepository.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.ccd.data.casedetails;
 
-import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseDetails;

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/getevents/DefaultGetEventsOperation.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/getevents/DefaultGetEventsOperation.java
@@ -45,12 +45,11 @@ public class DefaultGetEventsOperation implements GetEventsOperation {
             throw new BadRequestException("Case reference " + caseReference + " is not valid");
         }
 
-        final CaseDetails caseDetails =
-            getCaseOperation.execute(caseReference)
-                .orElseThrow(() -> new ResourceNotFoundException(
-                    String.format(RESOURCE_NOT_FOUND, jurisdiction, caseTypeId, caseReference)));
-
-        return getEvents(caseDetails);
+        List<AuditEvent> result = auditEventRepository.findByCaseReference(Long.valueOf(caseReference));
+        if (result.isEmpty()) {
+            throw new ResourceNotFoundException(String.format(RESOURCE_NOT_FOUND, jurisdiction, caseTypeId, caseReference));
+        }
+        return result;
     }
 
     @Override

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/getevents/DefaultGetEventsOperationTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/getevents/DefaultGetEventsOperationTest.java
@@ -72,12 +72,13 @@ class DefaultGetEventsOperationTest {
     @DisplayName("should find case details and retrieve events from repository")
     void shouldFindCaseDetailsAndDelegateCallToRepository() {
         doReturn(true).when(uidService).validateUID(CASE_REFERENCE);
-        doReturn(Optional.of(caseDetails)).when(getCaseOperation).execute(CASE_REFERENCE);
+        doReturn(EVENTS).when(auditEventRepository).findByCaseReference(Long.valueOf(CASE_REFERENCE));
+        EVENTS.add(event);
 
         final List<AuditEvent> events = listEventsOperation.getEvents(JURISDICTION_ID, CASE_TYPE_ID, CASE_REFERENCE);
 
         assertAll(
-            () -> verify(auditEventRepository).findByCase(caseDetails),
+            () -> verify(auditEventRepository).findByCaseReference(Long.valueOf(CASE_REFERENCE)),
             () -> assertThat(events, sameInstance(EVENTS))
         );
     }


### PR DESCRIPTION
JIRA link (if applicable)
https://tools.hmcts.net/jira/browse/RDM-5550

Change description
This is an optimisation to retrieve case events by case reference with
a single query, instead of first fetching a case and then issuing
another query to fetch its events.

This change performs an inner join between case_data and case_event
that can be executed efficiently by postgres using our existing indexes;
in my test DB with 200k cases each with 10 events, fetching events for
a case took a couple of milliseconds.

Does this PR introduce a breaking change? (check one with "x")

[ ] Yes
[x] No