### PR TITLE
Bump java base chart

### DIFF
--- a/charts/ccd-data-store-api/Chart.yaml
+++ b/charts/ccd-data-store-api/Chart.yaml
@@ -2,7 +2,7 @@ description: Helm chart for the HMCTS CCD Data Store
 name: ccd-data-store-api
 apiVersion: v1
 home: https://github.com/hmcts/ccd-data-store-api
-version: 1.2.7
+version: 1.2.8
 maintainers:
   - name: HMCTS CCD Dev Team
     email: ccd-devops@HMCTS.NET

--- a/charts/ccd-data-store-api/requirements.yaml
+++ b/charts/ccd-data-store-api/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: java
-    version: ~2.9.1
+    version: ~2.15.0
     repository: '@hmctspublic'


### PR DESCRIPTION
bulk-scanning is currently blocked because of a clash in the tpl in an old version of chart-java, this was fixed in ~2.10