### PR TITLE
RDM-5007 Fix the WizardPage fields displayContext override when no access

### DIFF
--- a/src/main/java/uk/gov/hmcts/ccd/domain/model/definition/WizardPage.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/model/definition/WizardPage.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.ccd.domain.model.definition;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -8,6 +9,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 @ApiModel(description = "")
 public class WizardPage implements Serializable {
@@ -87,5 +89,12 @@ public class WizardPage implements Serializable {
 
     public void setShowCondition(String showCondition) {
         this.showCondition = showCondition;
+    }
+
+    @JsonIgnore
+    public Optional<WizardPageField> getWizardPageField(String caseViewFieldId) {
+        return wizardPageFields.stream()
+            .filter(wizardPageField -> wizardPageField.getCaseFieldId().equals(caseViewFieldId))
+            .findFirst();
     }
 }

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/common/AccessControlService.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/common/AccessControlService.java
@@ -255,13 +255,10 @@ public class AccessControlService {
 
     private void setReadonlyOnWizardPageFieldDisplayContext(List<WizardPage> wizardPages,
                                                             String caseViewFieldId) {
-        wizardPages.forEach(wizardPage -> {
-            wizardPage.getWizardPageFields().stream()
-                .filter(wizardPageField -> wizardPageField.getCaseFieldId().equals(caseViewFieldId)).collect(toList())
-                .forEach(wizardPageField -> {
-                    wizardPageField.setDisplayContext(READONLY);
-                });
-        });
+       wizardPages.forEach(wizardPage -> {
+           Optional<WizardPageField> wizardPageField = wizardPage.getWizardPageField(caseViewFieldId);
+           wizardPageField.ifPresent(field -> field.setDisplayContext(READONLY));
+       });
     }
 
     private void setChildrenAsReadOnlyIfNoAccess(final List<WizardPage> wizardPages, final String rootFieldId, final CaseField caseField, final Predicate<AccessControlList> access, final Set<String> userRoles, final CommonField caseViewField) {

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/common/AccessControlServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/common/AccessControlServiceTest.java
@@ -2882,10 +2882,22 @@ public class AccessControlServiceTest {
                         .build())
                     .build())
                 .build();
+
+            CaseViewField differentCaseViewField = aViewField()
+                .withId("DifferentAddresses")
+                .build();
+
             CaseEventTrigger caseEventTrigger = newCaseEventTrigger()
                 .withField(
-                    aViewField()
-                        .withId("DifferentAddresses")
+                    differentCaseViewField)
+                .withWizardPage(
+                    newWizardPage()
+                        .withId("Page One")
+                        .withField(differentCaseViewField, OPTIONAL, singletonList(
+                            newWizardPageComplexFieldOverride()
+                                .withComplexFieldId("Addresses")
+                                .withDisplayContext(OPTIONAL)
+                                .build()))
                         .build())
                 .build();
 
@@ -2895,7 +2907,12 @@ public class AccessControlServiceTest {
                 USER_ROLES,
                 CAN_UPDATE);
 
-            assertThat(eventTrigger.getCaseFields(), everyItem(hasProperty("displayContext", is(READONLY))));
+            assertAll(
+                () -> assertThat("CaseField displayContext should change to READONLY",
+                    eventTrigger.getCaseFields().get(0).getDisplayContext(), is(READONLY)),
+                () -> assertThat("WizardPage CaseField displayContext should change to READONLY",
+                    eventTrigger.getWizardPages().get(0).getWizardPageFields().get(0).getDisplayContext(), is(READONLY))
+                     );
         }
 
         @Test

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/common/AccessControlServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/common/AccessControlServiceTest.java
@@ -2536,11 +2536,8 @@ public class AccessControlServiceTest {
                 () -> assertThat("WizardPage CaseField displayContext should change to READONLY",
                     eventTrigger.getWizardPages().get(0).getWizardPageFields().get(0).getDisplayContext(), is(READONLY)),
                 () -> assertThat("WizardPage CaseField Override should be size 1",
-                    eventTrigger.getWizardPages().get(0).getWizardPageFields().get(0).getComplexFieldOverrides().size(), is(1)),
-                () -> assertThat("WizardPage CaseField Override displayContext should change to READONLY",
-                    eventTrigger.getWizardPages().get(0).getWizardPageFields().get(0).getComplexFieldOverrides().get(1).getDisplayContext(), is(READONLY))
+                    eventTrigger.getWizardPages().get(0).getWizardPageFields().get(0).getComplexFieldOverrides().size(), is(1))
              );
-
         }
 
         @Test

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/common/AccessControlServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/common/AccessControlServiceTest.java
@@ -2908,8 +2908,10 @@ public class AccessControlServiceTest {
                 CAN_UPDATE);
 
             assertAll(
+                () -> assertThat(eventTrigger.getCaseFields().size(), is(1)),
                 () -> assertThat("CaseField displayContext should change to READONLY",
                     eventTrigger.getCaseFields().get(0).getDisplayContext(), is(READONLY)),
+                () -> assertThat(eventTrigger.getWizardPages().get(0).getWizardPageFields().size(), is(1)),
                 () -> assertThat("WizardPage CaseField displayContext should change to READONLY",
                     eventTrigger.getWizardPages().get(0).getWizardPageFields().get(0).getDisplayContext(), is(READONLY))
                      );

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/common/AccessControlServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/common/AccessControlServiceTest.java
@@ -2490,8 +2490,8 @@ public class AccessControlServiceTest {
         }
 
         @Test
-        @DisplayName("Should set readonly flag for top level field overrides if relevant acl is missing")
-        void shouldSetReadonlyFlagForWizardPageAndItsOverrideIfRelevantAclMissing() {
+        @DisplayName("Should set readonly flag for WizardPageFields if relevant acl is missing")
+        void shouldSetReadonlyFlagForWizardPageFieldsIfRelevantAclIsMissing() {
             final CaseType caseType = newCaseType()
                 .withField(newCaseField()
                     .withFieldType(aFieldType().withType("Text").build())
@@ -2534,9 +2534,7 @@ public class AccessControlServiceTest {
                 () -> assertThat("CaseField displayContext should change to READONLY",
                     eventTrigger.getCaseFields().get(0).getDisplayContext(), is(READONLY)),
                 () -> assertThat("WizardPage CaseField displayContext should change to READONLY",
-                    eventTrigger.getWizardPages().get(0).getWizardPageFields().get(0).getDisplayContext(), is(READONLY)),
-                () -> assertThat("WizardPage CaseField Override should be size 1",
-                    eventTrigger.getWizardPages().get(0).getWizardPageFields().get(0).getComplexFieldOverrides().size(), is(1))
+                    eventTrigger.getWizardPages().get(0).getWizardPageFields().get(0).getDisplayContext(), is(READONLY))
              );
         }
 

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/common/TestBuildersUtil.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/common/TestBuildersUtil.java
@@ -4,6 +4,7 @@ import static com.google.common.collect.Lists.newArrayList;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static uk.gov.hmcts.ccd.domain.model.definition.FieldType.COMPLEX;
+import static uk.gov.hmcts.ccd.domain.service.common.TestBuildersUtil.WizardPageFieldBuilder.newWizardPageField;
 
 import uk.gov.hmcts.ccd.data.casedetails.SecurityClassification;
 import uk.gov.hmcts.ccd.domain.model.aggregated.CaseEventTrigger;
@@ -966,28 +967,78 @@ public class TestBuildersUtil {
         }
 
         public WizardPageBuilder withField(CaseViewField caseField) {
-            WizardPageField wizardPageField = new WizardPageField();
-            wizardPageField.setCaseFieldId(caseField.getId());
-            wizardPageField.setPageColumnNumber(1);
-            wizardPageField.setOrder(1);
-            wizardPageField.setComplexFieldOverrides(emptyList());
-            wizardPageFields.add(wizardPageField);
+            wizardPageFields.add(newWizardPageField(caseField.getId(), "OPTIONAL", emptyList()).build());
             return this;
         }
 
-        public WizardPageBuilder withField(CaseViewField caseField, List<WizardPageComplexFieldOverride> complexFieldOverrides) {
-            WizardPageField wizardPageField = new WizardPageField();
-            wizardPageField.setCaseFieldId(caseField.getId());
-            wizardPageField.setPageColumnNumber(1);
-            wizardPageField.setOrder(1);
-            wizardPageField.setComplexFieldOverrides(complexFieldOverrides);
-            wizardPageFields.add(wizardPageField);
+        public WizardPageBuilder withField(CaseViewField caseField,
+                                           List<WizardPageComplexFieldOverride> complexFieldOverrides) {
+            wizardPageFields.add(newWizardPageField(caseField.getId(), "OPTIONAL", complexFieldOverrides).build());
+            return this;
+        }
+
+        public WizardPageBuilder withField(CaseViewField caseField,
+                                           String displayContext,
+                                           List<WizardPageComplexFieldOverride> complexFieldOverrides) {
+            wizardPageFields.add(newWizardPageField(caseField.getId(), displayContext, complexFieldOverrides).build());
             return this;
         }
 
         public WizardPage build() {
             this.wizardPage.setWizardPageFields(this.wizardPageFields);
             return wizardPage;
+        }
+    }
+
+    public static class WizardPageFieldBuilder {
+        private final WizardPageField wizardPageField;
+
+        private WizardPageFieldBuilder() {
+            this.wizardPageField = new WizardPageField();
+        }
+
+        public static WizardPageFieldBuilder newWizardPageField() {
+            return new WizardPageFieldBuilder();
+        }
+
+        public static WizardPageFieldBuilder newWizardPageField(String caseFieldId,
+                                                                String displayContext,
+                                                                List<WizardPageComplexFieldOverride> complexFieldOverrides) {
+            return newWizardPageField()
+                .withCaseFieldId(caseFieldId)
+                .withPageColumnNumber(1)
+                .withOrder(1)
+                .withDisplayContext(displayContext)
+                .withComplexFieldOverrides(complexFieldOverrides);
+        }
+
+        public WizardPageFieldBuilder withCaseFieldId(String caseFieldId) {
+            wizardPageField.setCaseFieldId(caseFieldId);
+            return this;
+        }
+
+        public WizardPageFieldBuilder withOrder(Integer order) {
+            wizardPageField.setOrder(order);
+            return this;
+        }
+
+        public WizardPageFieldBuilder withPageColumnNumber(Integer number) {
+            wizardPageField.setPageColumnNumber(number);
+            return this;
+        }
+
+        public WizardPageFieldBuilder withDisplayContext(String displayContext) {
+            wizardPageField.setDisplayContext(displayContext);
+            return this;
+        }
+
+        public WizardPageFieldBuilder withComplexFieldOverrides(List<WizardPageComplexFieldOverride> complexFieldOverrides) {
+            wizardPageField.setComplexFieldOverrides(complexFieldOverrides);
+            return this;
+        }
+
+        public WizardPageField build() {
+            return wizardPageField;
         }
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-5007


### Change description ###
The code missed update of the displayContext in WizardPageFields when user has no access. Eg.:
      "wizard_page_fields": [
        {
          "case_field_id": "defendantFirstName",
          "order": 1,
          "page_column_no": 1,
          "display_context": "OPTIONAL", <--- THIS will get updated to READONLY
          "complex_field_overrides": []
        },

This is for the update event, when the case has been already previously created.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
