### PR TITLE
TO BE CLOSED! RDM-6757 Populate display_context_parameter for collections using case role

### DIFF
--- a/src/main/java/uk/gov/hmcts/ccd/domain/model/aggregated/CommonField.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/model/aggregated/CommonField.java
@@ -25,6 +25,10 @@ public interface CommonField {
 
     void setDisplayContext(String displayContext);
 
+    String getDisplayContextParameter();
+
+    void setDisplayContextParameter(String displayContext);
+
     @JsonIgnore
     default boolean isCollectionFieldType() {
         return FieldType.COLLECTION.equalsIgnoreCase(getFieldType().getType());

--- a/src/main/java/uk/gov/hmcts/ccd/domain/model/definition/CaseField.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/model/definition/CaseField.java
@@ -50,6 +50,8 @@ public class CaseField implements Serializable, CommonField {
     private boolean metadata;
     @JsonProperty("display_context")
     private String displayContext;
+    @JsonProperty("display_context_parameter")
+    private String displayContextParameter;
 
     public String getId() {
         return id;
@@ -169,6 +171,14 @@ public class CaseField implements Serializable, CommonField {
 
     public void setDisplayContext(String displayContext) {
         this.displayContext = displayContext;
+    }
+
+    public String getDisplayContextParameter() {
+        return displayContextParameter;
+    }
+
+    public void setDisplayContextParameter(String displayContextParameter) {
+        this.displayContextParameter = displayContextParameter;
     }
 
     @JsonIgnore

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/aggregated/AuthorisedGetEventTriggerOperation.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/aggregated/AuthorisedGetEventTriggerOperation.java
@@ -67,10 +67,13 @@ public class AuthorisedGetEventTriggerOperation implements GetEventTriggerOperat
 
         verifyRequiredAccessExistsForCaseType(eventTriggerId, caseType, userRoles);
 
-        return filterCaseFieldsByCreateAccess(caseType, userRoles, getEventTriggerOperation.executeForCaseType(caseTypeId,
-                                                                                                               eventTriggerId,
-                                                                                                               ignoreWarning));
+        CaseEventTrigger caseEventTrigger = filterCaseFieldsByCreateAccess(caseType,
+            userRoles,
+            getEventTriggerOperation.executeForCaseType(caseTypeId,
+                eventTriggerId,
+                ignoreWarning));
 
+        return accessControlService.updateCollectionDisplayContextParameterByAccess(caseEventTrigger, userRoles);
     }
 
     @Override
@@ -87,9 +90,10 @@ public class AuthorisedGetEventTriggerOperation implements GetEventTriggerOperat
 
         verifyMandatoryAccessForCase(eventTriggerId, caseDetails, caseType, userRoles);
 
-        return filterUpsertAccessForCase(caseType, userRoles, getEventTriggerOperation.executeForCase(caseReference,
+        CaseEventTrigger caseEventTrigger = filterUpsertAccessForCase(caseType, userRoles, getEventTriggerOperation.executeForCase(caseReference,
                                                                                                       eventTriggerId,
                                                                                                       ignoreWarning));
+        return accessControlService.updateCollectionDisplayContextParameterByAccess(caseEventTrigger, userRoles);
     }
 
     @Override
@@ -102,8 +106,9 @@ public class AuthorisedGetEventTriggerOperation implements GetEventTriggerOperat
 
         verifyRequiredAccessExistsForCaseType(draftResponse.getDocument().getEventTriggerId(), caseType, userRoles);
 
-        return filterCaseFieldsByCreateAccess(caseType, userRoles, getEventTriggerOperation.executeForDraft(draftReference,
+        CaseEventTrigger caseEventTrigger = filterCaseFieldsByCreateAccess(caseType, userRoles, getEventTriggerOperation.executeForDraft(draftReference,
                                                                                                             ignoreWarning));
+        return accessControlService.updateCollectionDisplayContextParameterByAccess(caseEventTrigger, userRoles);
     }
 
     private CaseDetails getCaseDetails(String caseReference) {

--- a/src/test/java/uk/gov/hmcts/ccd/domain/model/definition/CaseFieldTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/model/definition/CaseFieldTest.java
@@ -116,13 +116,6 @@ public class CaseFieldTest {
 
             family.propagateACLsToNestedFields();
 
-            CaseField fInfo = family.getFieldType().getChildren().stream()
-                .filter(e -> e.getId().equals(FAMILY_INFO)).findFirst().get();
-            CaseField fNames = fInfo.getFieldType().getChildren().stream()
-                .filter(e -> e.getId().equals(FAMILY_NAMES)).findFirst().get();
-            CaseField fName = fNames.getFieldType().getChildren().stream()
-                .filter(e -> e.getId().equals(FAMILY_NAME)).findFirst().get();
-
             CaseField members = family.getFieldType().getChildren().stream()
                 .filter(e -> e.getId().equals(MEMBERS)).findFirst().get();
             CaseField person = members.getFieldType().getChildren().stream()

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/aggregated/AuthorisedGetEventTriggerOperationTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/aggregated/AuthorisedGetEventTriggerOperationTest.java
@@ -153,6 +153,8 @@ class AuthorisedGetEventTriggerOperationTest {
                                                                                                caseFields,
                                                                                                userRoles,
                                                                                                CAN_CREATE);
+            doReturn(caseEventTrigger).when(accessControlService)
+                .updateCollectionDisplayContextParameterByAccess(caseEventTrigger, userRoles);
         }
 
         @Test
@@ -200,7 +202,9 @@ class AuthorisedGetEventTriggerOperationTest {
                 () -> inOrder.verify(accessControlService).filterCaseViewFieldsByAccess(eq(caseEventTrigger),
                                                                                         eq(caseFields),
                                                                                         eq(userRoles),
-                                                                                        eq(CAN_CREATE))
+                                                                                        eq(CAN_CREATE)),
+                () -> inOrder.verify(accessControlService)
+                    .updateCollectionDisplayContextParameterByAccess(eq(caseEventTrigger), eq(userRoles))
             );
         }
 
@@ -278,6 +282,8 @@ class AuthorisedGetEventTriggerOperationTest {
                                                                                                         caseFields,
                                                                                                         userRoles,
                                                                                                         CAN_UPDATE);
+            doReturn(caseEventTrigger).when(accessControlService)
+                .updateCollectionDisplayContextParameterByAccess(caseEventTrigger, userRoles);
         }
 
         @Test
@@ -326,7 +332,10 @@ class AuthorisedGetEventTriggerOperationTest {
                 () -> inOrder.verify(accessControlService).setReadOnlyOnCaseViewFieldsIfNoAccess(eq(caseEventTrigger),
                                                                                                  eq(caseFields),
                                                                                                  eq(userRoles),
-                                                                                                 eq(CAN_UPDATE)));
+                                                                                                 eq(CAN_UPDATE)),
+                () -> inOrder.verify(accessControlService)
+                    .updateCollectionDisplayContextParameterByAccess(eq(caseEventTrigger), eq(userRoles))
+                     );
         }
 
         @Test


### PR DESCRIPTION
# # JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-6757


### Change description ###
The main problem was the user profile on the front-end has no case roles and we cannot use them to show/hide collection Add new/Remove buttons.

We have decided to put this information in the display_context_parameter:
#COLLECTION(allowInsert, allowDelete) - should show both Add New and Remove buttons
#COLLECTION(allowInsert) - should show Add New and hide Remove button
#COLLECTION(allowDelete) - should show Remove and hide Add New button
#COLLECTION() - should hide both Add New and Remove buttons

There will be a Front-End change to consume the display_context_parameter.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
