### PR TITLE
Revert "Temp sonar exclusions"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -486,7 +486,7 @@ jacoco {
 
 sonarqube {
     properties {
-        property "sonar.exclusions", "build/generated-sources/**/*.java,**/service/doclink/**,src/main/java/uk/gov/hmcts/ccd/data/definition/DefaultCaseDefinitionRepository.java,src/main/java/uk/gov/hmcts/ccd/AppInsights.java,**/DocLinksRestoreEndpoint.java,**/service/doclink/**,**/DefaultCaseDetailsRepository.java"
+        property "sonar.exclusions", "build/generated-sources/**/*.java,**/service/doclink/**"
         property "sonar.junit.reportPaths", "${project.buildDir}/test-results/junit-platform"
         property "sonar.projectName", "ccd-data-store-api"
         property "sonar.projectKey", "ccd-data-store-api"


### PR DESCRIPTION
Reverts hmcts/ccd-data-store-api#772 - quick fix / hack didn't work so better to revert 