### PR TITLE
RDM-7833 Fix tomcat security issue CVE-2020-1938

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -277,7 +277,7 @@ dependencyManagement {
         dependency 'com.google.guava:guava:24.1.1-jre'
 
         // CVE-2019-0232 - Java and Command Line injections in Windows
-        dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.30') {
+        dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.31') {
             entry 'tomcat-embed-core'
             entry 'tomcat-embed-el'
             entry 'tomcat-embed-websocket'


### PR DESCRIPTION
### JIRA link (if applicable) ###

[RDM-7833](https://tools.hmcts.net/jira/browse/RDM-7833)

### Change description ###

Bump `org.apache.tomcat.embed` version from `9.0.30` to `9.0.31` for *CVE-2020-1938*.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
