### PR TITLE
zipped content length can vary depending on ordering of chars in a text

### DIFF
--- a/src/aat/resources/features/F-051/S-109.td.json
+++ b/src/aat/resources/features/F-051/S-109.td.json
@@ -23,7 +23,7 @@
 	"expectedResponse": {
 		"headers": {
 			"Content-Encoding": "gzip",
-			"Content-Length": "ANY_INTEGER_NOT_NULLABLE",
+			"Content-Length": "[[ANY_INTEGER_NOT_NULLABLE]]",
 			"Content-Type": "application/json"
 		},
 		"body": {

--- a/src/aat/resources/features/F-051/S-109.td.json
+++ b/src/aat/resources/features/F-051/S-109.td.json
@@ -23,7 +23,7 @@
 	"expectedResponse": {
 		"headers": {
 			"Content-Encoding": "gzip",
-			"Content-Length": "857",
+			"Content-Length": "ANY_INTEGER_NOT_NULLABLE",
 			"Content-Type": "application/json"
 		},
 		"body": {


### PR DESCRIPTION
## Change description ###
zipped content length can vary depending on ordering of chars in a text 


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```
