### PR TITLE
RDM-8113 handle display without seconds or milliseconds

### DIFF
--- a/src/aat/resources/features/F-051/S-109.td.json
+++ b/src/aat/resources/features/F-051/S-109.td.json
@@ -23,7 +23,7 @@
   "expectedResponse": {
     "headers": {
       "Content-Encoding" : "gzip",
-      "Content-Length" : "857",
+      "Content-Length" : "[[ANYTHING_PRESENT]]",
       "Content-Type" : "application/json"
     },
     "body": {

--- a/src/aat/resources/features/F-051/S-109.td.json
+++ b/src/aat/resources/features/F-051/S-109.td.json
@@ -23,7 +23,7 @@
   "expectedResponse": {
     "headers": {
       "Content-Encoding" : "gzip",
-      "Content-Length" : "[[ANY_INTEGER_PRESENT]]",
+      "Content-Length" : "[[ANY_INTEGER_NOT_NULLABLE]]",
       "Content-Type" : "application/json"
     },
     "body": {

--- a/src/aat/resources/features/F-051/S-109.td.json
+++ b/src/aat/resources/features/F-051/S-109.td.json
@@ -23,7 +23,7 @@
   "expectedResponse": {
     "headers": {
       "Content-Encoding" : "gzip",
-      "Content-Length" : "[[ANYTHING_PRESENT]]",
+      "Content-Length" : "[[ANY_INTEGER_PRESENT]]",
       "Content-Type" : "application/json"
     },
     "body": {

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/processor/DateTimeFormatParser.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/processor/DateTimeFormatParser.java
@@ -4,9 +4,10 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
-import java.time.temporal.ChronoField;
+import java.time.temporal.*;
 
 import lombok.extern.slf4j.Slf4j;
+import org.joda.time.format.*;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -14,6 +15,7 @@ import org.springframework.stereotype.Component;
 public class DateTimeFormatParser {
 
     static final DateTimeFormatter DATE_TIME_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS");
+    static final DateTimeFormatter DATE_TIME_FORMAT_MILLISECOND = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SS");
     static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
     private static final int DEFAULT_YEAR = 1970;
 
@@ -42,7 +44,7 @@ public class DateTimeFormatParser {
     }
 
     public String convertIso8601ToDateTime(String dateTimeFormat, String value) {
-        LocalDateTime dateTime = LocalDateTime.parse(value, DATE_TIME_FORMAT);
+        LocalDateTime dateTime = LocalDateTime.parse(value);
         return dateTime.format(DateTimeFormatter.ofPattern(dateTimeFormat));
     }
 

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/processor/DisplayContextParameter.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/processor/DisplayContextParameter.java
@@ -1,15 +1,16 @@
 package uk.gov.hmcts.ccd.domain.service.processor;
 
 import com.google.common.base.Strings;
+import com.hazelcast.util.*;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 import static uk.gov.hmcts.ccd.domain.service.processor.DisplayContextParameterType.getParameterTypeFor;
 import static uk.gov.hmcts.ccd.domain.service.processor.DisplayContextParameterType.getParameterValueFor;
 
 public class DisplayContextParameter {
+
+    private static String MULTIPLE_PARAMETERS_STRING = "),";
 
     private DisplayContextParameterType type;
 
@@ -30,8 +31,17 @@ public class DisplayContextParameter {
 
     public static List<DisplayContextParameter> getDisplayContextParameterFor(String displayContextParameter) {
         List<DisplayContextParameter> displayContextParameterTypeList = new ArrayList<>();
+        List<String> displayContextParameters = new ArrayList();
 
-        String[] displayContextParameters = displayContextParameter == null ? new String[]{} : displayContextParameter.split(",");
+        displayContextParameter = (StringUtil.isNullOrEmpty(displayContextParameter)) ? "" : displayContextParameter;
+
+        while (displayContextParameter.contains(MULTIPLE_PARAMETERS_STRING)) {
+            displayContextParameters.add(displayContextParameter.substring(0, (displayContextParameter.indexOf(MULTIPLE_PARAMETERS_STRING) + 1)));
+            displayContextParameter = displayContextParameter.substring((displayContextParameter.indexOf(MULTIPLE_PARAMETERS_STRING) + 2)).trim();
+        }
+
+        displayContextParameters.add(displayContextParameter.trim());
+
         for (String s : displayContextParameters) {
             Optional<DisplayContextParameterType> type = getParameterTypeFor(s);
             Optional<String> value = getParameterValueFor(s);

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/processor/DateTimeFormatParserTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/processor/DateTimeFormatParserTest.java
@@ -92,6 +92,30 @@ class DateTimeFormatParserTest {
         );
     }
 
+    @Test
+    void shouldConvertIso8601ToDateTimeFormat5() {
+        final String dateTimeFormat = "dd/MM/yyyy HH-mm-ss-SSS";
+        final String value = "2012-04-21T00:00:00.5";
+
+        final String result = dateTimeFormatParser.convertIso8601ToDateTime(dateTimeFormat, value);
+
+        assertAll(
+            () -> assertThat(result, is("21/04/2012 00-00-00-500"))
+        );
+    }
+
+    @Test
+    void shouldConvertIso8601ToDateTimeFormat6() {
+        final String dateTimeFormat = "dd/MM/yyyy HH-mm-ss-SSS";
+        final String value = "2012-04-21T00:00:30.01";
+
+        final String result = dateTimeFormatParser.convertIso8601ToDateTime(dateTimeFormat, value);
+
+        assertAll(
+            () -> assertThat(result, is("21/04/2012 00-00-30-010"))
+        );
+    }
+
 
     @Test
     void shouldConvertIso8601ToDateFormat1() {

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/processor/DateTimeFormatParserTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/processor/DateTimeFormatParserTest.java
@@ -69,6 +69,31 @@ class DateTimeFormatParserTest {
     }
 
     @Test
+    void shouldConvertIso8601ToDateTimeFormat3() {
+        final String dateTimeFormat = "dd/MM/yyyy HH-mm-ss-SSS";
+        final String value = "2000-10-20T12:30";
+
+        final String result = dateTimeFormatParser.convertIso8601ToDateTime(dateTimeFormat, value);
+
+        assertAll(
+            () -> assertThat(result, is("20/10/2000 12-30-00-000"))
+        );
+    }
+
+    @Test
+    void shouldConvertIso8601ToDateTimeFormat4() {
+        final String dateTimeFormat = "dd/MM/yyyy HH-mm-ss-SSS";
+        final String value = "2000-10-20T12:30:00";
+
+        final String result = dateTimeFormatParser.convertIso8601ToDateTime(dateTimeFormat, value);
+
+        assertAll(
+            () -> assertThat(result, is("20/10/2000 12-30-00-000"))
+        );
+    }
+
+
+    @Test
     void shouldConvertIso8601ToDateFormat1() {
         final String dateTimeFormat = "dd/MM/yyyy";
         final String value = "2000-10-20";
@@ -129,6 +154,46 @@ class DateTimeFormatParserTest {
         final String result = dateTimeFormatParser.convertDateTimeToIso8601(dateTimeFormat, value);
         assertAll(
             () -> assertThat(result, is("1970-12-01T00:00:00.000"))
+        );
+    }
+
+    @Test
+    void shouldConvertDateTimeToIso8601FormatNullDisplayContextParameter() {
+        final String dateTimeFormat = null;
+        final String value = "2000-10-20T12:30:59.000";
+        final String result = dateTimeFormatParser.convertDateTimeToIso8601(dateTimeFormat, value);
+        assertAll(
+            () -> assertThat(result, is("2000-10-20T12:30:59.000"))
+        );
+    }
+
+    @Test
+    void shouldConvertDateTimeToIso8601FormatIncorrectDisplayContextParameter() {
+        final String dateTimeFormat = "HHmmssSSS dd/MM/yyyy";
+        final String value = "2000-10-20T12:30:59.000";
+        final String result = dateTimeFormatParser.convertDateTimeToIso8601(dateTimeFormat, value);
+        assertAll(
+            () -> assertThat(result, is("2000-10-20T12:30:59.000"))
+        );
+    }
+
+    @Test
+    void shouldConvertDateToIso8601FormatNullDisplayContextParameter() {
+        final String dateTimeFormat = null;
+        final String value = "2000-10-20";
+        final String result = dateTimeFormatParser.convertDateToIso8601(dateTimeFormat, value);
+        assertAll(
+            () -> assertThat(result, is("2000-10-20"))
+        );
+    }
+
+    @Test
+    void shouldConvertDateToIso8601FormatIncorrectDisplayContextParameter() {
+        final String dateTimeFormat = "dd/MM/yyyy";
+        final String value = "2000-10-20";
+        final String result = dateTimeFormatParser.convertDateToIso8601(dateTimeFormat, value);
+        assertAll(
+            () -> assertThat(result, is("2000-10-20"))
         );
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-8113


### Change description ###
RDM-8113 handle display without seconds or milliseconds
RDM-8057 split DCP correctly when there is multiple params

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
