### PR TITLE
IGNORE: RDM-8155 Are checkstyle error reports published?

### DIFF
--- a/src/test/java/uk/gov/hmcts/ccd/config/HalConfigTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/config/HalConfigTest.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.ccd.config;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map; // generate a checkstyle issue of severity error
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;


### PR DESCRIPTION
### _IGNORE_ ###
This is a test of Jenkins response to checkstyle failures.

### JIRA link (if applicable) ###

[RDM-8155](https://tools.hmcts.net/jira/browse/RDM-8155)

### Change description ###

Issue: if checkstyle task fails during Jenkins pipeline are the corresponding reports still published to the artefacts.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
