### PR TITLE
Moved converters to RestTemplateConfiguration

### DIFF
--- a/src/main/java/uk/gov/hmcts/ccd/RestTemplateConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/ccd/RestTemplateConfiguration.java
@@ -9,10 +9,16 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
 
 import javax.annotation.PreDestroy;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @Configuration
@@ -48,11 +54,21 @@ class RestTemplateConfiguration {
 
     @Bean(name = "restTemplate")
     public RestTemplate restTemplate() {
+
         final RestTemplate restTemplate = new RestTemplate();
         HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory(getHttpClient());
         requestFactory.setReadTimeout(readTimeout);
         LOG.info("readTimeout: {}", readTimeout);
         restTemplate.setRequestFactory(requestFactory);
+
+        List<HttpMessageConverter<?>> messageConverters = new ArrayList<>();
+        //Add the Jackson Message converter
+        MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter();
+        // Note: here we are making this converter to process any kind of response,
+        // not only application/*json, which is the default behaviour
+        converter.setSupportedMediaTypes(Collections.singletonList(MediaType.ALL));
+        messageConverters.add(converter);
+        restTemplate.setMessageConverters(messageConverters);
         return restTemplate;
     }
 

--- a/src/main/java/uk/gov/hmcts/ccd/domain/types/sanitiser/client/DocumentManagementRestClient.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/types/sanitiser/client/DocumentManagementRestClient.java
@@ -8,8 +8,6 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
-import org.springframework.http.converter.HttpMessageConverter;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.hmcts.ccd.data.SecurityUtils;
 import uk.gov.hmcts.ccd.domain.model.definition.FieldTypeDefinition;
@@ -18,9 +16,6 @@ import uk.gov.hmcts.ccd.endpoint.exceptions.ApiException;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 @Named
 @Singleton
@@ -43,18 +38,6 @@ public class DocumentManagementRestClient {
         final HttpHeaders headers = securityUtils.authorizationHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         final HttpEntity requestEntity = new HttpEntity(headers);
-
-        // Need to ignore the response Content Type header from Document Management because it is not the expected type
-        // of "application/json". See https://stackoverflow.com/a/44219832 for the same solution to a similar problem.
-        List<HttpMessageConverter<?>> messageConverters = new ArrayList<>();
-        //Add the Jackson Message converter
-        MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter();
-        // Note: here we are making this converter to process any kind of response,
-        // not only application/*json, which is the default behaviour
-        converter.setSupportedMediaTypes(Collections.singletonList(MediaType.ALL));
-        messageConverters.add(converter);
-        restTemplate.setMessageConverters(messageConverters);
-
         Document document = null;
         try {
             LOG.info("Requesting from Document management: {}", url);

--- a/src/test/java/uk/gov/hmcts/ccd/domain/types/sanitiser/client/DocumentManagementRestClientTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/types/sanitiser/client/DocumentManagementRestClientTest.java
@@ -15,6 +15,8 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.hmcts.ccd.data.SecurityUtils;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseFieldDefinition;
@@ -25,7 +27,9 @@ import uk.gov.hmcts.ccd.domain.types.sanitiser.document.Document;
 import uk.gov.hmcts.ccd.domain.types.sanitiser.document._links;
 import uk.gov.hmcts.ccd.endpoint.exceptions.ApiException;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 import static com.xebialabs.restito.builder.stub.StubHttp.whenHttp;
 import static com.xebialabs.restito.builder.verify.VerifyHttp.verifyHttp;
@@ -91,6 +95,11 @@ public class DocumentManagementRestClientTest extends StubServerDependent {
         document.set_links(links);
         document.setOriginalDocumentName(FILENAME);
         subject = new DocumentManagementRestClient(securityUtils, restTemplate);
+        List<HttpMessageConverter<?>> messageConverters = new ArrayList<>();
+        MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter();
+        converter.setSupportedMediaTypes(Collections.singletonList(MediaType.ALL));
+        messageConverters.add(converter);
+        restTemplate.setMessageConverters(messageConverters);
     }
 
     @Test


### PR DESCRIPTION
As mentioned in RDM-4449 moved converters to RestTemplateConfiguration to prevent the converters being set on RestTemplate every time a document is retrieved and have updated the associated tests.

If this converters is needed only for Documents, should there be a different RestTemplateConfiguration with converts only for document retrieval or is it ok to be added in RestTemplateConfiguration?

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDM-4449

### Change description ###
As mentioned in RDM-4449 moved converters to RestTemplateConfiguration to prevent the converters being set on RestTemplate every time a document is retrieved and have updated the associated tests.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
