### PR TITLE
RDM-8606 Implement Add Case-Assigned User and Role

### DIFF
--- a/src/main/java/uk/gov/hmcts/ccd/ApplicationParams.java
+++ b/src/main/java/uk/gov/hmcts/ccd/ApplicationParams.java
@@ -17,6 +17,9 @@ import uk.gov.hmcts.ccd.endpoint.exceptions.ServiceException;
 @Singleton
 public class ApplicationParams {
 
+    @Value("#{'${casedatastore.authorised.services.add_caseassigned_user_roles}'.split(',')}")
+    private List<String> authorisedServicesForAddUserCaseRoles;
+
     @Value("#{'${ccd.am.write.to_ccd_only}'.split(',')}")
     private List<String> writeToCCDCaseTypesOnly;
 
@@ -145,6 +148,10 @@ public class ApplicationParams {
         } catch (UnsupportedEncodingException e) {
             throw new ServiceException(e.getMessage());
         }
+    }
+
+    public List<String> getAuthorisedServicesForAddUserCaseRoles() {
+        return authorisedServicesForAddUserCaseRoles;
     }
 
     public boolean isWildcardSearchAllowed() {

--- a/src/main/java/uk/gov/hmcts/ccd/auditlog/AuditOperationType.java
+++ b/src/main/java/uk/gov/hmcts/ccd/auditlog/AuditOperationType.java
@@ -7,6 +7,7 @@ public enum AuditOperationType {
     SEARCH_CASE("Search case"),
     UPDATE_CASE_ACCESS("Update case access permissions"),
     GRANT_CASE_ACCESS("Grant case access permissions"),
+    ADD_CASE_ASSIGNED_USER_ROLES("Add Case-Assigned Users and Roles"),
     REVOKE_CASE_ACCESS("Revoke case access permissions"),
     VIEW_CASE_HISTORY("View case history");
 

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/caseaccess/CaseAccessOperation.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/caseaccess/CaseAccessOperation.java
@@ -80,6 +80,13 @@ public class CaseAccessOperation {
         revokeRemovedCaseRoles(userId, caseId, currentCaseRoles, targetCaseRoles);
     }
 
+    @Transactional
+    public void addCaseUserRoles(List<CaseAssignedUserRole> caseUserRoles) {
+        caseUserRoles.stream().forEach(caseUserRole -> {
+            final Long caseId = new Long(caseUserRole.getCaseDataId());
+            caseUserRepository.grantAccess(caseId, caseUserRole.getUserId(), caseUserRole.getCaseRole());
+        });
+    }
 
     public List<CaseAssignedUserRole> findCaseUserRoles(List<Long> caseIds, List<String> userIds) {
         List<CaseUserEntity>  caseUserEntities = caseUserRepository.findCaseUserRoles(caseIds, userIds);

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/cauroles/AuthorisedCaseAssignedUserRolesOperation.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/cauroles/AuthorisedCaseAssignedUserRolesOperation.java
@@ -23,6 +23,14 @@ public class AuthorisedCaseAssignedUserRolesOperation implements CaseAssignedUse
         this.cauRoleValidator = cauRoleValidator;
     }
 
+    public void addCaseUserRoles(List<CaseAssignedUserRole> caseUserRoles) {
+        if (this.cauRoleValidator.canAddUserCaseRoles()) {
+            this.cauRolesOperation.addCaseUserRoles(caseUserRoles);
+        } else {
+            throw new CaseRoleAccessException(V2.Error.CLIENT_SERVICE_NOT_AUTHORISED_FOR_OPERATION);
+        }
+    }
+
     public List<CaseAssignedUserRole> findCaseUserRoles(List<Long> caseIds, List<String> userIds) {
         if (this.cauRoleValidator.canAccessUserCaseRoles(userIds)) {
             return this.cauRolesOperation.findCaseUserRoles(caseIds, userIds);

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/cauroles/CaseAssignedUserRolesOperation.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/cauroles/CaseAssignedUserRolesOperation.java
@@ -5,6 +5,8 @@ import uk.gov.hmcts.ccd.domain.model.std.CaseAssignedUserRole;
 
 public interface CaseAssignedUserRolesOperation {
 
+    void addCaseUserRoles(List<CaseAssignedUserRole> caseUserRoles);
+
     List<CaseAssignedUserRole> findCaseUserRoles(List<Long> caseIds, List<String> userIds);
 
 }

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/cauroles/DefaultCaseAssignedUserRolesOperation.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/cauroles/DefaultCaseAssignedUserRolesOperation.java
@@ -18,6 +18,10 @@ public class DefaultCaseAssignedUserRolesOperation implements CaseAssignedUserRo
         this.caseAccessOperation = caseAccessOperation;
     }
 
+    public void addCaseUserRoles(List<CaseAssignedUserRole> caseUserRoles) {
+        this.caseAccessOperation.addCaseUserRoles(caseUserRoles);
+    }
+
     public List<CaseAssignedUserRole> findCaseUserRoles(List<Long> caseIds, List<String> userIds) {
         return this.caseAccessOperation.findCaseUserRoles(caseIds, userIds);
     }

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/cauroles/rolevalidator/CaseAssignedUserRoleValidator.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/cauroles/rolevalidator/CaseAssignedUserRoleValidator.java
@@ -5,4 +5,7 @@ import java.util.List;
 public interface CaseAssignedUserRoleValidator {
 
     boolean canAccessUserCaseRoles(List<String> userIds);
+
+    boolean canAddUserCaseRoles();
+
 }

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/cauroles/rolevalidator/DefaultCaseAssignedUserRoleValidator.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/cauroles/rolevalidator/DefaultCaseAssignedUserRoleValidator.java
@@ -4,8 +4,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import uk.gov.hmcts.ccd.ApplicationParams;
 import uk.gov.hmcts.ccd.data.SecurityUtils;
 import uk.gov.hmcts.ccd.data.user.CachedUserRepository;
 import uk.gov.hmcts.ccd.data.user.UserRepository;
@@ -14,18 +14,17 @@ import uk.gov.hmcts.ccd.data.user.UserRepository;
 @Qualifier("default")
 public class DefaultCaseAssignedUserRoleValidator implements CaseAssignedUserRoleValidator {
 
-
-    @Value("#{'${casedatastore.authorised.services.add_caseassigned_user_roles}'.split(',')}")
-    private List<String> authorisedAddServices;
-
     private final String roleCaseWorkerCaa = "caseworker-caa";
 
-    private UserRepository userRepository;
-    private SecurityUtils securityUtils;
+    private final ApplicationParams applicationParams;
+    private final UserRepository userRepository;
+    private final SecurityUtils securityUtils;
 
     @Autowired
-    public DefaultCaseAssignedUserRoleValidator(@Qualifier(CachedUserRepository.QUALIFIER) final UserRepository userRepository,
+    public DefaultCaseAssignedUserRoleValidator(ApplicationParams applicationParams,
+                                                @Qualifier(CachedUserRepository.QUALIFIER) UserRepository userRepository,
                                                 SecurityUtils securityUtils) {
+        this.applicationParams = applicationParams;
         this.userRepository = userRepository;
         this.securityUtils = securityUtils;
     }
@@ -40,7 +39,7 @@ public class DefaultCaseAssignedUserRoleValidator implements CaseAssignedUserRol
     }
 
     public boolean canAddUserCaseRoles() {
-        return authorisedAddServices.contains(securityUtils.getServiceName());
+        return applicationParams.getAuthorisedServicesForAddUserCaseRoles().contains(securityUtils.getServiceName());
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/cauroles/rolevalidator/DefaultCaseAssignedUserRoleValidator.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/cauroles/rolevalidator/DefaultCaseAssignedUserRoleValidator.java
@@ -4,7 +4,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import uk.gov.hmcts.ccd.data.SecurityUtils;
 import uk.gov.hmcts.ccd.data.user.CachedUserRepository;
 import uk.gov.hmcts.ccd.data.user.UserRepository;
 
@@ -12,13 +14,20 @@ import uk.gov.hmcts.ccd.data.user.UserRepository;
 @Qualifier("default")
 public class DefaultCaseAssignedUserRoleValidator implements CaseAssignedUserRoleValidator {
 
+
+    @Value("#{'${casedatastore.authorised.services.add_caseassigned_user_roles}'.split(',')}")
+    private List<String> authorisedAddServices;
+
     private final String roleCaseWorkerCaa = "caseworker-caa";
 
     private UserRepository userRepository;
+    private SecurityUtils securityUtils;
 
     @Autowired
-    public DefaultCaseAssignedUserRoleValidator(@Qualifier(CachedUserRepository.QUALIFIER) final UserRepository userRepository) {
+    public DefaultCaseAssignedUserRoleValidator(@Qualifier(CachedUserRepository.QUALIFIER) final UserRepository userRepository,
+                                                SecurityUtils securityUtils) {
         this.userRepository = userRepository;
+        this.securityUtils = securityUtils;
     }
 
     public boolean canAccessUserCaseRoles(List<String> userIds) {
@@ -29,4 +38,9 @@ public class DefaultCaseAssignedUserRoleValidator implements CaseAssignedUserRol
         }
         return canAccess;
     }
+
+    public boolean canAddUserCaseRoles() {
+        return authorisedAddServices.contains(securityUtils.getServiceName());
+    }
+
 }

--- a/src/main/java/uk/gov/hmcts/ccd/v2/V2.java
+++ b/src/main/java/uk/gov/hmcts/ccd/v2/V2.java
@@ -63,6 +63,7 @@ public final class V2 {
         public static final String CASE_ALTERED = "Case altered outside of transaction";
         public static final String CASE_ROLE_REQUIRED = "Case role missing";
         public static final String CASE_ROLE_INVALID = "Case role does not exist";
+        public static final String CASE_ROLE_FORMAT_INVALID = "Case role name format is invalid";
         public static final String GRANT_FORBIDDEN = "Grant action is reserved to users with entire jurisdiction access";
         public static final String CASE_FIELD_INVALID = "Cannot validate case field";
         public static final String CALLBACK_EXCEPTION = "Unsuccessful callback";
@@ -72,6 +73,8 @@ public final class V2 {
         public static final String ERROR_CASE_ID_INVALID = "Case ID is not valid";
         public static final String EMPTY_CASE_ID_LIST = "Case ID list is empty";
         public static final String USER_ID_INVALID = "User ID is not valid";
+        public static final String EMPTY_CASE_USER_ROLE_LIST = "Case user roles list is empty";
         public static final String OTHER_USER_CASE_ROLE_ACCESS_NOT_GRANTED = "Access to other user's case role assignments not granted";
+        public static final String CLIENT_SERVICE_NOT_AUTHORISED_FOR_OPERATION = "Client service not authorised to perform operation";
     }
 }

--- a/src/main/java/uk/gov/hmcts/ccd/v2/external/controller/CaseAssignedUserRolesController.java
+++ b/src/main/java/uk/gov/hmcts/ccd/v2/external/controller/CaseAssignedUserRolesController.java
@@ -5,27 +5,41 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import uk.gov.hmcts.ccd.auditlog.LogAudit;
 import uk.gov.hmcts.ccd.domain.model.std.CaseAssignedUserRole;
 import uk.gov.hmcts.ccd.domain.service.cauroles.CaseAssignedUserRolesOperation;
 import uk.gov.hmcts.ccd.domain.service.common.UIDService;
 import uk.gov.hmcts.ccd.endpoint.exceptions.BadRequestException;
 import uk.gov.hmcts.ccd.v2.V2;
+import uk.gov.hmcts.ccd.v2.external.domain.AddCaseAssignedUserRolesResponse;
 import uk.gov.hmcts.ccd.v2.external.resource.CaseAssignedUserRolesResource;
+
+import static uk.gov.hmcts.ccd.auditlog.AuditOperationType.ADD_CASE_ASSIGNED_USER_ROLES;
+import static uk.gov.hmcts.ccd.auditlog.aop.AuditContext.CASE_ID_SEPARATOR;
+import static uk.gov.hmcts.ccd.auditlog.aop.AuditContext.MAX_CASE_IDS_LIST;
 
 @RestController
 @RequestMapping(path = "/")
 public class CaseAssignedUserRolesController {
+
+    public static final String ADD_SUCCESS_MESSAGE = "Case-User-Role assignments created successfully";
 
     private final UIDService caseReferenceService;
     private final CaseAssignedUserRolesOperation caseAssignedUserRolesOperation;
@@ -35,6 +49,43 @@ public class CaseAssignedUserRolesController {
                                            @Qualifier("authorised") CaseAssignedUserRolesOperation caseAssignedUserRolesOperation) {
         this.caseReferenceService = caseReferenceService;
         this.caseAssignedUserRolesOperation = caseAssignedUserRolesOperation;
+    }
+
+    @PostMapping(
+        path = "/case-users"
+    )
+    @ApiOperation(
+        value = "Add Case-Assigned Users and Roles"
+    )
+    @ApiResponses({
+        @ApiResponse(
+            code = 200,
+            message = ADD_SUCCESS_MESSAGE,
+            response = AddCaseAssignedUserRolesResponse.class
+        ),
+        @ApiResponse(
+            code = 400,
+            message = "One or more of the following reasons:\n"
+                + "1. " + V2.Error.EMPTY_CASE_USER_ROLE_LIST + "\n"
+                + "2. " + V2.Error.CASE_ID_INVALID + "\n"
+                + "3. " + V2.Error.USER_ID_INVALID + "\n"
+                + "4. " + V2.Error.CASE_ROLE_FORMAT_INVALID + "."
+        ),
+        @ApiResponse(
+            code = 403,
+            message = V2.Error.CLIENT_SERVICE_NOT_AUTHORISED_FOR_OPERATION
+        )
+    })
+    @LogAudit(
+        operationType = ADD_CASE_ASSIGNED_USER_ROLES,
+        caseId = "T(uk.gov.hmcts.ccd.v2.external.controller.CaseAssignedUserRolesController).buildCaseIds(#caseAssignedUserRoles)",
+        targetIdamId = "T(uk.gov.hmcts.ccd.v2.external.controller.CaseAssignedUserRolesController).buildUserIds(#caseAssignedUserRoles)",
+        targetCaseRoles = "T(uk.gov.hmcts.ccd.v2.external.controller.CaseAssignedUserRolesController).buildCaseRoles(#caseAssignedUserRoles)"
+    )
+    public ResponseEntity<AddCaseAssignedUserRolesResponse> addCaseUserRoles(@RequestBody CaseAssignedUserRolesResource caseAssignedUserRoles) {
+        validateRequestParams(caseAssignedUserRoles);
+        this.caseAssignedUserRolesOperation.addCaseUserRoles(caseAssignedUserRoles.getCaseAssignedUserRoles());
+        return ResponseEntity.ok(new AddCaseAssignedUserRolesResponse(ADD_SUCCESS_MESSAGE));
     }
 
     @GetMapping(
@@ -101,4 +152,67 @@ public class CaseAssignedUserRolesController {
             throw new BadRequestException(message);
         }
     }
+
+    private void validateRequestParams(CaseAssignedUserRolesResource caseAssignedUserRoles) {
+        final Pattern caseRolePattern = Pattern.compile("^\\[.+\\]$");
+
+        List<String> errorMessages = Lists.newArrayList("Invalid data provided for the following inputs to the request:");
+
+        List<CaseAssignedUserRole> caseUserRoles =
+            caseAssignedUserRolesToStream(caseAssignedUserRoles).collect(Collectors.toList());
+
+        /// case-users: must be none empty
+        if (caseUserRoles.isEmpty()) {
+            errorMessages.add(V2.Error.EMPTY_CASE_USER_ROLE_LIST);
+        } else {
+            caseUserRoles.forEach(caseRole -> {
+                // case_id: has to be a valid 16-digit Luhn number)
+                if (!caseReferenceService.validateUID(caseRole.getCaseDataId())) {
+                    errorMessages.add(V2.Error.CASE_ID_INVALID);
+                }
+                // user_id: has to be a string of length > 0
+                if (StringUtils.isAllBlank(caseRole.getUserId())) {
+                    errorMessages.add(V2.Error.USER_ID_INVALID);
+                }
+                // case_role: has to be a none-empty string in square brackets
+                if (caseRole.getCaseRole() == null || !caseRolePattern.matcher(caseRole.getCaseRole()).matches()) {
+                    errorMessages.add(V2.Error.CASE_ROLE_FORMAT_INVALID);
+                }
+            });
+        }
+
+        if (errorMessages.size() > 1) {
+            String message = errorMessages.stream().collect(Collectors.joining("\n"));
+            throw new BadRequestException(message);
+        }
+    }
+
+    public static String buildCaseIds(CaseAssignedUserRolesResource caseAssignedUserRoles) {
+        return caseAssignedUserRolesToStream(caseAssignedUserRoles).limit(MAX_CASE_IDS_LIST)
+            .map(c -> c.getCaseDataId())
+            .collect(Collectors.joining(CASE_ID_SEPARATOR));
+    }
+
+    public static String buildCaseRoles(CaseAssignedUserRolesResource caseAssignedUserRoles) {
+        // NB: match Case ID list size and separator configuration
+        return caseAssignedUserRolesToStream(caseAssignedUserRoles).limit(MAX_CASE_IDS_LIST)
+            .map(c -> c.getCaseRole())
+            .collect(Collectors.joining(CASE_ID_SEPARATOR));
+    }
+
+    public static String buildUserIds(CaseAssignedUserRolesResource caseAssignedUserRoles) {
+        // NB: match Case ID list size and separator configuration
+        return caseAssignedUserRolesToStream(caseAssignedUserRoles).limit(MAX_CASE_IDS_LIST)
+            .map(c -> c.getUserId())
+            .collect(Collectors.joining(CASE_ID_SEPARATOR));
+    }
+
+    private static Stream<CaseAssignedUserRole> caseAssignedUserRolesToStream(CaseAssignedUserRolesResource caseAssignedUserRoles) {
+        return caseAssignedUserRoles != null
+            ? Optional.ofNullable(caseAssignedUserRoles.getCaseAssignedUserRoles())
+                .map(Collection::stream)
+                .orElseGet(Stream::empty)
+            : Stream.empty();
+    }
+
 }

--- a/src/main/java/uk/gov/hmcts/ccd/v2/external/controller/CaseAssignedUserRolesController.java
+++ b/src/main/java/uk/gov/hmcts/ccd/v2/external/controller/CaseAssignedUserRolesController.java
@@ -120,11 +120,11 @@ public class CaseAssignedUserRolesController {
     public ResponseEntity<CaseAssignedUserRolesResource> getCaseUserRoles(@RequestParam("case_ids") List<String> caseIds,
                                                                           @RequestParam(value = "user_ids", required = false)
                                                                               Optional<List<String>> optionalUserIds) {
-        List<String> userIds = optionalUserIds.orElseGet(() -> Lists.newArrayList());
+        List<String> userIds = optionalUserIds.orElseGet(Lists::newArrayList);
         validateRequestParams(caseIds, userIds);
         List<CaseAssignedUserRole> caseAssignedUserRoles = this.caseAssignedUserRolesOperation.findCaseUserRoles(caseIds
             .stream()
-            .map(caseId -> Long.valueOf(caseId))
+            .map(Long::valueOf)
             .collect(Collectors.toCollection(ArrayList::new)), userIds);
         return ResponseEntity.ok(new CaseAssignedUserRolesResource(caseAssignedUserRoles));
     }
@@ -148,13 +148,13 @@ public class CaseAssignedUserRolesController {
         });
 
         if (errorMessages.size() > 1) {
-            String message = errorMessages.stream().collect(Collectors.joining("\n"));
+            String message = String.join("\n", errorMessages);
             throw new BadRequestException(message);
         }
     }
 
     private void validateRequestParams(CaseAssignedUserRolesResource caseAssignedUserRoles) {
-        final Pattern caseRolePattern = Pattern.compile("^\\[.+\\]$");
+        final Pattern caseRolePattern = Pattern.compile("^\\[.+]$");
 
         List<String> errorMessages = Lists.newArrayList("Invalid data provided for the following inputs to the request:");
 
@@ -182,28 +182,28 @@ public class CaseAssignedUserRolesController {
         }
 
         if (errorMessages.size() > 1) {
-            String message = errorMessages.stream().collect(Collectors.joining("\n"));
+            String message = String.join("\n", errorMessages);
             throw new BadRequestException(message);
         }
     }
 
     public static String buildCaseIds(CaseAssignedUserRolesResource caseAssignedUserRoles) {
         return caseAssignedUserRolesToStream(caseAssignedUserRoles).limit(MAX_CASE_IDS_LIST)
-            .map(c -> c.getCaseDataId())
+            .map(CaseAssignedUserRole::getCaseDataId)
             .collect(Collectors.joining(CASE_ID_SEPARATOR));
     }
 
     public static String buildCaseRoles(CaseAssignedUserRolesResource caseAssignedUserRoles) {
         // NB: match Case ID list size and separator configuration
         return caseAssignedUserRolesToStream(caseAssignedUserRoles).limit(MAX_CASE_IDS_LIST)
-            .map(c -> c.getCaseRole())
+            .map(CaseAssignedUserRole::getCaseRole)
             .collect(Collectors.joining(CASE_ID_SEPARATOR));
     }
 
     public static String buildUserIds(CaseAssignedUserRolesResource caseAssignedUserRoles) {
         // NB: match Case ID list size and separator configuration
         return caseAssignedUserRolesToStream(caseAssignedUserRoles).limit(MAX_CASE_IDS_LIST)
-            .map(c -> c.getUserId())
+            .map(CaseAssignedUserRole::getUserId)
             .collect(Collectors.joining(CASE_ID_SEPARATOR));
     }
 

--- a/src/main/java/uk/gov/hmcts/ccd/v2/external/domain/AddCaseAssignedUserRolesResponse.java
+++ b/src/main/java/uk/gov/hmcts/ccd/v2/external/domain/AddCaseAssignedUserRolesResponse.java
@@ -1,0 +1,24 @@
+package uk.gov.hmcts.ccd.v2.external.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import uk.gov.hmcts.ccd.v2.external.controller.CaseAssignedUserRolesController;
+
+@Data
+@NoArgsConstructor
+@ApiModel("Add Case-Assigned User Roles Response")
+public class AddCaseAssignedUserRolesResponse {
+
+    public AddCaseAssignedUserRolesResponse(String status) {
+        this.status = status;
+    }
+
+    @JsonProperty("status_message")
+    @ApiModelProperty(value = "Domain Status Message", required = true, example = CaseAssignedUserRolesController.ADD_SUCCESS_MESSAGE)
+    private String status;
+
+}
+

--- a/src/main/java/uk/gov/hmcts/ccd/v2/external/resource/CaseAssignedUserRolesResource.java
+++ b/src/main/java/uk/gov/hmcts/ccd/v2/external/resource/CaseAssignedUserRolesResource.java
@@ -1,10 +1,12 @@
 package uk.gov.hmcts.ccd.v2.external.resource;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import org.springframework.hateoas.Links;
 import org.springframework.hateoas.RepresentationModel;
 import uk.gov.hmcts.ccd.domain.model.std.CaseAssignedUserRole;
 
@@ -19,4 +21,11 @@ public class CaseAssignedUserRolesResource extends RepresentationModel {
     public CaseAssignedUserRolesResource(List<CaseAssignedUserRole> caseAssignedUserRoles) {
         this.caseAssignedUserRoles = caseAssignedUserRoles;
     }
+
+    @Override
+    @JsonIgnore
+    public Links getLinks() {
+        return super.getLinks();
+    }
+
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -72,7 +72,8 @@ idam.s2s-auth.totp_secret=${DATA_STORE_IDAM_KEY:AAAAAAAAAAAAAAAB}
 idam.s2s-auth.microservice=ccd_data
 idam.s2s-auth.url=${IDAM_S2S_URL:http://localhost:4502}
 
-casedatastore.authorised.services=${DATA_STORE_S2S_AUTHORISED_SERVICES:ccd_gw,ccd_data,ccd_ps}
+casedatastore.authorised.services=${DATA_STORE_S2S_AUTHORISED_SERVICES:ccd_gw,ccd_data,ccd_ps,aac_manage_case_assignment}
+casedatastore.authorised.services.add_caseassigned_user_roles=aac_manage_case_assignment
 
 ccd.defaultPrintUrl=${CCD_DEFAULTPRINTURL:http://localhost:3453/print/jurisdictions/:jid/case-types/:ctid/cases/:cid}
 ccd.defaultPrintName=CCD Print

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/cauroles/AuthorisedCaseAssignedUserRolesOperationTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/cauroles/AuthorisedCaseAssignedUserRolesOperationTest.java
@@ -13,6 +13,9 @@ import uk.gov.hmcts.ccd.endpoint.exceptions.CaseRoleAccessException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 class AuthorisedCaseAssignedUserRolesOperationTest {
@@ -32,6 +35,34 @@ class AuthorisedCaseAssignedUserRolesOperationTest {
             defaultCaseAssignedUserRolesOperation,
             caseAssignedUserRoleValidator);
         when(defaultCaseAssignedUserRolesOperation.findCaseUserRoles(anyList(), anyList())).thenReturn(createCaseAssignedUserRoles());
+    }
+
+    @Test
+    void shouldCallDefaultAddCaseUserRolesWhenAuthorised() {
+        // ARRANGE
+        List<CaseAssignedUserRole> caseAssignedUserRoles = createCaseAssignedUserRoles();
+        when(caseAssignedUserRoleValidator.canAddUserCaseRoles()).thenReturn(true);
+
+        // ACT
+        authorisedCaseAssignedUserRolesOperation.addCaseUserRoles(caseAssignedUserRoles);
+
+        // ASSERT
+        verify(defaultCaseAssignedUserRolesOperation).addCaseUserRoles(caseAssignedUserRoles);
+        verifyNoMoreInteractions(defaultCaseAssignedUserRolesOperation);
+    }
+
+    @Test
+    void shouldThrowExceptionWhenNotAuthorisedToAddCaseUserRoles() {
+        // ARRANGE
+        List<CaseAssignedUserRole> caseAssignedUserRoles = createCaseAssignedUserRoles();
+        when(caseAssignedUserRoleValidator.canAddUserCaseRoles()).thenReturn(false);
+
+        // ACT / ASSERT
+        assertThrows(
+            CaseRoleAccessException.class,
+            () -> authorisedCaseAssignedUserRolesOperation.addCaseUserRoles(caseAssignedUserRoles)
+        );
+        verifyZeroInteractions(defaultCaseAssignedUserRolesOperation);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/cauroles/DefaultCaseAssignedUserRolesOperationTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/cauroles/DefaultCaseAssignedUserRolesOperationTest.java
@@ -11,6 +11,8 @@ import uk.gov.hmcts.ccd.domain.service.caseaccess.CaseAccessOperation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 class DefaultCaseAssignedUserRolesOperationTest {
@@ -25,11 +27,25 @@ class DefaultCaseAssignedUserRolesOperationTest {
         MockitoAnnotations.initMocks(this);
 
         caseAssignedUserRolesOperation = new DefaultCaseAssignedUserRolesOperation(caseAccessOperation);
-        when(caseAssignedUserRolesOperation.findCaseUserRoles(anyList(), anyList())).thenReturn(createCaseAssignedUserRoles());
+    }
+
+    @Test
+    void addCaseUserRoles() {
+        // ARRANGE
+        List<CaseAssignedUserRole> caseAssignedUserRoles = createCaseAssignedUserRoles();
+
+        // ACT
+        caseAssignedUserRolesOperation.addCaseUserRoles(caseAssignedUserRoles);
+
+        // ASSERT
+        verify(caseAccessOperation).addCaseUserRoles(caseAssignedUserRoles);
+        verifyNoMoreInteractions(caseAccessOperation);
     }
 
     @Test
     void findCaseUserRoles() {
+        when(caseAssignedUserRolesOperation.findCaseUserRoles(anyList(), anyList())).thenReturn(createCaseAssignedUserRoles());
+
         List<CaseAssignedUserRole> caseAssignedUserRoles = caseAssignedUserRolesOperation
             .findCaseUserRoles(Lists.newArrayList(), Lists.newArrayList());
 

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/cauroles/rolevalidator/DefaultCaseAssignedUserRoleValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/cauroles/rolevalidator/DefaultCaseAssignedUserRoleValidatorTest.java
@@ -4,9 +4,11 @@ import com.google.common.collect.Lists;
 import java.util.Collections;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import uk.gov.hmcts.ccd.ApplicationParams;
 import uk.gov.hmcts.ccd.data.SecurityUtils;
 import uk.gov.hmcts.ccd.data.user.UserRepository;
 
@@ -20,6 +22,9 @@ class DefaultCaseAssignedUserRoleValidatorTest {
     private final String roleCaseworkerSolicitor = "caseworker-solicitor";
 
     @Mock
+    private ApplicationParams applicationParams;
+
+    @Mock
     private UserRepository userRepository;
 
     @Mock
@@ -31,50 +36,101 @@ class DefaultCaseAssignedUserRoleValidatorTest {
     void setUp() {
         MockitoAnnotations.initMocks(this);
 
-        caseAssignedUserRoleValidator = new DefaultCaseAssignedUserRoleValidator(userRepository, securityUtils);
+        caseAssignedUserRoleValidator = new DefaultCaseAssignedUserRoleValidator(
+            applicationParams,
+            userRepository,
+            securityUtils
+        );
     }
 
-    @Test
-    @DisplayName("Can access case roles when user has caseworker-caa")
-    void canAccessUserCaseRolesWhenUserRolesContainsValidAccessRole() {
-        when(userRepository.getUserRoles()).thenReturn(Collections.singleton(roleCaseworkerCaa));
-        boolean canAccess = caseAssignedUserRoleValidator.canAccessUserCaseRoles(Lists.newArrayList());
-        assertTrue(canAccess);
+    @Nested
+    @DisplayName("Can Access UserCaseRoles")
+    class CanAccessUserCaseRoles {
+
+        @Test
+        @DisplayName("Can access case roles when user has caseworker-caa")
+        void canAccessUserCaseRolesWhenUserRolesContainsValidAccessRole() {
+            when(userRepository.getUserRoles()).thenReturn(Collections.singleton(roleCaseworkerCaa));
+            boolean canAccess = caseAssignedUserRoleValidator.canAccessUserCaseRoles(Lists.newArrayList());
+            assertTrue(canAccess);
+        }
+
+        @Test
+        @DisplayName("Can access self case user roles")
+        void canAccessSelfUserCaseRolesWhenSelfUserIdPassed() {
+            when(userRepository.getUserRoles()).thenReturn(Collections.singleton(roleCaseworkerSolicitor));
+            when(userRepository.getUserId()).thenReturn("1234567");
+            boolean canAccess = caseAssignedUserRoleValidator.canAccessUserCaseRoles(Lists.newArrayList("1234567"));
+            assertTrue(canAccess);
+        }
+
+        @Test
+        @DisplayName("Can access self case user roles even same user id passed more than once")
+        void canAccessSelfUserCaseRolesWhenSelfUserIdPassedMoreThanOnce() {
+            when(userRepository.getUserRoles()).thenReturn(Collections.singleton(roleCaseworkerSolicitor));
+            when(userRepository.getUserId()).thenReturn("1234567");
+            boolean canAccess = caseAssignedUserRoleValidator.canAccessUserCaseRoles(Lists.newArrayList("1234567", "1234567"));
+            assertTrue(canAccess);
+        }
+
+        @Test
+        @DisplayName("Can not access other user case roles")
+        void canNotAccessOtherUserCaseRolesWhenMoreUserIdsPassedOtherThanSelf() {
+            when(userRepository.getUserRoles()).thenReturn(Collections.singleton(roleCaseworkerSolicitor));
+            when(userRepository.getUserId()).thenReturn("1234567");
+            boolean canAccess = caseAssignedUserRoleValidator.canAccessUserCaseRoles(Lists.newArrayList("1234567", "1234568"));
+            assertFalse(canAccess);
+        }
+
+        @Test
+        @DisplayName("Can not access other user case roles when self id not passed")
+        void canNotAccessOtherUserCaseRolesWhenSelfUserIdNotPassed() {
+            when(userRepository.getUserRoles()).thenReturn(Collections.singleton(roleCaseworkerSolicitor));
+            when(userRepository.getUserId()).thenReturn("1234567");
+            boolean canAccess = caseAssignedUserRoleValidator.canAccessUserCaseRoles(Lists.newArrayList("1234568"));
+            assertFalse(canAccess);
+        }
     }
 
-    @Test
-    @DisplayName("Can access self case user roles")
-    void canAccessSelfUserCaseRolesWhenSelfUserIdPassed() {
-        when(userRepository.getUserRoles()).thenReturn(Collections.singleton(roleCaseworkerSolicitor));
-        when(userRepository.getUserId()).thenReturn("1234567");
-        boolean canAccess = caseAssignedUserRoleValidator.canAccessUserCaseRoles(Lists.newArrayList("1234567"));
-        assertTrue(canAccess);
+
+    @Nested
+    @DisplayName("Can Add UserCaseRoles")
+    class CanAddUserCaseRoles {
+
+        @Test
+        @DisplayName("Can add UserCaseRoles when calling service is in authorised list")
+        void canAddUserCaseRolesWhenServiceIsInAuthorisedList() {
+            // ARRANGE
+            String myServiceName = "my-service";
+            when(applicationParams.getAuthorisedServicesForAddUserCaseRoles()).thenReturn(
+                Lists.newArrayList("other-service", myServiceName)
+            );
+            when(securityUtils.getServiceName()).thenReturn(myServiceName);
+
+            // ACT
+            boolean canAddUserCaseRoles = caseAssignedUserRoleValidator.canAddUserCaseRoles();
+
+            // ASSERT
+            assertTrue(canAddUserCaseRoles);
+        }
+
+        @Test
+        @DisplayName("Can not add UserCaseRoles when calling service is not in authorised list")
+        void canNotAddUserCaseRolesWhenServiceIsNotInAuthorisedList() {
+            // ARRANGE
+            String myServiceName = "my-service";
+            when(applicationParams.getAuthorisedServicesForAddUserCaseRoles()).thenReturn(
+                Lists.newArrayList("other-service")
+            );
+            when(securityUtils.getServiceName()).thenReturn(myServiceName);
+
+            // ACT
+            boolean canAddUserCaseRoles = caseAssignedUserRoleValidator.canAddUserCaseRoles();
+
+            // ASSERT
+            assertFalse(canAddUserCaseRoles);
+        }
+
     }
 
-    @Test
-    @DisplayName("Can access self case user roles even same user id passed more than once")
-    void canAccessSelfUserCaseRolesWhenSelfUserIdPassedMoreThanOnce() {
-        when(userRepository.getUserRoles()).thenReturn(Collections.singleton(roleCaseworkerSolicitor));
-        when(userRepository.getUserId()).thenReturn("1234567");
-        boolean canAccess = caseAssignedUserRoleValidator.canAccessUserCaseRoles(Lists.newArrayList("1234567", "1234567"));
-        assertTrue(canAccess);
-    }
-
-    @Test
-    @DisplayName("Can not access other user case roles")
-    void canNotAccessOtherUserCaseRolesWhenMoreUserIdsPassedOtherThanSelf() {
-        when(userRepository.getUserRoles()).thenReturn(Collections.singleton(roleCaseworkerSolicitor));
-        when(userRepository.getUserId()).thenReturn("1234567");
-        boolean canAccess = caseAssignedUserRoleValidator.canAccessUserCaseRoles(Lists.newArrayList("1234567", "1234568"));
-        assertFalse(canAccess);
-    }
-
-    @Test
-    @DisplayName("Can not access other user case roles when self id not passed")
-    void canNotAccessOtherUserCaseRolesWhenSelfUserIdNotPassed() {
-        when(userRepository.getUserRoles()).thenReturn(Collections.singleton(roleCaseworkerSolicitor));
-        when(userRepository.getUserId()).thenReturn("1234567");
-        boolean canAccess = caseAssignedUserRoleValidator.canAccessUserCaseRoles(Lists.newArrayList("1234568"));
-        assertFalse(canAccess);
-    }
 }

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/cauroles/rolevalidator/DefaultCaseAssignedUserRoleValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/cauroles/rolevalidator/DefaultCaseAssignedUserRoleValidatorTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import uk.gov.hmcts.ccd.data.SecurityUtils;
 import uk.gov.hmcts.ccd.data.user.UserRepository;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -21,13 +22,16 @@ class DefaultCaseAssignedUserRoleValidatorTest {
     @Mock
     private UserRepository userRepository;
 
+    @Mock
+    private SecurityUtils securityUtils;
+
     private DefaultCaseAssignedUserRoleValidator caseAssignedUserRoleValidator;
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.initMocks(this);
 
-        caseAssignedUserRoleValidator = new DefaultCaseAssignedUserRoleValidator(userRepository);
+        caseAssignedUserRoleValidator = new DefaultCaseAssignedUserRoleValidator(userRepository, securityUtils);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/ccd/v2/external/controller/CaseAssignedUserRolesControllerIT.java
+++ b/src/test/java/uk/gov/hmcts/ccd/v2/external/controller/CaseAssignedUserRolesControllerIT.java
@@ -1,62 +1,102 @@
 package uk.gov.hmcts.ccd.v2.external.controller;
 
+import com.google.common.collect.Lists;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import java.io.IOException;
+import java.util.List;
 import javax.inject.Inject;
-import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
+import uk.gov.hmcts.ccd.ApplicationParams;
 import uk.gov.hmcts.ccd.MockUtils;
 import uk.gov.hmcts.ccd.WireMockBaseTest;
+import uk.gov.hmcts.ccd.auditlog.AuditEntry;
+import uk.gov.hmcts.ccd.auditlog.AuditOperationType;
+import uk.gov.hmcts.ccd.auditlog.AuditRepository;
+import uk.gov.hmcts.ccd.data.caseaccess.CaseUserRepository;
+import uk.gov.hmcts.ccd.data.caseaccess.DefaultCaseUserRepository;
+import uk.gov.hmcts.ccd.domain.model.std.CaseAssignedUserRole;
 import uk.gov.hmcts.ccd.v2.V2;
+import uk.gov.hmcts.ccd.v2.external.domain.AddCaseAssignedUserRolesResponse;
 import uk.gov.hmcts.ccd.v2.external.resource.CaseAssignedUserRolesResource;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.ccd.v2.V2.Error.OTHER_USER_CASE_ROLE_ACCESS_NOT_GRANTED;
+import static uk.gov.hmcts.ccd.v2.external.controller.CaseAssignedUserRolesController.ADD_SUCCESS_MESSAGE;
 
 class CaseAssignedUserRolesControllerIT extends WireMockBaseTest {
 
     private static final Long INVALID_CASE_ID = 222L;
 
+    private static final String AUTHORISED_ADD_SERVICE_1 = "ADD_SERVICE_1";
+    private static final String AUTHORISED_ADD_SERVICE_2 = "ADD_SERVICE_2";
+
     private static final String CASE_ID_1 = "7578590391163133";
     private static final String CASE_ID_2 = "6375837333991692";
     private static final String CASE_IDS = CASE_ID_1 + "," + CASE_ID_2;
 
+    private static final String CASE_ID_ADD_SUCCESS = "1111222233334444";
+    private static final String CASE_ID_ADD_FAILURE = "4444333322221111";
+
+    private static final String CASE_ROLE_1 = "[case-role-1]";
+    private static final String CASE_ROLE_2 = "[case-role-2]";
+    private static final String INVALID_CASE_ROLE = "bad-role";
+
     private static final String USER_IDS_1 = "89000";
     private static final String USER_IDS_2 = "89001";
     private static final String USER_IDS_3 = "89002";
+    private static final String USER_IDS_4 = "89003";
     private static final String USER_IDS = USER_IDS_1 + "," + USER_IDS_2;
 
     private static final String INVALID_USER_IDS = USER_IDS_1 + ", ," + USER_IDS_2;
 
+    @SuppressWarnings("SpellCheckingInspection")
+    private static final String SERVICE_NAME = "servicename";
+
     private final String caseworkerCaa = "caseworker-caa";
     private final String getCaseAssignedUserRoles = "/case-users";
+    private final String postCaseAssignedUserRoles = "/case-users";
 
     private static final String PARAM_CASE_IDS = "case_ids";
     private static final String PARAM_USER_IDS = "user_ids";
+
+    @Inject
+    private ApplicationParams applicationParams;
+
+    @SpyBean @Inject
+    private AuditRepository auditRepository;
 
     @Mock
     private Authentication authentication;
@@ -65,6 +105,9 @@ class CaseAssignedUserRolesControllerIT extends WireMockBaseTest {
     private SecurityContext securityContext;
 
     private MockMvc mockMvc;
+
+    @Inject @Qualifier(DefaultCaseUserRepository.QUALIFIER)
+    private CaseUserRepository caseUserRepository;
 
     @Inject
     private WebApplicationContext wac;
@@ -79,8 +122,418 @@ class CaseAssignedUserRolesControllerIT extends WireMockBaseTest {
 
         MockUtils.setSecurityAuthorities(authentication, MockUtils.ROLE_CASEWORKER_PUBLIC);
 
+        ReflectionTestUtils.setField(
+            applicationParams,
+            "authorisedServicesForAddUserCaseRoles",
+            Lists.newArrayList(AUTHORISED_ADD_SERVICE_1, AUTHORISED_ADD_SERVICE_2)
+        );
+
         mockMvc = MockMvcBuilders.webAppContextSetup(wac).build();
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    }
+
+    // RDM-8606: AC-1
+    @Test
+    @DisplayName(
+        "addCaseUserRoles: AC-1: must successfully assign a user and case role for a specific case by a user calling through/from an authorised application"
+    )
+    public void addCaseUserRoles_shouldAddCaseUserRoleForAuthorisedApp() throws Exception {
+        // ARRANGE
+        MockUtils.setSecurityAuthorities(authentication);
+        ReflectionTestUtils.setField(authentication.getPrincipal(), SERVICE_NAME, AUTHORISED_ADD_SERVICE_1);
+
+        List<CaseAssignedUserRole> caseUserRoles = Lists.newArrayList();
+        CaseAssignedUserRole caseUserRole1 = new CaseAssignedUserRole(CASE_ID_ADD_SUCCESS, USER_IDS_1, CASE_ROLE_1);
+        caseUserRoles.add(caseUserRole1);
+
+        // ACT
+        final MvcResult result = mockMvc.perform(post(postCaseAssignedUserRoles)
+            .contentType(JSON_CONTENT_TYPE)
+            .content(mapper.writeValueAsBytes(new CaseAssignedUserRolesResource(caseUserRoles)))
+            .headers(createHttpHeaders()))
+            .andExpect(status().is(200))
+            .andReturn();
+
+        // ASSERT
+        assertEquals(result.getResponse().getContentAsString(), 200, result.getResponse().getStatus());
+        String content = result.getResponse().getContentAsString();
+        assertNotNull("Content Should not be null", content);
+        AddCaseAssignedUserRolesResponse response = mapper.readValue(content, AddCaseAssignedUserRolesResponse.class);
+        assertNotNull("Response should not be null", response);
+        assertEquals("Success message should be returned", ADD_SUCCESS_MESSAGE, response.getStatus());
+
+        // check data has been saved
+        List<String> caseRoles = caseUserRepository.findCaseRoles(Long.valueOf(CASE_ID_ADD_SUCCESS), USER_IDS_1);
+        assertEquals(1, caseRoles.size());
+        assertThat(caseRoles, hasItems(CASE_ROLE_1));
+    }
+
+    // RDM-8606: AC-2
+    @Test
+    @DisplayName("addCaseUserRoles: AC-2: Must return an error response for a missing Case ID")
+    public void addCaseUserRoles_shouldThrowExceptionWhenCaseIDNotPassed() throws Exception {
+        // ARRANGE
+        MockUtils.setSecurityAuthorities(authentication);
+        ReflectionTestUtils.setField(authentication.getPrincipal(), SERVICE_NAME, AUTHORISED_ADD_SERVICE_1);
+
+        List<CaseAssignedUserRole> caseUserRoles = Lists.newArrayList();
+        CaseAssignedUserRole caseUserRole1 = new CaseAssignedUserRole(CASE_ID_ADD_FAILURE, USER_IDS_1, CASE_ROLE_1);
+        CaseAssignedUserRole caseUserRole2 = new CaseAssignedUserRole(null, USER_IDS_1, CASE_ROLE_1);
+        caseUserRoles.add(caseUserRole1);
+        caseUserRoles.add(caseUserRole2);
+
+        // ACT
+        Exception exception = mockMvc.perform(post(postCaseAssignedUserRoles)
+            .contentType(JSON_CONTENT_TYPE)
+            .content(mapper.writeValueAsBytes(new CaseAssignedUserRolesResource(caseUserRoles)))
+            .headers(createHttpHeaders()))
+            .andExpect(status().is(400))
+            .andReturn().getResolvedException();
+
+        // ASSERT
+        assertNotNull(exception);
+        assertThat(exception.getMessage(), containsString(V2.Error.CASE_ID_INVALID));
+
+        // check data has not been saved
+        List<String> caseRoles = caseUserRepository.findCaseRoles(Long.valueOf(CASE_ID_ADD_FAILURE), USER_IDS_1);
+        assertEquals(0, caseRoles.size());
+    }
+
+    // RDM-8606: AC-3
+    @Test
+    @DisplayName("addCaseUserRoles: AC-3: Must return an error response for a malformed Case ID")
+    public void addCaseUserRoles_shouldThrowExceptionWhenInvalidCaseIDPassed() throws Exception {
+        // ARRANGE
+        MockUtils.setSecurityAuthorities(authentication);
+        ReflectionTestUtils.setField(authentication.getPrincipal(), SERVICE_NAME, AUTHORISED_ADD_SERVICE_1);
+
+        List<CaseAssignedUserRole> caseUserRoles = Lists.newArrayList();
+        CaseAssignedUserRole caseUserRole1 = new CaseAssignedUserRole(CASE_ID_ADD_FAILURE, USER_IDS_1, CASE_ROLE_1);
+        CaseAssignedUserRole caseUserRole2 = new CaseAssignedUserRole(INVALID_CASE_ID.toString(), USER_IDS_1, CASE_ROLE_1);
+        caseUserRoles.add(caseUserRole1);
+        caseUserRoles.add(caseUserRole2);
+
+        // ACT
+        Exception exception = mockMvc.perform(post(postCaseAssignedUserRoles)
+            .contentType(JSON_CONTENT_TYPE)
+            .content(mapper.writeValueAsBytes(new CaseAssignedUserRolesResource(caseUserRoles)))
+            .headers(createHttpHeaders()))
+            .andExpect(status().is(400))
+            .andReturn().getResolvedException();
+
+        // ASSERT
+        assertNotNull(exception);
+        assertThat(exception.getMessage(), containsString(V2.Error.CASE_ID_INVALID));
+
+        // check data has not been saved
+        List<String> caseRoles = caseUserRepository.findCaseRoles(Long.valueOf(CASE_ID_ADD_FAILURE), USER_IDS_2);
+        assertEquals(0, caseRoles.size());
+    }
+
+    // RDM-8606: AC-4
+    @Test
+    @DisplayName("addCaseUserRoles: AC-4: Must return an error response for a missing User ID")
+    public void addCaseUserRoles_shouldThrowExceptionWhenUserIDNotPassed() throws Exception {
+        // ARRANGE
+        MockUtils.setSecurityAuthorities(authentication);
+        ReflectionTestUtils.setField(authentication.getPrincipal(), SERVICE_NAME, AUTHORISED_ADD_SERVICE_1);
+
+        List<CaseAssignedUserRole> caseUserRoles = Lists.newArrayList();
+        CaseAssignedUserRole caseUserRole1 = new CaseAssignedUserRole(CASE_ID_ADD_FAILURE, USER_IDS_1, CASE_ROLE_1);
+        CaseAssignedUserRole caseUserRole2 = new CaseAssignedUserRole(CASE_ID_ADD_FAILURE, null, CASE_ROLE_1);
+        caseUserRoles.add(caseUserRole1);
+        caseUserRoles.add(caseUserRole2);
+
+        // ACT
+        Exception exception = mockMvc.perform(post(postCaseAssignedUserRoles)
+            .contentType(JSON_CONTENT_TYPE)
+            .content(mapper.writeValueAsBytes(new CaseAssignedUserRolesResource(caseUserRoles)))
+            .headers(createHttpHeaders()))
+            .andExpect(status().is(400))
+            .andReturn().getResolvedException();
+
+        // ASSERT
+        assertNotNull(exception);
+        assertThat(exception.getMessage(), containsString(V2.Error.USER_ID_INVALID));
+
+        // check data has not been saved
+        List<String> caseRoles = caseUserRepository.findCaseRoles(Long.valueOf(CASE_ID_ADD_FAILURE), USER_IDS_1);
+        assertEquals(0, caseRoles.size());
+    }
+
+    // RDM-8606: AC-5
+    @Test
+    @DisplayName("addCaseUserRoles: AC-5: Must return an error response for a malformed User ID Provided")
+    public void addCaseUserRoles_shouldThrowExceptionWhenInvalidUserIDPassed() throws Exception {
+        // ARRANGE
+        MockUtils.setSecurityAuthorities(authentication);
+        ReflectionTestUtils.setField(authentication.getPrincipal(), SERVICE_NAME, AUTHORISED_ADD_SERVICE_1);
+
+        List<CaseAssignedUserRole> caseUserRoles = Lists.newArrayList();
+        CaseAssignedUserRole caseUserRole1 = new CaseAssignedUserRole(CASE_ID_ADD_FAILURE, USER_IDS_1, CASE_ROLE_1);
+        CaseAssignedUserRole caseUserRole2 = new CaseAssignedUserRole(CASE_ID_ADD_FAILURE, "", CASE_ROLE_1);
+        caseUserRoles.add(caseUserRole1);
+        caseUserRoles.add(caseUserRole2);
+
+        // ACT
+        Exception exception = mockMvc.perform(post(postCaseAssignedUserRoles)
+            .contentType(JSON_CONTENT_TYPE)
+            .content(mapper.writeValueAsBytes(new CaseAssignedUserRolesResource(caseUserRoles)))
+            .headers(createHttpHeaders()))
+            .andExpect(status().is(400))
+            .andReturn().getResolvedException();
+
+        // ASSERT
+        assertNotNull(exception);
+        assertThat(exception.getMessage(), containsString(V2.Error.USER_ID_INVALID));
+
+        // check data has not been saved
+        List<String> caseRoles = caseUserRepository.findCaseRoles(Long.valueOf(CASE_ID_ADD_FAILURE), USER_IDS_1);
+        assertEquals(0, caseRoles.size());
+    }
+
+    // RDM-8606: AC-6
+    @Test
+    @DisplayName("addCaseUserRoles: AC-6: must return an error response when the request is made from an un-authorised application")
+    public void addCaseUserRoles_shouldThrowExceptionWhenCalledFromUnauthorisedApp() throws Exception {
+        // ARRANGE
+        MockUtils.setSecurityAuthorities(authentication);
+        ReflectionTestUtils.setField(authentication.getPrincipal(), SERVICE_NAME, "UNAUTHORISED_ADD_SERVICE");
+
+        List<CaseAssignedUserRole> caseUserRoles = Lists.newArrayList();
+        CaseAssignedUserRole caseUserRole1 = new CaseAssignedUserRole(CASE_ID_ADD_FAILURE, USER_IDS_1, CASE_ROLE_1);
+        caseUserRoles.add(caseUserRole1);
+
+        // ACT
+        Exception exception = mockMvc.perform(post(postCaseAssignedUserRoles)
+            .contentType(JSON_CONTENT_TYPE)
+            .content(mapper.writeValueAsBytes(new CaseAssignedUserRolesResource(caseUserRoles)))
+            .headers(createHttpHeaders()))
+            .andExpect(status().is(403))
+            .andReturn().getResolvedException();
+
+        // ASSERT
+        assertNotNull(exception);
+        assertThat(exception.getMessage(), containsString(V2.Error.CLIENT_SERVICE_NOT_AUTHORISED_FOR_OPERATION));
+
+        // check data has not been saved
+        List<String> caseRoles = caseUserRepository.findCaseRoles(Long.valueOf(CASE_ID_ADD_FAILURE), USER_IDS_1);
+        assertEquals(0, caseRoles.size());
+    }
+
+    // RDM-8606: AC-7
+    @Test
+    @DisplayName("addCaseUserRoles: AC-7: Must return an error response for a malformed Case Role provided")
+    public void addCaseUserRoles_shouldThrowExceptionWhenInvalidCaseRolePassed() throws Exception {
+        // ARRANGE
+        MockUtils.setSecurityAuthorities(authentication);
+        ReflectionTestUtils.setField(authentication.getPrincipal(), SERVICE_NAME, AUTHORISED_ADD_SERVICE_1);
+
+        List<CaseAssignedUserRole> caseUserRoles = Lists.newArrayList();
+        CaseAssignedUserRole caseUserRole1 = new CaseAssignedUserRole(CASE_ID_ADD_FAILURE, USER_IDS_1, CASE_ROLE_1);
+        CaseAssignedUserRole caseUserRole2 = new CaseAssignedUserRole(CASE_ID_ADD_FAILURE, USER_IDS_1, INVALID_CASE_ROLE);
+        caseUserRoles.add(caseUserRole1);
+        caseUserRoles.add(caseUserRole2);
+
+        // ACT
+        Exception exception = mockMvc.perform(post(postCaseAssignedUserRoles)
+            .contentType(JSON_CONTENT_TYPE)
+            .content(mapper.writeValueAsBytes(new CaseAssignedUserRolesResource(caseUserRoles)))
+            .headers(createHttpHeaders()))
+            .andExpect(status().is(400))
+            .andReturn().getResolvedException();
+
+        // ASSERT
+        assertNotNull(exception);
+        assertThat(exception.getMessage(), containsString(V2.Error.CASE_ROLE_FORMAT_INVALID));
+
+        // check data has not been saved
+        List<String> caseRoles = caseUserRepository.findCaseRoles(Long.valueOf(CASE_ID_ADD_FAILURE), USER_IDS_1);
+        assertEquals(0, caseRoles.size());
+    }
+
+    // RDM-8606: AC-8
+    @Test
+    @DisplayName("addCaseUserRoles: AC-8: Must return an error response for a missing Case Role")
+    public void addCaseUserRoles_shouldThrowExceptionWhenCaseRoleNotPassed() throws Exception {
+        // ARRANGE
+        MockUtils.setSecurityAuthorities(authentication);
+        ReflectionTestUtils.setField(authentication.getPrincipal(), SERVICE_NAME, AUTHORISED_ADD_SERVICE_1);
+
+        List<CaseAssignedUserRole> caseUserRoles = Lists.newArrayList();
+        CaseAssignedUserRole caseUserRole1 = new CaseAssignedUserRole(CASE_ID_ADD_FAILURE, USER_IDS_1, CASE_ROLE_1);
+        CaseAssignedUserRole caseUserRole2 = new CaseAssignedUserRole(CASE_ID_ADD_FAILURE, USER_IDS_1, null);
+        caseUserRoles.add(caseUserRole1);
+        caseUserRoles.add(caseUserRole2);
+
+        // ACT
+        Exception exception = mockMvc.perform(post(postCaseAssignedUserRoles)
+            .contentType(JSON_CONTENT_TYPE)
+            .content(mapper.writeValueAsBytes(new CaseAssignedUserRolesResource(caseUserRoles)))
+            .headers(createHttpHeaders()))
+            .andExpect(status().is(400))
+            .andReturn().getResolvedException();
+
+        // ASSERT
+        assertNotNull(exception);
+        assertThat(exception.getMessage(), containsString(V2.Error.CASE_ROLE_FORMAT_INVALID));
+
+        // check data has not been saved
+        List<String> caseRoles = caseUserRepository.findCaseRoles(Long.valueOf(CASE_ID_ADD_FAILURE), USER_IDS_1);
+        assertEquals(0, caseRoles.size());
+    }
+
+    // RDM-8606: null
+    @Test
+    @DisplayName("addCaseUserRoles: null: should throw exception")
+    public void addCaseUserRoles_shouldThrowExceptionWhenNullListPassed() throws Exception {
+        // ARRANGE
+        MockUtils.setSecurityAuthorities(authentication);
+        ReflectionTestUtils.setField(authentication.getPrincipal(), SERVICE_NAME, AUTHORISED_ADD_SERVICE_1);
+
+        // ACT
+        Exception exception = mockMvc.perform(post(postCaseAssignedUserRoles)
+            .contentType(JSON_CONTENT_TYPE)
+            .content(mapper.writeValueAsBytes(new CaseAssignedUserRolesResource(null)))
+            .headers(createHttpHeaders()))
+            .andExpect(status().is(400))
+            .andReturn().getResolvedException();
+
+        // ASSERT
+        assertNotNull(exception);
+        assertThat(exception.getMessage(), containsString(V2.Error.EMPTY_CASE_USER_ROLE_LIST));
+    }
+
+    // RDM-8606: empty-list
+    @Test
+    @DisplayName("addCaseUserRoles: empty-list: should throw exception")
+    public void addCaseUserRoles_shouldThrowExceptionWhenEmptyListPassed() throws Exception {
+        // ARRANGE
+        MockUtils.setSecurityAuthorities(authentication);
+        ReflectionTestUtils.setField(authentication.getPrincipal(), SERVICE_NAME, AUTHORISED_ADD_SERVICE_1);
+
+        List<CaseAssignedUserRole> caseUserRoles = Lists.newArrayList();
+
+        // ACT
+        Exception exception = mockMvc.perform(post(postCaseAssignedUserRoles)
+            .contentType(JSON_CONTENT_TYPE)
+            .content(mapper.writeValueAsBytes(new CaseAssignedUserRolesResource(caseUserRoles)))
+            .headers(createHttpHeaders()))
+            .andExpect(status().is(400))
+            .andReturn().getResolvedException();
+
+        // ASSERT
+        assertNotNull(exception);
+        assertThat(exception.getMessage(), containsString(V2.Error.EMPTY_CASE_USER_ROLE_LIST));
+    }
+
+    // RDM-8606: duplicate
+    @Test
+    @DisplayName("addCaseUserRoles: duplicate: should not generate duplicates")
+    public void addCaseUserRoles_shouldAddSingleCaseUserRoleWhenDuplicatePassed() throws Exception {
+        // ARRANGE
+        MockUtils.setSecurityAuthorities(authentication);
+        ReflectionTestUtils.setField(authentication.getPrincipal(), SERVICE_NAME, AUTHORISED_ADD_SERVICE_1);
+
+        List<CaseAssignedUserRole> caseUserRoles = Lists.newArrayList();
+        CaseAssignedUserRole caseUserRole1 = new CaseAssignedUserRole(CASE_ID_ADD_SUCCESS, USER_IDS_2, CASE_ROLE_1);
+        CaseAssignedUserRole caseUserRole2 = new CaseAssignedUserRole(CASE_ID_ADD_SUCCESS, USER_IDS_2, CASE_ROLE_1);
+        caseUserRoles.add(caseUserRole1);
+        caseUserRoles.add(caseUserRole2);
+
+        // ACT
+        final MvcResult result = mockMvc.perform(post(postCaseAssignedUserRoles)
+            .contentType(JSON_CONTENT_TYPE)
+            .content(mapper.writeValueAsBytes(new CaseAssignedUserRolesResource(caseUserRoles)))
+            .headers(createHttpHeaders()))
+            .andExpect(status().is(200))
+            .andReturn();
+
+        // ASSERT
+        assertEquals(result.getResponse().getContentAsString(), 200, result.getResponse().getStatus());
+        String content = result.getResponse().getContentAsString();
+        assertNotNull("Content Should not be null", content);
+        AddCaseAssignedUserRolesResponse response = mapper.readValue(content, AddCaseAssignedUserRolesResponse.class);
+        assertNotNull("Response should not be null", response);
+        assertEquals("Success message should be returned", ADD_SUCCESS_MESSAGE, response.getStatus());
+
+        // check data has been saved
+        List<String> caseRoles = caseUserRepository.findCaseRoles(Long.valueOf(CASE_ID_ADD_SUCCESS), USER_IDS_2);
+        assertEquals(1, caseRoles.size());
+        assertThat(caseRoles, hasItems(CASE_ROLE_1));
+    }
+
+    // RDM-8606: multiple
+    @Test
+    @DisplayName("addCaseUserRoles: multiple: should allow multiple CaseUserRoles to be added in single call")
+    public void addCaseUserRoles_shouldAddMultipleCaseUserRoles() throws Exception {
+        // ARRANGE
+        MockUtils.setSecurityAuthorities(authentication);
+        ReflectionTestUtils.setField(authentication.getPrincipal(), SERVICE_NAME, AUTHORISED_ADD_SERVICE_1);
+
+        List<CaseAssignedUserRole> caseUserRoles = Lists.newArrayList();
+        CaseAssignedUserRole caseUserRole1 = new CaseAssignedUserRole(CASE_ID_ADD_SUCCESS, USER_IDS_3, CASE_ROLE_1);
+        CaseAssignedUserRole caseUserRole2 = new CaseAssignedUserRole(CASE_ID_ADD_SUCCESS, USER_IDS_3, CASE_ROLE_2);
+        caseUserRoles.add(caseUserRole1);
+        caseUserRoles.add(caseUserRole2);
+
+        // ACT
+        final MvcResult result = mockMvc.perform(post(postCaseAssignedUserRoles)
+            .contentType(JSON_CONTENT_TYPE)
+            .content(mapper.writeValueAsBytes(new CaseAssignedUserRolesResource(caseUserRoles)))
+            .headers(createHttpHeaders()))
+            .andExpect(status().is(200))
+            .andReturn();
+
+        // ASSERT
+        assertEquals(result.getResponse().getContentAsString(), 200, result.getResponse().getStatus());
+        String content = result.getResponse().getContentAsString();
+        assertNotNull("Content Should not be null", content);
+        AddCaseAssignedUserRolesResponse response = mapper.readValue(content, AddCaseAssignedUserRolesResponse.class);
+        assertNotNull("Response should not be null", response);
+        assertEquals("Success message should be returned", ADD_SUCCESS_MESSAGE, response.getStatus());
+
+        // check data has been saved
+        List<String> caseRoles = caseUserRepository.findCaseRoles(Long.valueOf(CASE_ID_ADD_SUCCESS), USER_IDS_3);
+        assertEquals(2, caseRoles.size());
+        assertThat(caseRoles, hasItems(CASE_ROLE_1));
+        assertThat(caseRoles, hasItems(CASE_ROLE_2));
+    }
+
+    // RDM-8606: log-audit
+    @Test
+    @DisplayName("addCaseUserRoles: log-audit: should allow multiple CaseUserRoles to be added in single call")
+    public void addCaseUserRoles_shouldCreateLogAuditWhenCalled() throws Exception {
+        // ARRANGE
+        MockUtils.setSecurityAuthorities(authentication);
+        ReflectionTestUtils.setField(authentication.getPrincipal(), SERVICE_NAME, AUTHORISED_ADD_SERVICE_1);
+
+        List<CaseAssignedUserRole> caseUserRoles = Lists.newArrayList();
+        CaseAssignedUserRole caseUserRole1 = new CaseAssignedUserRole(CASE_ID_ADD_SUCCESS, USER_IDS_4, CASE_ROLE_1);
+        CaseAssignedUserRole caseUserRole2 = new CaseAssignedUserRole(CASE_ID_ADD_SUCCESS, USER_IDS_4, CASE_ROLE_2);
+        caseUserRoles.add(caseUserRole1);
+        caseUserRoles.add(caseUserRole2);
+
+        // ACT
+        mockMvc.perform(post(postCaseAssignedUserRoles)
+            .contentType(JSON_CONTENT_TYPE)
+            .content(mapper.writeValueAsBytes(new CaseAssignedUserRolesResource(caseUserRoles)))
+            .headers(createHttpHeaders()))
+            .andExpect(status().is(200))
+            .andReturn();
+
+        // ASSERT
+        ArgumentCaptor<AuditEntry> captor = ArgumentCaptor.forClass(AuditEntry.class);
+        verify(auditRepository).save(captor.capture());
+
+        assertThat(captor.getValue().getOperationType(), is(AuditOperationType.ADD_CASE_ASSIGNED_USER_ROLES.getLabel()));
+        assertThat(captor.getValue().getCaseId(), is(CASE_ID_ADD_SUCCESS + "," + CASE_ID_ADD_SUCCESS));
+        assertThat(captor.getValue().getTargetCaseRoles(), is(Lists.newArrayList(CASE_ROLE_1, CASE_ROLE_2)));
+        assertThat(captor.getValue().getTargetIdamId(), is(USER_IDS_4 + "," + USER_IDS_4));
+        assertThat(captor.getValue().getInvokingService(), is(AUTHORISED_ADD_SERVICE_1));
+        assertThat(captor.getValue().getHttpStatus(), is(200));
+        assertThat(captor.getValue().getPath(), is(postCaseAssignedUserRoles));
+        assertThat(captor.getValue().getHttpMethod(), is(HttpMethod.POST.name()));
     }
 
     // AC-1
@@ -119,7 +572,7 @@ class CaseAssignedUserRolesControllerIT extends WireMockBaseTest {
         final MvcResult result = mockMvc.perform(get(getCaseAssignedUserRoles)
             .contentType(JSON_CONTENT_TYPE)
             .param(PARAM_CASE_IDS, CASE_IDS)
-            .param(PARAM_USER_IDS, USER_IDS_1.toString())
+            .param(PARAM_USER_IDS, USER_IDS_1)
             .headers(createHttpHeaders()))
             .andExpect(status().is(200))
             .andReturn();
@@ -146,7 +599,7 @@ class CaseAssignedUserRolesControllerIT extends WireMockBaseTest {
 
         final MvcResult result = mockMvc.perform(get(getCaseAssignedUserRoles)
             .contentType(JSON_CONTENT_TYPE)
-            .param(PARAM_CASE_IDS, CASE_ID_2.toString())
+            .param(PARAM_CASE_IDS, CASE_ID_2)
             .headers(createHttpHeaders()))
             .andExpect(status().is(200))
             .andReturn();
@@ -199,10 +652,10 @@ class CaseAssignedUserRolesControllerIT extends WireMockBaseTest {
         assertAll(
             () -> assertThat(caseAssignedUserRolesResource.getCaseAssignedUserRoles(),
                 hasItems(allOf(hasProperty("caseDataId", Matchers.is(CASE_ID_1)),
-                hasProperty("userId", Matchers.is(USER_IDS_1)),
-                hasProperty("caseRole", Matchers.is("[CREATOR]"))))),
+                    hasProperty("userId", Matchers.is(USER_IDS_1)),
+                    hasProperty("caseRole", Matchers.is("[CREATOR]"))))),
             () -> assertThat(caseAssignedUserRolesResource.getCaseAssignedUserRoles(),
-                    hasItems(allOf(hasProperty("caseDataId", Matchers.is(CASE_ID_2)),
+                hasItems(allOf(hasProperty("caseDataId", Matchers.is(CASE_ID_2)),
                     hasProperty("userId", Matchers.is(USER_IDS_2)),
                     hasProperty("caseRole", Matchers.is("[DEFENDANT]"))))));
     }
@@ -212,15 +665,16 @@ class CaseAssignedUserRolesControllerIT extends WireMockBaseTest {
     public void shouldThrowExceptionWhenEmptyCaseIDListPassed() throws Exception {
         MockUtils.setSecurityAuthorities(authentication, MockUtils.ROLE_CASEWORKER_PUBLIC, caseworkerCaa);
 
-        String errorMessage = mockMvc.perform(get(getCaseAssignedUserRoles)
+        Exception exception = mockMvc.perform(get(getCaseAssignedUserRoles)
             .contentType(JSON_CONTENT_TYPE)
             .param(PARAM_CASE_IDS, "")
             .param(PARAM_USER_IDS, USER_IDS)
             .headers(createHttpHeaders()))
             .andExpect(status().is(400))
-            .andReturn().getResolvedException().getMessage();
+            .andReturn().getResolvedException();
 
-        assertTrue(StringUtils.contains(errorMessage, V2.Error.EMPTY_CASE_ID_LIST));
+        assertNotNull(exception);
+        assertThat(exception.getMessage(), containsString(V2.Error.EMPTY_CASE_ID_LIST));
     }
 
     @Test
@@ -240,15 +694,16 @@ class CaseAssignedUserRolesControllerIT extends WireMockBaseTest {
     public void shouldThrowExceptionWhenInvalidCaseIDIsPassed() throws Exception {
         MockUtils.setSecurityAuthorities(authentication, MockUtils.ROLE_CASEWORKER_PUBLIC, caseworkerCaa);
 
-        String errorMessage = mockMvc.perform(get(getCaseAssignedUserRoles)
+        Exception exception = mockMvc.perform(get(getCaseAssignedUserRoles)
             .contentType(JSON_CONTENT_TYPE)
             .param(PARAM_CASE_IDS, INVALID_CASE_ID.toString())
             .param(PARAM_USER_IDS, USER_IDS)
             .headers(createHttpHeaders()))
             .andExpect(status().is(400))
-            .andReturn().getResolvedException().getMessage();
+            .andReturn().getResolvedException();
 
-        assertTrue(StringUtils.contains(errorMessage, V2.Error.CASE_ID_INVALID));
+        assertNotNull(exception);
+        assertThat(exception.getMessage(), containsString(V2.Error.CASE_ID_INVALID));
     }
 
     // AC-7
@@ -256,15 +711,16 @@ class CaseAssignedUserRolesControllerIT extends WireMockBaseTest {
     public void shouldThrowExceptionWhenInvalidUserIdDataPassed() throws Exception {
         MockUtils.setSecurityAuthorities(authentication, MockUtils.ROLE_CASEWORKER_PUBLIC, caseworkerCaa);
 
-        String errorMessage = mockMvc.perform(get(getCaseAssignedUserRoles)
+        Exception exception = mockMvc.perform(get(getCaseAssignedUserRoles)
             .contentType(JSON_CONTENT_TYPE)
             .param(PARAM_CASE_IDS, CASE_IDS)
             .param(PARAM_USER_IDS, INVALID_USER_IDS)
             .headers(createHttpHeaders()))
             .andExpect(status().is(400))
-            .andReturn().getResolvedException().getMessage();
+            .andReturn().getResolvedException();
 
-        assertTrue(StringUtils.contains(errorMessage, V2.Error.USER_ID_INVALID));
+        assertNotNull(exception);
+        assertThat(exception.getMessage(), containsString(V2.Error.USER_ID_INVALID));
     }
 
     // AC-8
@@ -272,36 +728,39 @@ class CaseAssignedUserRolesControllerIT extends WireMockBaseTest {
     public void shouldThrowExceptionWhenInvokingUserHasNoPrivileges() throws Exception {
         MockUtils.setSecurityAuthorities(authentication, MockUtils.ROLE_CASEWORKER_PUBLIC);
 
-        String errorMessage = mockMvc.perform(get(getCaseAssignedUserRoles)
+        Exception exception = mockMvc.perform(get(getCaseAssignedUserRoles)
             .contentType(JSON_CONTENT_TYPE)
             .param(PARAM_CASE_IDS, CASE_IDS)
             .param(PARAM_USER_IDS, USER_IDS)
             .headers(createHttpHeaders()))
             .andExpect(status().is(403))
-            .andReturn().getResolvedException().getMessage();
+            .andReturn().getResolvedException();
 
-        assertTrue(StringUtils.contains(errorMessage, OTHER_USER_CASE_ROLE_ACCESS_NOT_GRANTED));
+        assertNotNull(exception);
+        assertThat(exception.getMessage(), containsString(OTHER_USER_CASE_ROLE_ACCESS_NOT_GRANTED));
     }
 
     @Test
     public void shouldThrowExceptionWhenUserRequestedForSelfCaseRoleAccessAlongWithOtherUsers() throws Exception {
         MockUtils.setSecurityAuthorities("89000", authentication, MockUtils.ROLE_CASEWORKER_PUBLIC);
 
-        String errorMessage = mockMvc.perform(get(getCaseAssignedUserRoles)
+        Exception exception = mockMvc.perform(get(getCaseAssignedUserRoles)
             .contentType(JSON_CONTENT_TYPE)
             .param(PARAM_CASE_IDS, CASE_IDS)
             .param(PARAM_USER_IDS, USER_IDS)
             .headers(createHttpHeaders()))
             .andExpect(status().is(403))
-            .andReturn().getResolvedException().getMessage();
+            .andReturn().getResolvedException();
 
-        assertTrue(StringUtils.contains(errorMessage, OTHER_USER_CASE_ROLE_ACCESS_NOT_GRANTED));
+        assertNotNull(exception);
+        assertThat(exception.getMessage(), containsString(OTHER_USER_CASE_ROLE_ACCESS_NOT_GRANTED));
     }
 
     private HttpHeaders createHttpHeaders() {
         HttpHeaders headers = new HttpHeaders();
         headers.add(AUTHORIZATION, "Bearer user1");
-        headers.add(AUTHORIZATION, "Bearer user1");
+        headers.add("ServiceAuthorization", "Bearer service1");
         return headers;
     }
+
 }

--- a/src/test/java/uk/gov/hmcts/ccd/v2/external/resource/CaseAssignedUserRolesResourceTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/v2/external/resource/CaseAssignedUserRolesResourceTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.ccd.domain.model.std.CaseAssignedUserRole;
 
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -26,7 +26,19 @@ class CaseAssignedUserRolesResourceTest {
         CaseAssignedUserRolesResource resource = new CaseAssignedUserRolesResource(caseAssignedUserRoles);
 
         assertAll(
-            () -> assertThat(resource.getCaseAssignedUserRoles().size(), equalTo(2))
+            () -> assertThat(resource.getCaseAssignedUserRoles(), hasSize(2))
+        );
+    }
+
+    @Test
+    @DisplayName("should have no links")
+    public void shouldHaveNoLinks() {
+        List<CaseAssignedUserRole> caseAssignedUserRoles = createCaseAssignedUserRoles();
+
+        CaseAssignedUserRolesResource resource = new CaseAssignedUserRolesResource(caseAssignedUserRoles);
+
+        assertAll(
+            () -> assertThat(resource.getLinks().toList(), hasSize(0))
         );
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

[RDM-8606](https://tools.hmcts.net/jira/browse/RDM-8606)

### Change description ###

Implement 'Add Case-Assigned User and Role'

LLD: [API Operation: Add Case-Assigned Users and Roles](https://tools.hmcts.net/confluence/display/RCCD/API+Operation%3A+Add+Case-Assigned+Users+and+Roles)

> Note: This change is currently based on [RDM-8344](https://tools.hmcts.net/jira/browse/RDM-8344) branch (PR #968) as they share the same controller and models.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
