### PR TITLE
RDM-8806 FTA for 'Add Case-Assigned User and Role'

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -49,7 +49,8 @@ def secrets = [
         secret('ccd-befta-caseworker-caa-pwd', 'CCD_BEFTA_CASEWORKER_CAA_PWD')
     ],
     's2s-${env}': [
-        secret('microservicekey-ccd-gw', 'BEFTA_S2S_CLIENT_SECRET')
+        secret('microservicekey-ccd-gw', 'BEFTA_S2S_CLIENT_SECRET'),
+        secret('microservicekey-aac-manage-case-assignment', 'BEFTA_S2S_CLIENT_SECRET_OF_AAC_MANAGE_CASE_ASSIGNMENT')
     ]
 ]
 

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -45,7 +45,8 @@ def secrets = [
         secret('ccd-befta-caseworker-caa-pwd', 'CCD_BEFTA_CASEWORKER_CAA_PWD')
     ],
     's2s-${env}': [
-        secret('microservicekey-ccd-gw', 'BEFTA_S2S_CLIENT_SECRET')
+        secret('microservicekey-ccd-gw', 'BEFTA_S2S_CLIENT_SECRET'),
+        secret('microservicekey-aac-manage-case-assignment', 'BEFTA_S2S_CLIENT_SECRET_OF_AAC_MANAGE_CASE_ASSIGNMENT')
     ]
 ]
 

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -42,7 +42,8 @@ def secrets = [
         secret('ccd-befta-caseworker-caa-pwd', 'CCD_BEFTA_CASEWORKER_CAA_PWD')
     ],
     's2s-${env}': [
-        secret('microservicekey-ccd-gw', 'BEFTA_S2S_CLIENT_SECRET')
+        secret('microservicekey-ccd-gw', 'BEFTA_S2S_CLIENT_SECRET'),
+        secret('microservicekey-aac-manage-case-assignment', 'BEFTA_S2S_CLIENT_SECRET_OF_AAC_MANAGE_CASE_ASSIGNMENT')
     ]
 ]
 

--- a/build.gradle
+++ b/build.gradle
@@ -275,7 +275,7 @@ dependencies {
     }
     compile 'org.jooq:jool-java-8:0.9.14'
 
-    testCompile group: 'uk.gov.hmcts', name: 'befta-fw', version: '3.2.0'
+    testCompile group: 'uk.gov.hmcts', name: 'befta-fw', version: '3.3.0-RDM-8806.1'
 
 }
 // end::dependencies[]

--- a/build.gradle
+++ b/build.gradle
@@ -275,7 +275,7 @@ dependencies {
     }
     compile 'org.jooq:jool-java-8:0.9.14'
 
-    testCompile group: 'uk.gov.hmcts', name: 'befta-fw', version: '3.0.1'
+    testCompile group: 'uk.gov.hmcts', name: 'befta-fw', version: '3.0.4'
 
 }
 // end::dependencies[]

--- a/build.gradle
+++ b/build.gradle
@@ -275,7 +275,7 @@ dependencies {
     }
     compile 'org.jooq:jool-java-8:0.9.14'
 
-    testCompile group: 'uk.gov.hmcts', name: 'befta-fw', version: '3.3.0-RDM-8806.2'
+    testCompile group: 'uk.gov.hmcts', name: 'befta-fw', version: '3.3.0-RDM-8806.3'
 
 }
 // end::dependencies[]

--- a/build.gradle
+++ b/build.gradle
@@ -275,7 +275,7 @@ dependencies {
     }
     compile 'org.jooq:jool-java-8:0.9.14'
 
-    testCompile group: 'uk.gov.hmcts', name: 'befta-fw', version: '3.3.0-RDM-8806.3'
+    testCompile group: 'uk.gov.hmcts', name: 'befta-fw', version: '3.3.0'
 
 }
 // end::dependencies[]

--- a/build.gradle
+++ b/build.gradle
@@ -275,7 +275,7 @@ dependencies {
     }
     compile 'org.jooq:jool-java-8:0.9.14'
 
-    testCompile group: 'uk.gov.hmcts', name: 'befta-fw', version: '3.3.0-RDM-8806.1'
+    testCompile group: 'uk.gov.hmcts', name: 'befta-fw', version: '3.3.0-RDM-8806.2'
 
 }
 // end::dependencies[]

--- a/src/aat/resources/features/F-103/F-103_Jamal_Assign_Dil_Case_Role_To_C1.td.json
+++ b/src/aat/resources/features/F-103/F-103_Jamal_Assign_Dil_Case_Role_To_C1.td.json
@@ -12,7 +12,7 @@
 	},
 	"request": {
 		"pathVariables": {
-			"case_id": "${${}[scenarioContext][siblingContexts][F103_Case_Data_Create_C1][testData][actualResponse][body][id]}",
+			"case_id": "${[scenarioContext][siblingContexts][F103_Case_Data_Create_C1][testData][actualResponse][body][id]}",
 			"user_id": "${[scenarioContext][testData][users][userDil][id]}"
 		},
 		"body": {

--- a/src/aat/resources/features/F-103/F-103_Jamal_Assign_Dil_Case_Role_To_C1.td.json
+++ b/src/aat/resources/features/F-103/F-103_Jamal_Assign_Dil_Case_Role_To_C1.td.json
@@ -12,7 +12,7 @@
 	},
 	"request": {
 		"pathVariables": {
-			"case_id": "${{{}}[scenarioContext][siblingContexts][F103_Case_Data_Create_C1][testData][actualResponse][body][id]}",
+			"case_id": "${${}[scenarioContext][siblingContexts][F103_Case_Data_Create_C1][testData][actualResponse][body][id]}",
 			"user_id": "${[scenarioContext][testData][users][userDil][id]}"
 		},
 		"body": {

--- a/src/aat/resources/features/F-103/F-103_Jamal_Assign_Dil_Case_Role_To_C1.td.json
+++ b/src/aat/resources/features/F-103/F-103_Jamal_Assign_Dil_Case_Role_To_C1.td.json
@@ -12,7 +12,7 @@
 	},
 	"request": {
 		"pathVariables": {
-			"case_id": "${[scenarioContext][siblingContexts][F103_Case_Data_Create_C1][testData][actualResponse][body][id]}",
+			"case_id": "${{{}}[scenarioContext][siblingContexts][F103_Case_Data_Create_C1][testData][actualResponse][body][id]}",
 			"user_id": "${[scenarioContext][testData][users][userDil][id]}"
 		},
 		"body": {

--- a/src/aat/resources/features/F-103/F-103_Jamal_Assign_Dil_Case_Role_To_C2.td.json
+++ b/src/aat/resources/features/F-103/F-103_Jamal_Assign_Dil_Case_Role_To_C2.td.json
@@ -12,7 +12,7 @@
 	},
 	"request": {
 		"pathVariables": {
-			"case_id": "${[scenarioContext][siblingContexts][F103_Case_Data_Create_C2][testData][actualResponse][body][id]}",
+			"case_id": "${[scenarioContext][siblingContexts][F103_Case_Data_Create_C2][testData][actualResponse][body][id]}{{}}",
 			"user_id": "${[scenarioContext][testData][users][userDil][id]}"
 		},
 		"body": {

--- a/src/aat/resources/features/F-103/F-103_Jamal_Assign_Dil_Case_Role_To_C2.td.json
+++ b/src/aat/resources/features/F-103/F-103_Jamal_Assign_Dil_Case_Role_To_C2.td.json
@@ -12,7 +12,7 @@
 	},
 	"request": {
 		"pathVariables": {
-			"case_id": "${[scenarioContext][siblingContexts][F103_Case_Data_Create_C2][testData][actualResponse][body][id]}{{}}",
+			"case_id": "${[scenarioContext][siblingContexts][F103_Case_Data_Create_C2][testData][actualResponse][body][id]}${}",
 			"user_id": "${[scenarioContext][testData][users][userDil][id]}"
 		},
 		"body": {

--- a/src/aat/resources/features/F-103/F-103_Jamal_Assign_Dil_Case_Role_To_C2.td.json
+++ b/src/aat/resources/features/F-103/F-103_Jamal_Assign_Dil_Case_Role_To_C2.td.json
@@ -12,7 +12,7 @@
 	},
 	"request": {
 		"pathVariables": {
-			"case_id": "${[scenarioContext][siblingContexts][F103_Case_Data_Create_C2][testData][actualResponse][body][id]}${}",
+			"case_id": "${[scenarioContext][siblingContexts][F103_Case_Data_Create_C2][testData][actualResponse][body][id]}",
 			"user_id": "${[scenarioContext][testData][users][userDil][id]}"
 		},
 		"body": {

--- a/src/aat/resources/features/F-103/S-597.td.json
+++ b/src/aat/resources/features/F-103/S-597.td.json
@@ -25,12 +25,12 @@
 					"__elementId__": "case_id,user_id,case_role"
 				},
 				{
-					"case_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
+					"case_id": "${}${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][body][case_roles][1]}"
 				},
 				{
-					"case_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
+					"case_id": "${}${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][body][case_roles][0]}"
 				}

--- a/src/aat/resources/features/F-103/S-598.td.json
+++ b/src/aat/resources/features/F-103/S-598.td.json
@@ -31,12 +31,12 @@
 					"__elementId__": "case_id,user_id,case_role"
 				},
 				{
-					"case_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
+					"case_id": "${{{}}[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][body][case_roles][1]}"
 				},
 				{
-					"case_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
+					"case_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]{{}}}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][body][case_roles][0]}"
 				}

--- a/src/aat/resources/features/F-103/S-598.td.json
+++ b/src/aat/resources/features/F-103/S-598.td.json
@@ -31,12 +31,12 @@
 					"__elementId__": "case_id,user_id,case_role"
 				},
 				{
-					"case_id": "${{{}}[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
+					"case_id": "${${}[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][body][case_roles][1]}"
 				},
 				{
-					"case_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]{{}}}",
+					"case_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]${}}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][body][case_roles][0]}"
 				}

--- a/src/aat/resources/features/F-103/S-598.td.json
+++ b/src/aat/resources/features/F-103/S-598.td.json
@@ -31,12 +31,12 @@
 					"__elementId__": "case_id,user_id,case_role"
 				},
 				{
-					"case_id": "${${}[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
+					"case_id": "${}${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][body][case_roles][1]}"
 				},
 				{
-					"case_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]${}}",
+					"case_id": "${}${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][body][case_roles][0]}"
 				}

--- a/src/aat/resources/features/F-103/S-599.td.json
+++ b/src/aat/resources/features/F-103/S-599.td.json
@@ -31,22 +31,22 @@
 					"__elementId__": "case_id,user_id,case_role"
 				},
 				{
-					"case_id": "${{{}}[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
+					"case_id": "${${}[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][body][case_roles][1]}"
 				},
 				{
-					"case_id": "${{{}}[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
+					"case_id": "${${}[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][body][case_roles][0]}"
 				},
 				{
-					"case_id": "${{{}}[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
+					"case_id": "${${}[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][body][case_roles][1]}"
 				},
 				{
-					"case_id": "${{{}}[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
+					"case_id": "${${}[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][body][case_roles][0]}"
 				}

--- a/src/aat/resources/features/F-103/S-599.td.json
+++ b/src/aat/resources/features/F-103/S-599.td.json
@@ -31,22 +31,22 @@
 					"__elementId__": "case_id,user_id,case_role"
 				},
 				{
-					"case_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
+					"case_id": "${{{}}[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][body][case_roles][1]}"
 				},
 				{
-					"case_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
+					"case_id": "${{{}}[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][body][case_roles][0]}"
 				},
 				{
-					"case_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
+					"case_id": "${{{}}[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][body][case_roles][1]}"
 				},
 				{
-					"case_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
+					"case_id": "${{{}}[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][body][case_roles][0]}"
 				}

--- a/src/aat/resources/features/F-103/S-599.td.json
+++ b/src/aat/resources/features/F-103/S-599.td.json
@@ -31,22 +31,22 @@
 					"__elementId__": "case_id,user_id,case_role"
 				},
 				{
-					"case_id": "${${}[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
+					"case_id": "${}${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][body][case_roles][1]}"
 				},
 				{
-					"case_id": "${${}[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
+					"case_id": "${}${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][body][case_roles][0]}"
 				},
 				{
-					"case_id": "${${}[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
+					"case_id": "${}${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][body][case_roles][1]}"
 				},
 				{
-					"case_id": "${${}[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
+					"case_id": "${}${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][body][case_roles][0]}"
 				}

--- a/src/aat/resources/features/F-103/S-600.td.json
+++ b/src/aat/resources/features/F-103/S-600.td.json
@@ -32,17 +32,17 @@
 					"__elementId__": "case_id,user_id,case_role"
 				},
 				{
-					"case_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
+					"case_id": "${{{}}[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][body][case_roles][0]}"
 				},
 				{
-					"case_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
+					"case_id": "${{{}}[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][body][case_roles][1]}"
 				},
 				{
-					"case_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C2][testData][request][pathVariables][case_id]}",
+					"case_id": "${{{}}[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C2][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C2][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C2][testData][request][body][case_roles][0]}"
 				},
@@ -52,42 +52,42 @@
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C2][testData][request][body][case_roles][1]}"
 				},
 				{
-					"case_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C3][testData][request][pathVariables][case_id]}",
-					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C3][testData][request][pathVariables][user_id]}",
+					"case_id": "${{{}}[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C3][testData][request][pathVariables][case_id]}",
+					"user_id": "${{{}}[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C3][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C3][testData][request][body][case_roles][0]}"
 				},
 				{
-					"case_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C3][testData][request][pathVariables][case_id]}",
+					"case_id": "${{{}}[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C3][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C3][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C3][testData][request][body][case_roles][1]}"
 				},
 				{
-					"case_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
+					"case_id": "${{{}}[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][body][case_roles][0]}"
 				},
 				{
-					"case_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
+					"case_id": "${{{}}[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][body][case_roles][1]}"
 				},
 				{
-					"case_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C2][testData][request][pathVariables][case_id]}",
+					"case_id": "${{{}}[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C2][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C2][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C2][testData][request][body][case_roles][0]}"
 				},
 				{
-					"case_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C2][testData][request][pathVariables][case_id]}",
+					"case_id": "${{{}}[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C2][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C2][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C2][testData][request][body][case_roles][1]}"
 				},
 				{
-					"case_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C3][testData][request][pathVariables][case_id]}",
+					"case_id": "${{{}}[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C3][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C3][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C3][testData][request][body][case_roles][0]}"
 				},
 				{
-					"case_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C3][testData][request][pathVariables][case_id]}",
+					"case_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C3][testData][request][pathVariables][case_id]{{}}}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C3][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C3][testData][request][body][case_roles][1]}"
 				}

--- a/src/aat/resources/features/F-103/S-600.td.json
+++ b/src/aat/resources/features/F-103/S-600.td.json
@@ -32,17 +32,17 @@
 					"__elementId__": "case_id,user_id,case_role"
 				},
 				{
-					"case_id": "${{{}}[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
+					"case_id": "${${}[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][body][case_roles][0]}"
 				},
 				{
-					"case_id": "${{{}}[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
+					"case_id": "${${}[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][body][case_roles][1]}"
 				},
 				{
-					"case_id": "${{{}}[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C2][testData][request][pathVariables][case_id]}",
+					"case_id": "${${}[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C2][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C2][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C2][testData][request][body][case_roles][0]}"
 				},
@@ -52,42 +52,42 @@
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C2][testData][request][body][case_roles][1]}"
 				},
 				{
-					"case_id": "${{{}}[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C3][testData][request][pathVariables][case_id]}",
-					"user_id": "${{{}}[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C3][testData][request][pathVariables][user_id]}",
+					"case_id": "${${}[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C3][testData][request][pathVariables][case_id]}",
+					"user_id": "${${}[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C3][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C3][testData][request][body][case_roles][0]}"
 				},
 				{
-					"case_id": "${{{}}[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C3][testData][request][pathVariables][case_id]}",
+					"case_id": "${${}[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C3][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C3][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C3][testData][request][body][case_roles][1]}"
 				},
 				{
-					"case_id": "${{{}}[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
+					"case_id": "${${}[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][body][case_roles][0]}"
 				},
 				{
-					"case_id": "${{{}}[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
+					"case_id": "${${}[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][body][case_roles][1]}"
 				},
 				{
-					"case_id": "${{{}}[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C2][testData][request][pathVariables][case_id]}",
+					"case_id": "${${}[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C2][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C2][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C2][testData][request][body][case_roles][0]}"
 				},
 				{
-					"case_id": "${{{}}[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C2][testData][request][pathVariables][case_id]}",
+					"case_id": "${${}[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C2][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C2][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C2][testData][request][body][case_roles][1]}"
 				},
 				{
-					"case_id": "${{{}}[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C3][testData][request][pathVariables][case_id]}",
+					"case_id": "${${}[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C3][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C3][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C3][testData][request][body][case_roles][0]}"
 				},
 				{
-					"case_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C3][testData][request][pathVariables][case_id]{{}}}",
+					"case_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C3][testData][request][pathVariables][case_id]${}}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C3][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C3][testData][request][body][case_roles][1]}"
 				}

--- a/src/aat/resources/features/F-103/S-600.td.json
+++ b/src/aat/resources/features/F-103/S-600.td.json
@@ -32,62 +32,62 @@
 					"__elementId__": "case_id,user_id,case_role"
 				},
 				{
-					"case_id": "${${}[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
+					"case_id": "${}${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][body][case_roles][0]}"
 				},
 				{
-					"case_id": "${${}[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
+					"case_id": "${}${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C1][testData][request][body][case_roles][1]}"
 				},
 				{
-					"case_id": "${${}[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C2][testData][request][pathVariables][case_id]}",
+					"case_id": "${}${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C2][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C2][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C2][testData][request][body][case_roles][0]}"
 				},
 				{
-					"case_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C2][testData][request][pathVariables][case_id]}",
+					"case_id": "${}${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C2][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C2][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C2][testData][request][body][case_roles][1]}"
 				},
 				{
-					"case_id": "${${}[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C3][testData][request][pathVariables][case_id]}",
+					"case_id": "${}${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C3][testData][request][pathVariables][case_id]}",
 					"user_id": "${${}[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C3][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C3][testData][request][body][case_roles][0]}"
 				},
 				{
-					"case_id": "${${}[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C3][testData][request][pathVariables][case_id]}",
+					"case_id": "${}${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C3][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C3][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C3][testData][request][body][case_roles][1]}"
 				},
 				{
-					"case_id": "${${}[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
+					"case_id": "${}${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][body][case_roles][0]}"
 				},
 				{
-					"case_id": "${${}[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
+					"case_id": "${}${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C1][testData][request][body][case_roles][1]}"
 				},
 				{
-					"case_id": "${${}[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C2][testData][request][pathVariables][case_id]}",
+					"case_id": "${}${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C2][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C2][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C2][testData][request][body][case_roles][0]}"
 				},
 				{
-					"case_id": "${${}[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C2][testData][request][pathVariables][case_id]}",
+					"case_id": "${}${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C2][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C2][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C2][testData][request][body][case_roles][1]}"
 				},
 				{
-					"case_id": "${${}[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C3][testData][request][pathVariables][case_id]}",
+					"case_id": "${}${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C3][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C3][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C3][testData][request][body][case_roles][0]}"
 				},
 				{
-					"case_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C3][testData][request][pathVariables][case_id]${}}",
+					"case_id": "${}${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C3][testData][request][pathVariables][case_id]}",
 					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C3][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Steve_Case_Role_To_C3][testData][request][body][case_roles][1]}"
 				}

--- a/src/aat/resources/features/F-103/S-600.td.json
+++ b/src/aat/resources/features/F-103/S-600.td.json
@@ -53,7 +53,7 @@
 				},
 				{
 					"case_id": "${}${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C3][testData][request][pathVariables][case_id]}",
-					"user_id": "${${}[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C3][testData][request][pathVariables][user_id]}",
+					"user_id": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C3][testData][request][pathVariables][user_id]}",
 					"case_role": "${[scenarioContext][childContexts][F-103_Jamal_Assign_Dil_Case_Role_To_C3][testData][request][body][case_roles][0]}"
 				},
 				{

--- a/src/aat/resources/features/F-105/F-105.feature
+++ b/src/aat/resources/features/F-105/F-105.feature
@@ -15,7 +15,7 @@ Feature: F-105: Add Case-Assigned Users and Roles
     And a successful call [by Richard to create a case - C1] as in [F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment],
     When a request is prepared with appropriate values,
     And the request [is made from an authorised application, by Dil, with the Case ID of C1, User ID of Olawale and a proper Case Role CR-1],
-    And it is submitted to call the [Add Case-Assigned User and Role] operation of [CCD Data Store api],
+    And it is submitted to call the [Add Case-Assigned User and Role] operation of [CCD Data Store Api],
     Then a positive response is received,
     And the response has all the details as expected,
     And a call [to verify Olawale's reception of the role CR-1 over the case C1] will get the expected response as in [S-105.1_Get_Case_Roles_for_Case_C1].
@@ -32,7 +32,7 @@ Feature: F-105: Add Case-Assigned Users and Roles
     When a request is prepared with appropriate values,
     And the request [is made by Dil for 2 assignments each containing Olawale's User ID and a proper Case Role CR-1]
     And the request [contains the Case ID of C1 in one entry but no case ID in the other]
-    And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store api],
+    And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store Api],
     Then a negative response is received,
     And the response has all the details as expected.
     And a call [to verify that Olawale hasn't received the role CR-1 over the case C1] will get the expected response as in [S-105.2_Get_Case_Roles_for_Case_C1].
@@ -49,7 +49,7 @@ Feature: F-105: Add Case-Assigned Users and Roles
     When a request is prepared with appropriate values,
     And the request [is made by Dil for 2 assignments each containing Olawale's User ID and a proper Case Role CR-1]
     And the request [contains the Case ID of C1 in one entry and a malformed case ID in the other]
-    And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store api],
+    And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store Api],
     Then a negative response is received,
     And the response has all the details as expected.
     And a call [to verify that Olawale hasn't received the role CR-1 over the case C1] will get the expected response as in [S-105.3_Get_Case_Roles_for_Case_C1].
@@ -66,7 +66,7 @@ Feature: F-105: Add Case-Assigned Users and Roles
     When a request is prepared with appropriate values,
     And the request [is made by Dil for 2 assignments each containing the Case ID of C1 and a proper Case Role CR-1]
     And the request [contains the User ID of Olawale in one entry but no User ID in the other]
-    And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store api],
+    And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store Api],
     Then a negative response is received,
     And the response has all the details as expected.
     And a call [to verify that Olawale hasn't received the role CR-1 over the case C1] will get the expected response as in [S-105.4_Get_Case_Roles_for_Case_C1].
@@ -83,7 +83,7 @@ Feature: F-105: Add Case-Assigned Users and Roles
     When a request is prepared with appropriate values,
     And the request [is made by Dil for 2 assignments each containing the Case ID of C1 and a proper Case Role CR-1]
     And the request [contains the User ID of Olawale in one entry and a malformed User ID in the other]
-    And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store api],
+    And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store Api],
     Then a negative response is received,
     And the response has all the details as expected.
     And a call [to verify that Olawale hasn't received the role CR-1 over the case C1] will get the expected response as in [S-105.5_Get_Case_Roles_for_Case_C1].
@@ -99,7 +99,7 @@ Feature: F-105: Add Case-Assigned Users and Roles
     And a user [Olawale - who is not a privileged user and is calling from an un-authorised application],
     When a request is prepared with appropriate values,
     And the request [is made by Olawale with the Case ID of C1 & Dil's User ID and a proper Case Role CR-1],
-    And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store api],
+    And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store Api],
     Then a negative response is received,
     And the response has all the details as expected.
     And a call [to verify that Dil hasn't received the role CR-1 over the case C1] will get the expected response as in [S-105.6_Get_Case_Roles_for_Case_C1].
@@ -116,7 +116,7 @@ Feature: F-105: Add Case-Assigned Users and Roles
     When a request is prepared with appropriate values,
     And the request [is made from an authorised application by Dil, for 2 assignments each containing the Case ID of C1 and User ID of Olawale],
     And the request [contains a proper Case Role CR-1 in one entry and an improper Case Role in the other]
-    And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store api],
+    And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store Api],
     Then a negative response is received,
     And the response has all the details as expected.
     And a call [to verify that Olawale hasn't received the role CR-1 over the case C1] will get the expected response as in [S-105.7_Get_Case_Roles_for_Case_C1].
@@ -133,7 +133,7 @@ Feature: F-105: Add Case-Assigned Users and Roles
     When a request is prepared with appropriate values,
     And the request [is made from an authorised application by Dil, for 2 assignments each containing the Case ID of C1 and User ID of Olawale],
     And the request [contains a proper Case Role CR-1 in one entry and no Case Role in the other]
-    And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store api],
+    And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store Api],
     Then a negative response is received,
     And the response has all the details as expected.
     And a call [to verify that Olawale hasn't received the role CR-1 over the case C1] will get the expected response as in [S-105.8_Get_Case_Roles_for_Case_C1].
@@ -145,7 +145,7 @@ Feature: F-105: Add Case-Assigned Users and Roles
     And a user [Dil - who is to add some case role assignment for a case],
     When a request is prepared with appropriate values,
     And the request [is made from an authorised application by Dil, with no case_users supplied]
-    And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store api],
+    And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store Api],
     Then a negative response is received,
     And the response has all the details as expected.
 
@@ -156,7 +156,7 @@ Feature: F-105: Add Case-Assigned Users and Roles
     And a user [Dil - who is to add some case role assignment for a case],
     When a request is prepared with appropriate values,
     And the request [is made from an authorised application by Dil, with an empty list of case_users supplied]
-    And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store api],
+    And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store Api],
     Then a negative response is received,
     And the response has all the details as expected.
 
@@ -172,7 +172,7 @@ Feature: F-105: Add Case-Assigned Users and Roles
     When a request is prepared with appropriate values,
     And the request [is made by Dil for 2 assignments each containing Olawale's User ID and a proper Case Role CR-1]
     And the request [contains the Case ID of C1 in one entry and a well formed but non-existant case ID in the other]
-    And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store api],
+    And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store Api],
     Then a negative response is received,
     And the response has all the details as expected.
     And a call [to verify that Olawale hasn't received the role CR-1 over the case C1] will get the expected response as in [S-105.11_Get_Case_Roles_for_Case_C1].
@@ -189,7 +189,7 @@ Feature: F-105: Add Case-Assigned Users and Roles
     And a successful call [by Richard to create a case - C1] as in [F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment],
     When a request is prepared with appropriate values,
     And the request [is made by Dil for 2 assignments each containing the Case ID of C1, User ID of Olawale and a proper Case Role CR-1]
-    And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store api],
+    And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store Api],
     Then a positive response is received,
     And the response has all the details as expected.
     And a call [to verify Olawale's reception of the role CR-1 over the case C1] will get the expected response as in [S-105.12_Get_Case_Roles_for_Case_C1].
@@ -206,7 +206,7 @@ Feature: F-105: Add Case-Assigned Users and Roles
     When a request is prepared with appropriate values,
     And the request [is made from an authorised application by Dil, for 2 assignments each containing the Case ID of C1 and User ID of Olawale],
     And the request [contains a proper Case Role CR-1 in one entry and a proper Case Role CR-2 in the other]
-    And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store api],
+    And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store Api],
     Then a positive response is received,
     And the response has all the details as expected.
     And a call [to verify Olawale's reception of the role CR-1 and CR-2 over the case C1] will get the expected response as in [S-105.13_Get_Case_Roles_for_Case_C1].

--- a/src/aat/resources/features/F-105/F-105.feature
+++ b/src/aat/resources/features/F-105/F-105.feature
@@ -1,0 +1,201 @@
+@F-105
+Feature: F-105: Add Case-Assigned Users and Roles
+
+  Background: Load test data for the scenario
+    Given an appropriate test context as detailed in the test data source
+    And a successful call [to create a token for case creation] as in [Befta_Jurisdiction2_Default_Token_Creation_Data_For_Case_Creation]
+
+  # RDM-8606/8806 AC-1
+  @S-105.1
+  Scenario: Must successfully assign a user and case role for a specific case by a user calling through/from an authorised application
+    Given an appropriate test context as detailed in the test data source,
+    And a user [Richard - who can create a case],
+    And a user [Dil - who is to add some case role assignment for a case],
+    And a user [Olawale - with an active solicitor profile],
+    And a successful call [by Richard to create a case - C1] as in [F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment],
+    When a request is prepared with appropriate values,
+    And the request [is made from an authorised application, by Dil, with the Case ID of C1, User ID of Olawale and a proper Case Role CR-1],
+    And it is submitted to call the [Add Case-Assigned User and Role] operation of [CCD Data Store api],
+    Then a positive response is received,
+    And the response has all the details as expected,
+    And a call [to verify Olawale's reception of the role CR-1 over the case C1] will get the expected response as in [S-105.1_Get_Case_Roles_for_Case_C1].
+
+  # RDM-8606/8806 AC-2
+  @S-105.2
+  Scenario: Must return an error response for a missing Case ID
+    Given an appropriate test context as detailed in the test data source,
+    And a user [Richard - who can create a case],
+    And a user [Dil - who is to add some case role assignment for a case],
+    And a user [Olawale - with an active solicitor profile and valid User ID],
+    And a successful call [by Richard to create a case - C1] as in [F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment],
+    When a request is prepared with appropriate values,
+    And the request [is made by Dil for 2 assignments each containing Olawale's User ID and a proper Case Role CR-1]
+    And the request [contains the Case ID of C1 in one entry but no case ID in the other]
+    And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store api],
+    Then a negative response is received,
+    And the response has all the details as expected.
+    And a call [to verify Olawale's reception of the role CR-1 over the case C1] will get the expected response as in [S-105.2_Get_Case_Roles_for_Case_C1].
+
+  # RDM-8606/8806 AC-3
+  @S-105.3
+  Scenario: Must return an error response for a malformed Case ID
+    Given an appropriate test context as detailed in the test data source,
+    And a user [Richard - who can create a case],
+    And a user [Dil - who is to add some case role assignment for a case],
+    And a user [Olawale - with an active solicitor profile and valid User ID],
+    And a successful call [by Richard to create a case - C1] as in [F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment],
+    When a request is prepared with appropriate values,
+    And the request [is made by Dil for 2 assignments each containing Olawale's User ID and a proper Case Role CR-1]
+    And the request [contains the Case ID of C1 in one entry and a malformed case ID in the other]
+    And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store api],
+    Then a negative response is received,
+    And the response has all the details as expected.
+    And a call [to verify Olawale's reception of the role CR-1 over the case C1] will get the expected response as in [S-105.3_Get_Case_Roles_for_Case_C1].
+
+  # RDM-8606/8806 AC-4
+  @S-105.4
+  Scenario: Must return an error response for a missing User ID
+    Given an appropriate test context as detailed in the test data source,
+    And a user [Richard - who can create a case],
+    And a user [Dil - who is to add some case role assignment for a case],
+    And a user [Olawale - with an active solicitor profile and valid User ID],
+    And a successful call [by Richard to create a case - C1] as in [F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment],
+    When a request is prepared with appropriate values,
+    And the request [is made by Dil for 2 assignments each containing the Case ID of C1 and a proper Case Role CR-1]
+    And the request [contains the User ID of Olawale in one entry but no User ID in the other]
+    And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store api],
+    Then a negative response is received,
+    And the response has all the details as expected.
+    And a call [to verify Olawale's reception of the role CR-1 over the case C1] will get the expected response as in [S-105.4_Get_Case_Roles_for_Case_C1].
+
+  # RDM-8606/8806 AC-5
+  @S-105.5
+  Scenario: Must return an error response for a malformed User ID Provided
+    Given an appropriate test context as detailed in the test data source,
+    And a user [Richard - who can create a case],
+    And a user [Dil - who is to add some case role assignment for a case],
+    And a user [Olawale - with an active solicitor profile and valid User ID],
+    And a successful call [by Richard to create a case - C1] as in [F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment],
+    When a request is prepared with appropriate values,
+    And the request [is made by Dil for 2 assignments each containing the Case ID of C1 and a proper Case Role CR-1]
+    And the request [contains the User ID of Olawale in one entry and a malformed User ID in the other]
+    And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store api],
+    Then a negative response is received,
+    And the response has all the details as expected.
+    And a call [to verify Olawale's reception of the role CR-1 over the case C1] will get the expected response as in [S-105.5_Get_Case_Roles_for_Case_C1].
+
+  # RDM-8606/8806 AC-6
+  @S-105.6
+  Scenario: Must return an error response when the request is made from an un-authorised application
+    Given an appropriate test context as detailed in the test data source,
+    And a user [Richard - who can create a case],
+    And a successful call [by Richard to create a case - C1] as in [F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment],
+    And a user [Dil - with an active profile],
+    And a user [Olawale - who is not a privileged user and is calling from an un-authorised application],
+    When a request is prepared with appropriate values,
+    And the request [is made by Olawale with the Case ID of C1 & Dil's User ID and a proper Case Role CR-1],
+    And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store api],
+    Then a negative response is received,
+    And the response has all the details as expected.
+
+  # RDM-8606/8806 AC-7
+  @S-105.7
+  Scenario: Must return an error response for a malformed Case Role provided
+    Given an appropriate test context as detailed in the test data source,
+    And a user [Richard - who can create a case],
+    And a user [Dil - who is to add some case role assignment for a case],
+    And a user [Olawale - with an active solicitor profile and valid User ID],
+    And a successful call [by Richard to create a case - C1] as in [F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment],
+    When a request is prepared with appropriate values,
+    And the request [is made from an authorised application by Dil, for 2 assignments each containing the Case ID of C1 and User ID of Olawale],
+    And the request [contains a proper Case Role CR-1 in one entry and an improper Case Role in the other]
+    And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store api],
+    Then a negative response is received,
+    And the response has all the details as expected.
+    And a call [to verify Olawale's reception of the role CR-1 over the case C1] will get the expected response as in [S-105.7_Get_Case_Roles_for_Case_C1].
+
+  # RDM-8606/8806 AC-8
+  @S-105.8
+  Scenario: Must return an error response for a missing Case Role
+    Given an appropriate test context as detailed in the test data source,
+    And a user [Richard - who can create a case],
+    And a user [Dil - who is to add some case role assignment for a case],
+    And a user [Olawale - with an active solicitor profile and valid User ID],
+    And a successful call [by Richard to create a case - C1] as in [F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment],
+    When a request is prepared with appropriate values,
+    And the request [is made from an authorised application by Dil, for 2 assignments each containing the Case ID of C1 and User ID of Olawale],
+    And the request [contains a proper Case Role CR-1 in one entry and no Case Role in the other]
+    And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store api],
+    Then a negative response is received,
+    And the response has all the details as expected.
+    And a call [to verify Olawale's reception of the role CR-1 over the case C1] will get the expected response as in [S-105.8_Get_Case_Roles_for_Case_C1].
+
+  # RDM-8606 no list
+  @S-105.9
+  Scenario: Must return an error response for missing case_users list
+    Given an appropriate test context as detailed in the test data source,
+    And a user [Dil - who is to add some case role assignment for a case],
+    When a request is prepared with appropriate values,
+    And the request [is made from an authorised application by Dil, with no case_users supplied]
+    And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store api],
+    Then a negative response is received,
+    And the response has all the details as expected.
+
+  # RDM-8606 empty list
+  @S-105.10
+  Scenario: Must return an error response for empty case_users list
+    Given an appropriate test context as detailed in the test data source,
+    And a user [Dil - who is to add some case role assignment for a case],
+    When a request is prepared with appropriate values,
+    And the request [is made from an authorised application by Dil, with an empty list of case_users supplied]
+    And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store api],
+    Then a negative response is received,
+    And the response has all the details as expected.
+
+  # RDM-8606 case not found
+  @S-105.11
+  Scenario: Must return an error response when the case does not exist
+    Given an appropriate test context as detailed in the test data source,
+    And a user [Richard - who can create a case],
+    And a user [Dil - who is to add some case role assignment for a case],
+    And a user [Olawale - with an active solicitor profile and valid User ID],
+    And a successful call [by Richard to create a case - C1] as in [F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment],
+    When a request is prepared with appropriate values,
+    And the request [is made by Dil for 2 assignments each containing Olawale's User ID and a proper Case Role CR-1]
+    And the request [contains the Case ID of C1 in one entry and a well formed but non-existant case ID in the other]
+    And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store api],
+    Then a negative response is received,
+    And the response has all the details as expected.
+    And a call [to verify Olawale's reception of the role CR-1 over the case C1] will get the expected response as in [S-105.11_Get_Case_Roles_for_Case_C1].
+
+
+  # RDM-8606 duplicate
+  @S-105.12
+  Scenario: Must not create duplicate case-user-roles
+    Given an appropriate test context as detailed in the test data source,
+    And a user [Richard - who can create a case],
+    And a user [Dil - who is to add some case role assignment for a case],
+    And a user [Olawale - with an active solicitor profile and valid User ID],
+    And a successful call [by Richard to create a case - C1] as in [F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment],
+    When a request is prepared with appropriate values,
+    And the request [is made by Dil for 2 assignments each containing the Case ID of C1, User ID of Olawale and a proper Case Role CR-1]
+    And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store api],
+    Then a positive response is received,
+    And the response has all the details as expected.
+    And a call [to verify Olawale's reception of the role CR-1 over the case C1] will get the expected response as in [S-105.12_Get_Case_Roles_for_Case_C1].
+
+  # RDM-8606 multiple
+  @S-105.13
+  Scenario: Must successfully assign multiple user and case roles for a specific case by a user calling through/from an authorised application
+    Given an appropriate test context as detailed in the test data source,
+    And a user [Richard - who can create a case],
+    And a user [Dil - who is to add some case role assignment for a case],
+    And a user [Olawale - with an active solicitor profile and valid User ID],
+    And a successful call [by Richard to create a case - C1] as in [F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment],
+    When a request is prepared with appropriate values,
+    And the request [is made from an authorised application by Dil, for 2 assignments each containing the Case ID of C1 and User ID of Olawale],
+    And the request [contains a proper Case Role CR-1 in one entry and a proper Case Role CR-2 in the other]
+    And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store api],
+    Then a positive response is received,
+    And the response has all the details as expected.
+    And a call [to verify Olawale's reception of the role CR-1 and CR-2 over the case C1] will get the expected response as in [S-105.13_Get_Case_Roles_for_Case_C1].

--- a/src/aat/resources/features/F-105/F-105.feature
+++ b/src/aat/resources/features/F-105/F-105.feature
@@ -15,7 +15,7 @@ Feature: F-105: Add Case-Assigned Users and Roles
     And a successful call [by Richard to create a case - C1] as in [F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment],
     When a request is prepared with appropriate values,
     And the request [is made from an authorised application, by Dil, with the Case ID of C1, User ID of Olawale and a proper Case Role CR-1],
-    And it is submitted to call the [Add Case-Assigned User and Role] operation of [CCD Data Store Api],
+    And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store Api],
     Then a positive response is received,
     And the response has all the details as expected,
     And a call [to verify Olawale's reception of the role CR-1 over the case C1] will get the expected response as in [S-105.1_Get_Case_Roles_for_Case_C1].

--- a/src/aat/resources/features/F-105/F-105.feature
+++ b/src/aat/resources/features/F-105/F-105.feature
@@ -3,7 +3,6 @@ Feature: F-105: Add Case-Assigned Users and Roles
 
   Background: Load test data for the scenario
     Given an appropriate test context as detailed in the test data source
-    And a successful call [to create a token for case creation] as in [Befta_Jurisdiction2_Default_Token_Creation_Data_For_Case_Creation]
 
   # RDM-8606/8806 AC-1
   @S-105.1
@@ -12,6 +11,7 @@ Feature: F-105: Add Case-Assigned Users and Roles
     And a user [Richard - who can create a case],
     And a user [Dil - who is to add some case role assignment for a case],
     And a user [Olawale - with an active solicitor profile],
+    And a successful call [to create a token for case creation] as in [Befta_Jurisdiction2_Default_Token_Creation_Data_For_Case_Creation]
     And a successful call [by Richard to create a case - C1] as in [F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment],
     When a request is prepared with appropriate values,
     And the request [is made from an authorised application, by Dil, with the Case ID of C1, User ID of Olawale and a proper Case Role CR-1],
@@ -27,6 +27,7 @@ Feature: F-105: Add Case-Assigned Users and Roles
     And a user [Richard - who can create a case],
     And a user [Dil - who is to add some case role assignment for a case],
     And a user [Olawale - with an active solicitor profile and valid User ID],
+    And a successful call [to create a token for case creation] as in [Befta_Jurisdiction2_Default_Token_Creation_Data_For_Case_Creation]
     And a successful call [by Richard to create a case - C1] as in [F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment],
     When a request is prepared with appropriate values,
     And the request [is made by Dil for 2 assignments each containing Olawale's User ID and a proper Case Role CR-1]
@@ -34,7 +35,7 @@ Feature: F-105: Add Case-Assigned Users and Roles
     And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store api],
     Then a negative response is received,
     And the response has all the details as expected.
-    And a call [to verify Olawale's reception of the role CR-1 over the case C1] will get the expected response as in [S-105.2_Get_Case_Roles_for_Case_C1].
+    And a call [to verify that Olawale hasn't received the role CR-1 over the case C1] will get the expected response as in [S-105.2_Get_Case_Roles_for_Case_C1].
 
   # RDM-8606/8806 AC-3
   @S-105.3
@@ -43,6 +44,7 @@ Feature: F-105: Add Case-Assigned Users and Roles
     And a user [Richard - who can create a case],
     And a user [Dil - who is to add some case role assignment for a case],
     And a user [Olawale - with an active solicitor profile and valid User ID],
+    And a successful call [to create a token for case creation] as in [Befta_Jurisdiction2_Default_Token_Creation_Data_For_Case_Creation]
     And a successful call [by Richard to create a case - C1] as in [F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment],
     When a request is prepared with appropriate values,
     And the request [is made by Dil for 2 assignments each containing Olawale's User ID and a proper Case Role CR-1]
@@ -50,7 +52,7 @@ Feature: F-105: Add Case-Assigned Users and Roles
     And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store api],
     Then a negative response is received,
     And the response has all the details as expected.
-    And a call [to verify Olawale's reception of the role CR-1 over the case C1] will get the expected response as in [S-105.3_Get_Case_Roles_for_Case_C1].
+    And a call [to verify that Olawale hasn't received the role CR-1 over the case C1] will get the expected response as in [S-105.3_Get_Case_Roles_for_Case_C1].
 
   # RDM-8606/8806 AC-4
   @S-105.4
@@ -59,6 +61,7 @@ Feature: F-105: Add Case-Assigned Users and Roles
     And a user [Richard - who can create a case],
     And a user [Dil - who is to add some case role assignment for a case],
     And a user [Olawale - with an active solicitor profile and valid User ID],
+    And a successful call [to create a token for case creation] as in [Befta_Jurisdiction2_Default_Token_Creation_Data_For_Case_Creation]
     And a successful call [by Richard to create a case - C1] as in [F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment],
     When a request is prepared with appropriate values,
     And the request [is made by Dil for 2 assignments each containing the Case ID of C1 and a proper Case Role CR-1]
@@ -66,7 +69,7 @@ Feature: F-105: Add Case-Assigned Users and Roles
     And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store api],
     Then a negative response is received,
     And the response has all the details as expected.
-    And a call [to verify Olawale's reception of the role CR-1 over the case C1] will get the expected response as in [S-105.4_Get_Case_Roles_for_Case_C1].
+    And a call [to verify that Olawale hasn't received the role CR-1 over the case C1] will get the expected response as in [S-105.4_Get_Case_Roles_for_Case_C1].
 
   # RDM-8606/8806 AC-5
   @S-105.5
@@ -75,6 +78,7 @@ Feature: F-105: Add Case-Assigned Users and Roles
     And a user [Richard - who can create a case],
     And a user [Dil - who is to add some case role assignment for a case],
     And a user [Olawale - with an active solicitor profile and valid User ID],
+    And a successful call [to create a token for case creation] as in [Befta_Jurisdiction2_Default_Token_Creation_Data_For_Case_Creation]
     And a successful call [by Richard to create a case - C1] as in [F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment],
     When a request is prepared with appropriate values,
     And the request [is made by Dil for 2 assignments each containing the Case ID of C1 and a proper Case Role CR-1]
@@ -82,13 +86,14 @@ Feature: F-105: Add Case-Assigned Users and Roles
     And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store api],
     Then a negative response is received,
     And the response has all the details as expected.
-    And a call [to verify Olawale's reception of the role CR-1 over the case C1] will get the expected response as in [S-105.5_Get_Case_Roles_for_Case_C1].
+    And a call [to verify that Olawale hasn't received the role CR-1 over the case C1] will get the expected response as in [S-105.5_Get_Case_Roles_for_Case_C1].
 
   # RDM-8606/8806 AC-6
   @S-105.6
   Scenario: Must return an error response when the request is made from an un-authorised application
     Given an appropriate test context as detailed in the test data source,
     And a user [Richard - who can create a case],
+    And a successful call [to create a token for case creation] as in [Befta_Jurisdiction2_Default_Token_Creation_Data_For_Case_Creation]
     And a successful call [by Richard to create a case - C1] as in [F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment],
     And a user [Dil - with an active profile],
     And a user [Olawale - who is not a privileged user and is calling from an un-authorised application],
@@ -97,6 +102,7 @@ Feature: F-105: Add Case-Assigned Users and Roles
     And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store api],
     Then a negative response is received,
     And the response has all the details as expected.
+    And a call [to verify that Dil hasn't received the role CR-1 over the case C1] will get the expected response as in [S-105.6_Get_Case_Roles_for_Case_C1].
 
   # RDM-8606/8806 AC-7
   @S-105.7
@@ -105,6 +111,7 @@ Feature: F-105: Add Case-Assigned Users and Roles
     And a user [Richard - who can create a case],
     And a user [Dil - who is to add some case role assignment for a case],
     And a user [Olawale - with an active solicitor profile and valid User ID],
+    And a successful call [to create a token for case creation] as in [Befta_Jurisdiction2_Default_Token_Creation_Data_For_Case_Creation]
     And a successful call [by Richard to create a case - C1] as in [F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment],
     When a request is prepared with appropriate values,
     And the request [is made from an authorised application by Dil, for 2 assignments each containing the Case ID of C1 and User ID of Olawale],
@@ -112,7 +119,7 @@ Feature: F-105: Add Case-Assigned Users and Roles
     And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store api],
     Then a negative response is received,
     And the response has all the details as expected.
-    And a call [to verify Olawale's reception of the role CR-1 over the case C1] will get the expected response as in [S-105.7_Get_Case_Roles_for_Case_C1].
+    And a call [to verify that Olawale hasn't received the role CR-1 over the case C1] will get the expected response as in [S-105.7_Get_Case_Roles_for_Case_C1].
 
   # RDM-8606/8806 AC-8
   @S-105.8
@@ -121,6 +128,7 @@ Feature: F-105: Add Case-Assigned Users and Roles
     And a user [Richard - who can create a case],
     And a user [Dil - who is to add some case role assignment for a case],
     And a user [Olawale - with an active solicitor profile and valid User ID],
+    And a successful call [to create a token for case creation] as in [Befta_Jurisdiction2_Default_Token_Creation_Data_For_Case_Creation]
     And a successful call [by Richard to create a case - C1] as in [F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment],
     When a request is prepared with appropriate values,
     And the request [is made from an authorised application by Dil, for 2 assignments each containing the Case ID of C1 and User ID of Olawale],
@@ -128,7 +136,7 @@ Feature: F-105: Add Case-Assigned Users and Roles
     And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store api],
     Then a negative response is received,
     And the response has all the details as expected.
-    And a call [to verify Olawale's reception of the role CR-1 over the case C1] will get the expected response as in [S-105.8_Get_Case_Roles_for_Case_C1].
+    And a call [to verify that Olawale hasn't received the role CR-1 over the case C1] will get the expected response as in [S-105.8_Get_Case_Roles_for_Case_C1].
 
   # RDM-8606 no list
   @S-105.9
@@ -159,6 +167,7 @@ Feature: F-105: Add Case-Assigned Users and Roles
     And a user [Richard - who can create a case],
     And a user [Dil - who is to add some case role assignment for a case],
     And a user [Olawale - with an active solicitor profile and valid User ID],
+    And a successful call [to create a token for case creation] as in [Befta_Jurisdiction2_Default_Token_Creation_Data_For_Case_Creation]
     And a successful call [by Richard to create a case - C1] as in [F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment],
     When a request is prepared with appropriate values,
     And the request [is made by Dil for 2 assignments each containing Olawale's User ID and a proper Case Role CR-1]
@@ -166,7 +175,7 @@ Feature: F-105: Add Case-Assigned Users and Roles
     And it is submitted to call the [Add Case-Assigned Users and Roles] operation of [CCD Data Store api],
     Then a negative response is received,
     And the response has all the details as expected.
-    And a call [to verify Olawale's reception of the role CR-1 over the case C1] will get the expected response as in [S-105.11_Get_Case_Roles_for_Case_C1].
+    And a call [to verify that Olawale hasn't received the role CR-1 over the case C1] will get the expected response as in [S-105.11_Get_Case_Roles_for_Case_C1].
 
 
   # RDM-8606 duplicate
@@ -176,6 +185,7 @@ Feature: F-105: Add Case-Assigned Users and Roles
     And a user [Richard - who can create a case],
     And a user [Dil - who is to add some case role assignment for a case],
     And a user [Olawale - with an active solicitor profile and valid User ID],
+    And a successful call [to create a token for case creation] as in [Befta_Jurisdiction2_Default_Token_Creation_Data_For_Case_Creation]
     And a successful call [by Richard to create a case - C1] as in [F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment],
     When a request is prepared with appropriate values,
     And the request [is made by Dil for 2 assignments each containing the Case ID of C1, User ID of Olawale and a proper Case Role CR-1]
@@ -191,6 +201,7 @@ Feature: F-105: Add Case-Assigned Users and Roles
     And a user [Richard - who can create a case],
     And a user [Dil - who is to add some case role assignment for a case],
     And a user [Olawale - with an active solicitor profile and valid User ID],
+    And a successful call [to create a token for case creation] as in [Befta_Jurisdiction2_Default_Token_Creation_Data_For_Case_Creation]
     And a successful call [by Richard to create a case - C1] as in [F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment],
     When a request is prepared with appropriate values,
     And the request [is made from an authorised application by Dil, for 2 assignments each containing the Case ID of C1 and User ID of Olawale],

--- a/src/aat/resources/features/F-105/F-105_Add_Case_Assigned_User_Roles_201_response.td.json
+++ b/src/aat/resources/features/F-105/F-105_Add_Case_Assigned_User_Roles_201_response.td.json
@@ -1,0 +1,8 @@
+{
+  "_guid_": "F-105_Add_Case_Assigned_User_Roles_201_response",
+  "_extends_": "Common_201_Response",
+
+  "body": {
+    "status_message": "Case-User-Role assignments created successfully"
+  }
+}

--- a/src/aat/resources/features/F-105/F-105_Add_Case_Assigned_User_Roles_400_response.td.json
+++ b/src/aat/resources/features/F-105/F-105_Add_Case_Assigned_User_Roles_400_response.td.json
@@ -1,0 +1,11 @@
+{
+  "_guid_": "F-105_Add_Case_Assigned_User_Roles_400_response",
+  "_extends_": "Common_400_Response",
+
+  "body": {
+    "exception": "uk.gov.hmcts.ccd.endpoint.exceptions.BadRequestException",
+    "details": null,
+    "callbackErrors": null,
+    "callbackWarnings": null
+  }
+}

--- a/src/aat/resources/features/F-105/F-105_Add_Case_Assigned_User_Roles_Base.td.json
+++ b/src/aat/resources/features/F-105/F-105_Add_Case_Assigned_User_Roles_Base.td.json
@@ -1,9 +1,14 @@
 {
   "_guid_": "F-105_Add_Case_Assigned_User_Roles_Base",
+
+  "productName": "CCD Data Store",
   "title": "Add Case-Assigned Users and Roles",
+
   "method": "POST",
   "uri": "/case-users",
 
+  "s2sClientId": "aac_manage_case_assignment",
+  
   "request": {
     "_extends_": "Common_Request"
   },

--- a/src/aat/resources/features/F-105/F-105_Add_Case_Assigned_User_Roles_Base.td.json
+++ b/src/aat/resources/features/F-105/F-105_Add_Case_Assigned_User_Roles_Base.td.json
@@ -2,7 +2,7 @@
   "_guid_": "F-105_Add_Case_Assigned_User_Roles_Base",
 
   "productName": "CCD Data Store",
-  "title": "Add Case-Assigned Users and Roles",
+  "operationName": "Add Case-Assigned Users and Roles",
 
   "method": "POST",
   "uri": "/case-users",

--- a/src/aat/resources/features/F-105/F-105_Add_Case_Assigned_User_Roles_Base.td.json
+++ b/src/aat/resources/features/F-105/F-105_Add_Case_Assigned_User_Roles_Base.td.json
@@ -1,0 +1,19 @@
+{
+  "_guid_": "F-105_Add_Case_Assigned_User_Roles_Base",
+  "title": "Add Case-Assigned Users and Roles",
+  "method": "POST",
+  "uri": "/case-users",
+
+  "request": {
+    "_extends_": "Common_Request"
+  },
+
+  "expectedResponse": {
+    "headers": {
+      "_extends_": "Common_Response_Headers",
+      "Content-Length": "[[ANYTHING_PRESENT]]",
+      "Content-Type": "[[ANYTHING_PRESENT]]",
+      "Content-Encoding": "[[ANYTHING_PRESENT]]"
+    }
+  }
+}

--- a/src/aat/resources/features/F-105/F-105_Add_Case_Assigned_User_Roles_Base.td.json
+++ b/src/aat/resources/features/F-105/F-105_Add_Case_Assigned_User_Roles_Base.td.json
@@ -1,7 +1,7 @@
 {
   "_guid_": "F-105_Add_Case_Assigned_User_Roles_Base",
 
-  "productName": "CCD Data Store",
+  "productName": "CCD Data Store Api",
   "operationName": "Add Case-Assigned Users and Roles",
 
   "method": "POST",

--- a/src/aat/resources/features/F-105/F-105_Get_Case_Roles_for_Case_C1_Base.td.json
+++ b/src/aat/resources/features/F-105/F-105_Get_Case_Roles_for_Case_C1_Base.td.json
@@ -1,0 +1,39 @@
+{
+  "_guid_": "F-105_Get_Case_Roles_for_Case_C1_Base",
+  "title": "Get Case-Assigned Users and Roles",
+  "productName": "CCD Data Store",
+  "operationName": "Get Case-Assigned Users and Roles",
+  "method": "GET",
+  "uri": "/case-users",
+
+  "specs": [
+    "to verify Olawale's reception of the role CR-1 over the case C1"
+  ],
+
+  "users": {
+    "invokingUser": {
+      "username": "befta.caseworker.caa@gmail.com",
+      "password": "[[$CCD_BEFTA_CASEWORKER_CAA_PWD]]"
+    }
+  },
+
+  "request": {
+    "_extends_": "Common_Request",
+    "queryParams": {
+      "case_ids": "${[scenarioContext][siblingContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}"
+    }
+  },
+
+  "expectedResponse": {
+    "_extends_": "Common_200_Response",
+    "headers": {
+      "_extends_": "Common_Response_Headers",
+      "Content-Length": "[[ANYTHING_PRESENT]]",
+      "Content-Type": "[[ANYTHING_PRESENT]]",
+      "Content-Encoding": "[[ANYTHING_PRESENT]]"
+    },
+    "body": {
+      "case_users": []
+    }
+  }
+}

--- a/src/aat/resources/features/F-105/F-105_Get_Case_Roles_for_Case_C1_Base.td.json
+++ b/src/aat/resources/features/F-105/F-105_Get_Case_Roles_for_Case_C1_Base.td.json
@@ -6,10 +6,6 @@
   "method": "GET",
   "uri": "/case-users",
 
-  "specs": [
-    "to verify Olawale's reception of the role CR-1 over the case C1"
-  ],
-
   "users": {
     "invokingUser": {
       "username": "befta.caseworker.caa@gmail.com",
@@ -31,9 +27,6 @@
       "Content-Length": "[[ANYTHING_PRESENT]]",
       "Content-Type": "[[ANYTHING_PRESENT]]",
       "Content-Encoding": "[[ANYTHING_PRESENT]]"
-    },
-    "body": {
-      "case_users": []
     }
   }
 }

--- a/src/aat/resources/features/F-105/F-105_Get_Case_Roles_for_Case_C1_Base.td.json
+++ b/src/aat/resources/features/F-105/F-105_Get_Case_Roles_for_Case_C1_Base.td.json
@@ -1,8 +1,11 @@
 {
-  "_guid_": "F-105_Get_Case_Roles_for_Case_C1_Base",
   "title": "Get Case-Assigned Users and Roles",
+
+  "_guid_": "F-105_Get_Case_Roles_for_Case_C1_Base",
+
   "productName": "CCD Data Store",
   "operationName": "Get Case-Assigned Users and Roles",
+
   "method": "GET",
   "uri": "/case-users",
 

--- a/src/aat/resources/features/F-105/F-105_Get_Case_Roles_for_Case_C1_Empty_Response_Base.td.json
+++ b/src/aat/resources/features/F-105/F-105_Get_Case_Roles_for_Case_C1_Empty_Response_Base.td.json
@@ -1,0 +1,10 @@
+{
+  "_guid_": "F-105_Get_Case_Roles_for_Case_C1_Empty_Response_Base",
+  "_extends_": "F-105_Get_Case_Roles_for_Case_C1_Base",
+
+  "expectedResponse": {
+    "body": {
+      "case_users": []
+    }
+  }
+}

--- a/src/aat/resources/features/F-105/F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment.td.json
+++ b/src/aat/resources/features/F-105/F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment.td.json
@@ -1,6 +1,7 @@
 {
   "_guid_": "F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment",
   "_extends_": "Befta_Jurisdiction2_Default_Full_Case_Creation_Data_solicitor_1",
+
   "specs": [
     "by Richard to create a case - C1"
   ],

--- a/src/aat/resources/features/F-105/F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment.td.json
+++ b/src/aat/resources/features/F-105/F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment.td.json
@@ -1,0 +1,21 @@
+{
+  "_guid_": "F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment",
+  "_extends_": "Befta_Jurisdiction2_Default_Full_Case_Creation_Data_solicitor_1",
+  "specs": [
+    "by Richard to create a case - C1"
+  ],
+
+  "users": {
+    "_extends_": "F-105_Users"
+  },
+
+  "request": {
+    "headers": {
+      "_extends_": "Common_Request_Headers",
+      "Authorization": "Bearer ${[scenarioContext][testData][users][userRichard][accessToken]}"
+    },
+    "body": {
+      "event_token": "${[scenarioContext][siblingContexts][Befta_Jurisdiction2_Default_Token_Creation_Data_For_Case_Creation][testData][actualResponse][body][token]}"
+    }
+  }
+}

--- a/src/aat/resources/features/F-105/F-105_Users.td.json
+++ b/src/aat/resources/features/F-105/F-105_Users.td.json
@@ -1,0 +1,16 @@
+{
+  "_guid_": "F-105_Users",
+
+  "userRichard": {
+    "username": "befta.caseworker.2.solicitor.1@gmail.com",
+    "password": "[[$CCD_BEFTA_CASEWORKER_2_SOLICITOR_1_PWD]]"
+  },
+  "userDil": {
+    "username": "befta.caseworker.2.solicitor.2@gmail.com",
+    "password": "[[$CCD_BEFTA_CASEWORKER_2_SOLICITOR_2_PWD]]"
+  },
+  "userOlawale": {
+    "username": "befta.caseworker.2.solicitor.3@gmail.com",
+    "password": "[[$CCD_BEFTA_CASEWORKER_2_SOLICITOR_3_PWD]]"
+  }
+}

--- a/src/aat/resources/features/F-105/S-105.1.td.json
+++ b/src/aat/resources/features/F-105/S-105.1.td.json
@@ -1,0 +1,38 @@
+{
+  "title": "Must successfully assign a user and case role for a specific case by a user calling through/from an authorised application",
+  "_guid_": "S-105.1",
+  "_extends_": "F-105_Add_Case_Assigned_User_Roles_Base",
+  "productName": "CCD Data Store api",
+  "operationName": "Add Case-Assigned User and Role",
+  "s2sClientId": "aac_manage_case_assignment",
+
+  "specs": [
+    "Richard - who can create a case",
+    "Dil - who is to add some case role assignment for a case",
+    "Olawale - with an active solicitor profile",
+    "is made from an authorised application, by Dil, with the Case ID of C1, User ID of Olawale and a proper Case Role CR-1"
+  ],
+
+  "users": {
+    "_extends_": "F-105_Users"
+  },
+
+  "request": {
+    "headers": {
+      "Authorization": "Bearer ${[scenarioContext][testData][users][userDil][accessToken]}"
+    },
+    "body": {
+      "case_users": [
+        {
+          "case_id": "${[scenarioContext][childContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
+          "user_id": "${[scenarioContext][testData][users][userOlawale][id]}",
+          "case_role": "[CR-1]"
+        }
+      ]
+    }
+  },
+
+  "expectedResponse": {
+    "_extends_": "F-105_Add_Case_Assigned_User_Roles_201_response"
+  }
+}

--- a/src/aat/resources/features/F-105/S-105.1.td.json
+++ b/src/aat/resources/features/F-105/S-105.1.td.json
@@ -1,10 +1,8 @@
 {
   "title": "Must successfully assign a user and case role for a specific case by a user calling through/from an authorised application",
+
   "_guid_": "S-105.1",
   "_extends_": "F-105_Add_Case_Assigned_User_Roles_Base",
-  "productName": "CCD Data Store api",
-  "operationName": "Add Case-Assigned User and Role",
-  "s2sClientId": "aac_manage_case_assignment",
 
   "specs": [
     "Richard - who can create a case",

--- a/src/aat/resources/features/F-105/S-105.1.verify.td.json
+++ b/src/aat/resources/features/F-105/S-105.1.verify.td.json
@@ -1,0 +1,24 @@
+{
+  "_guid_": "S-105.1_Get_Case_Roles_for_Case_C1",
+  "_extends_": "F-105_Get_Case_Roles_for_Case_C1_Base",
+
+  "users": {
+    "_extends_": "F-105_Users"    
+  },
+
+  "expectedResponse": {
+    "body": {
+      "case_users": [
+        {
+          "__ordering__": "UNORDERED",
+          "__elementId__": "case_id,user_id,case_role"
+        },
+        {
+          "case_id": "${[scenarioContext][siblingContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
+          "user_id": "${[scenarioContext][testData][users][userOlawale][id]}",
+          "case_role": "[CR-1]"
+        }
+      ]
+    }
+  }
+}

--- a/src/aat/resources/features/F-105/S-105.1.verify.td.json
+++ b/src/aat/resources/features/F-105/S-105.1.verify.td.json
@@ -14,7 +14,7 @@
           "__elementId__": "case_id,user_id,case_role"
         },
         {
-          "case_id": "${{{}}[scenarioContext][siblingContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
+          "case_id": "${${}[scenarioContext][siblingContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
           "user_id": "${[scenarioContext][testData][users][userOlawale][id]}",
           "case_role": "[CR-1]"
         }

--- a/src/aat/resources/features/F-105/S-105.1.verify.td.json
+++ b/src/aat/resources/features/F-105/S-105.1.verify.td.json
@@ -14,7 +14,7 @@
           "__elementId__": "case_id,user_id,case_role"
         },
         {
-          "case_id": "${${}[scenarioContext][siblingContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
+          "case_id": "${}${[scenarioContext][siblingContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
           "user_id": "${[scenarioContext][testData][users][userOlawale][id]}",
           "case_role": "[CR-1]"
         }

--- a/src/aat/resources/features/F-105/S-105.1.verify.td.json
+++ b/src/aat/resources/features/F-105/S-105.1.verify.td.json
@@ -2,8 +2,12 @@
   "_guid_": "S-105.1_Get_Case_Roles_for_Case_C1",
   "_extends_": "F-105_Get_Case_Roles_for_Case_C1_Base",
 
+  "specs": [
+    "to verify Olawale's reception of the role CR-1 over the case C1"
+  ],
+
   "users": {
-    "_extends_": "F-105_Users"    
+    "_extends_": "F-105_Users"
   },
 
   "expectedResponse": {

--- a/src/aat/resources/features/F-105/S-105.1.verify.td.json
+++ b/src/aat/resources/features/F-105/S-105.1.verify.td.json
@@ -14,7 +14,7 @@
           "__elementId__": "case_id,user_id,case_role"
         },
         {
-          "case_id": "${[scenarioContext][siblingContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
+          "case_id": "${{{}}[scenarioContext][siblingContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
           "user_id": "${[scenarioContext][testData][users][userOlawale][id]}",
           "case_role": "[CR-1]"
         }

--- a/src/aat/resources/features/F-105/S-105.10.td.json
+++ b/src/aat/resources/features/F-105/S-105.10.td.json
@@ -1,0 +1,35 @@
+{
+  "title": "Must return an error response for empty case_users list",
+  "_guid_": "S-105.10",
+  "_extends_": "F-105_Add_Case_Assigned_User_Roles_Base",
+  "productName": "CCD Data Store api",
+  "operationName": "Add Case-Assigned Users and Roles",
+  "s2sClientId": "aac_manage_case_assignment",
+
+  "specs": [
+    "Dil - who is to add some case role assignment for a case",
+    "is made from an authorised application by Dil, with an empty list of case_users supplied"
+  ],
+
+  "users": {
+    "userDil": {
+      "username": "befta.caseworker.2.solicitor.2@gmail.com",
+      "password": "[[$CCD_BEFTA_CASEWORKER_2_SOLICITOR_2_PWD]]"
+    }
+  },
+
+  "request": {
+    "headers": {
+      "Authorization": "Bearer ${[scenarioContext][testData][users][userDil][accessToken]}"
+    },
+    "body": {
+    }
+  },
+
+  "expectedResponse": {
+    "_extends_": "F-105_Add_Case_Assigned_User_Roles_400_response",
+    "body": {
+      "message": "Invalid data provided for the following inputs to the request:\nCase user roles list is empty"
+    }
+  }
+}

--- a/src/aat/resources/features/F-105/S-105.10.td.json
+++ b/src/aat/resources/features/F-105/S-105.10.td.json
@@ -2,9 +2,6 @@
   "title": "Must return an error response for empty case_users list",
   "_guid_": "S-105.10",
   "_extends_": "F-105_Add_Case_Assigned_User_Roles_Base",
-  "productName": "CCD Data Store api",
-  "operationName": "Add Case-Assigned Users and Roles",
-  "s2sClientId": "aac_manage_case_assignment",
 
   "specs": [
     "Dil - who is to add some case role assignment for a case",

--- a/src/aat/resources/features/F-105/S-105.11.td.json
+++ b/src/aat/resources/features/F-105/S-105.11.td.json
@@ -1,0 +1,51 @@
+{
+  "title": "Must return an error response when the case does not exist",
+  "_guid_": "S-105.11",
+  "_extends_": "F-105_Add_Case_Assigned_User_Roles_Base",
+  "productName": "CCD Data Store api",
+  "operationName": "Add Case-Assigned Users and Roles",
+  "s2sClientId": "aac_manage_case_assignment",
+
+  "specs": [
+    "Richard - who can create a case",
+    "Dil - who is to add some case role assignment for a case",
+    "Olawale - with an active solicitor profile and valid User ID",
+    "is made by Dil for 2 assignments each containing Olawale's User ID and a proper Case Role CR-1",
+    "contains the Case ID of C1 in one entry and a well formed but non-existant case ID in the other"
+  ],
+
+  "users": {
+    "_extends_": "F-105_Users"
+  },
+
+  "request": {
+    "headers": {
+      "Authorization": "Bearer ${[scenarioContext][testData][users][userDil][accessToken]}"
+    },
+    "body": {
+      "case_users": [
+        {
+          "case_id": "${[scenarioContext][childContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
+          "user_id": "${[scenarioContext][testData][users][userOlawale][id]}",
+          "case_role": "[CR-1]"
+        },
+        {
+          "case_id": "4444333322221111",
+          "user_id": "${[scenarioContext][testData][users][userOlawale][id]}",
+          "case_role": "[CR-1]"
+        }
+      ]
+    }
+  },
+
+  "expectedResponse": {
+    "_extends_": "Common_404_Response",
+    "body": {
+      "exception": "uk.gov.hmcts.ccd.domain.service.getcase.CaseNotFoundException",
+      "message": "No case found for reference: 4444333322221111",
+      "details": null,
+      "callbackErrors": null,
+      "callbackWarnings": null
+    }
+  }
+}

--- a/src/aat/resources/features/F-105/S-105.11.td.json
+++ b/src/aat/resources/features/F-105/S-105.11.td.json
@@ -1,10 +1,8 @@
 {
   "title": "Must return an error response when the case does not exist",
+
   "_guid_": "S-105.11",
   "_extends_": "F-105_Add_Case_Assigned_User_Roles_Base",
-  "productName": "CCD Data Store api",
-  "operationName": "Add Case-Assigned Users and Roles",
-  "s2sClientId": "aac_manage_case_assignment",
 
   "specs": [
     "Richard - who can create a case",

--- a/src/aat/resources/features/F-105/S-105.11.verify.td.json
+++ b/src/aat/resources/features/F-105/S-105.11.verify.td.json
@@ -1,4 +1,8 @@
 {
   "_guid_": "S-105.11_Get_Case_Roles_for_Case_C1",
-  "_extends_": "F-105_Get_Case_Roles_for_Case_C1_Base"
+  "_extends_": "F-105_Get_Case_Roles_for_Case_C1_Empty_Response_Base",
+
+  "specs": [
+    "to verify that Olawale hasn't received the role CR-1 over the case C1"
+  ]
 }

--- a/src/aat/resources/features/F-105/S-105.11.verify.td.json
+++ b/src/aat/resources/features/F-105/S-105.11.verify.td.json
@@ -1,0 +1,4 @@
+{
+  "_guid_": "S-105.11_Get_Case_Roles_for_Case_C1",
+  "_extends_": "F-105_Get_Case_Roles_for_Case_C1_Base"
+}

--- a/src/aat/resources/features/F-105/S-105.12.td.json
+++ b/src/aat/resources/features/F-105/S-105.12.td.json
@@ -1,0 +1,43 @@
+{
+  "title": "Must not create duplicate case-user-roles",
+  "_guid_": "S-105.12",
+  "_extends_": "F-105_Add_Case_Assigned_User_Roles_Base",
+  "productName": "CCD Data Store api",
+  "operationName": "Add Case-Assigned Users and Roles",
+  "s2sClientId": "aac_manage_case_assignment",
+
+  "specs": [
+    "Richard - who can create a case",
+    "Dil - who is to add some case role assignment for a case",
+    "Olawale - with an active solicitor profile and valid User ID",
+    "is made by Dil for 2 assignments each containing the Case ID of C1, User ID of Olawale and a proper Case Role CR-1"
+  ],
+
+  "users": {
+    "_extends_": "F-105_Users"
+  },
+
+  "request": {
+    "headers": {
+      "Authorization": "Bearer ${[scenarioContext][testData][users][userDil][accessToken]}"
+    },
+    "body": {
+      "case_users": [
+        {
+          "case_id": "${[scenarioContext][childContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
+          "user_id": "${[scenarioContext][testData][users][userOlawale][id]}",
+          "case_role": "[CR-1]"
+        },
+        {
+          "case_id": "${[scenarioContext][childContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
+          "user_id": "${[scenarioContext][testData][users][userOlawale][id]}",
+          "case_role": "[CR-1]"
+        }
+      ]
+    }
+  },
+
+  "expectedResponse": {
+    "_extends_": "F-105_Add_Case_Assigned_User_Roles_201_response"
+  }
+}

--- a/src/aat/resources/features/F-105/S-105.12.td.json
+++ b/src/aat/resources/features/F-105/S-105.12.td.json
@@ -1,10 +1,8 @@
 {
   "title": "Must not create duplicate case-user-roles",
+
   "_guid_": "S-105.12",
   "_extends_": "F-105_Add_Case_Assigned_User_Roles_Base",
-  "productName": "CCD Data Store api",
-  "operationName": "Add Case-Assigned Users and Roles",
-  "s2sClientId": "aac_manage_case_assignment",
 
   "specs": [
     "Richard - who can create a case",

--- a/src/aat/resources/features/F-105/S-105.12.verify.td.json
+++ b/src/aat/resources/features/F-105/S-105.12.verify.td.json
@@ -14,7 +14,7 @@
 					"__elementId__": "case_id,user_id,case_role"
 				},
 				{
-					"case_id": "${[scenarioContext][siblingContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
+					"case_id": "${{{}}[scenarioContext][siblingContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
 					"user_id": "${[scenarioContext][testData][users][userOlawale][id]}",
 					"case_role": "[CR-1]"
 				}

--- a/src/aat/resources/features/F-105/S-105.12.verify.td.json
+++ b/src/aat/resources/features/F-105/S-105.12.verify.td.json
@@ -2,8 +2,12 @@
   "_guid_": "S-105.12_Get_Case_Roles_for_Case_C1",
   "_extends_": "F-105_Get_Case_Roles_for_Case_C1_Base",
 
+  "specs": [
+    "to verify Olawale's reception of the role CR-1 over the case C1"
+  ],
+
   "users": {
-    "_extends_": "F-105_Users"    
+    "_extends_": "F-105_Users"
   },
 
   "expectedResponse": {

--- a/src/aat/resources/features/F-105/S-105.12.verify.td.json
+++ b/src/aat/resources/features/F-105/S-105.12.verify.td.json
@@ -1,0 +1,24 @@
+{
+  "_guid_": "S-105.12_Get_Case_Roles_for_Case_C1",
+  "_extends_": "F-105_Get_Case_Roles_for_Case_C1_Base",
+
+  "users": {
+    "_extends_": "F-105_Users"    
+  },
+
+  "expectedResponse": {
+		"body": {
+			"case_users": [
+				{
+					"__ordering__": "UNORDERED",
+					"__elementId__": "case_id,user_id,case_role"
+				},
+				{
+					"case_id": "${[scenarioContext][siblingContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
+					"user_id": "${[scenarioContext][testData][users][userOlawale][id]}",
+					"case_role": "[CR-1]"
+				}
+			]
+		}
+  }
+}

--- a/src/aat/resources/features/F-105/S-105.12.verify.td.json
+++ b/src/aat/resources/features/F-105/S-105.12.verify.td.json
@@ -14,7 +14,7 @@
 					"__elementId__": "case_id,user_id,case_role"
 				},
 				{
-					"case_id": "${{{}}[scenarioContext][siblingContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
+					"case_id": "${${}[scenarioContext][siblingContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
 					"user_id": "${[scenarioContext][testData][users][userOlawale][id]}",
 					"case_role": "[CR-1]"
 				}

--- a/src/aat/resources/features/F-105/S-105.12.verify.td.json
+++ b/src/aat/resources/features/F-105/S-105.12.verify.td.json
@@ -14,7 +14,7 @@
 					"__elementId__": "case_id,user_id,case_role"
 				},
 				{
-					"case_id": "${${}[scenarioContext][siblingContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
+					"case_id": "${}${[scenarioContext][siblingContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
 					"user_id": "${[scenarioContext][testData][users][userOlawale][id]}",
 					"case_role": "[CR-1]"
 				}

--- a/src/aat/resources/features/F-105/S-105.13.td.json
+++ b/src/aat/resources/features/F-105/S-105.13.td.json
@@ -2,9 +2,6 @@
   "title": "Must successfully assign multiple user and case roles for a specific case by a user calling through/from an authorised application",
   "_guid_": "S-105.13",
   "_extends_": "F-105_Add_Case_Assigned_User_Roles_Base",
-  "productName": "CCD Data Store api",
-  "operationName": "Add Case-Assigned Users and Roles",
-  "s2sClientId": "aac_manage_case_assignment",
 
   "specs": [
     "Richard - who can create a case",

--- a/src/aat/resources/features/F-105/S-105.13.td.json
+++ b/src/aat/resources/features/F-105/S-105.13.td.json
@@ -1,0 +1,44 @@
+{
+  "title": "Must successfully assign multiple user and case roles for a specific case by a user calling through/from an authorised application",
+  "_guid_": "S-105.13",
+  "_extends_": "F-105_Add_Case_Assigned_User_Roles_Base",
+  "productName": "CCD Data Store api",
+  "operationName": "Add Case-Assigned Users and Roles",
+  "s2sClientId": "aac_manage_case_assignment",
+
+  "specs": [
+    "Richard - who can create a case",
+    "Dil - who is to add some case role assignment for a case",
+    "Olawale - with an active solicitor profile and valid User ID",
+    "is made from an authorised application by Dil, for 2 assignments each containing the Case ID of C1 and User ID of Olawale",
+    "contains a proper Case Role CR-1 in one entry and a proper Case Role CR-2 in the other"
+  ],
+
+  "users": {
+    "_extends_": "F-105_Users"
+  },
+
+  "request": {
+    "headers": {
+      "Authorization": "Bearer ${[scenarioContext][testData][users][userDil][accessToken]}"
+    },
+    "body": {
+      "case_users": [
+        {
+          "case_id": "${[scenarioContext][childContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
+          "user_id": "${[scenarioContext][testData][users][userOlawale][id]}",
+          "case_role": "[CR-1]"
+        },
+        {
+          "case_id": "${[scenarioContext][childContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
+          "user_id": "${[scenarioContext][testData][users][userOlawale][id]}",
+          "case_role": "[CR-2]"
+        }
+      ]
+    }
+  },
+
+  "expectedResponse": {
+    "_extends_": "F-105_Add_Case_Assigned_User_Roles_201_response"
+  }
+}

--- a/src/aat/resources/features/F-105/S-105.13.verify.td.json
+++ b/src/aat/resources/features/F-105/S-105.13.verify.td.json
@@ -18,12 +18,12 @@
           "__elementId__": "case_id,user_id,case_role"
         },
         {
-          "case_id": "${[scenarioContext][siblingContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
+          "case_id": "${{{}}[scenarioContext][siblingContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
           "user_id": "${[scenarioContext][testData][users][userOlawale][id]}",
           "case_role": "[CR-1]"
         },
         {
-          "case_id": "${[scenarioContext][siblingContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
+          "case_id": "${{{}}[scenarioContext][siblingContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
           "user_id": "${[scenarioContext][testData][users][userOlawale][id]}",
           "case_role": "[CR-2]"
         }

--- a/src/aat/resources/features/F-105/S-105.13.verify.td.json
+++ b/src/aat/resources/features/F-105/S-105.13.verify.td.json
@@ -7,7 +7,7 @@
   ],
 
   "users": {
-    "_extends_": "F-105_Users"    
+    "_extends_": "F-105_Users"
   },
 
   "expectedResponse": {

--- a/src/aat/resources/features/F-105/S-105.13.verify.td.json
+++ b/src/aat/resources/features/F-105/S-105.13.verify.td.json
@@ -18,12 +18,12 @@
           "__elementId__": "case_id,user_id,case_role"
         },
         {
-          "case_id": "${${}[scenarioContext][siblingContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
+          "case_id": "${}${[scenarioContext][siblingContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
           "user_id": "${[scenarioContext][testData][users][userOlawale][id]}",
           "case_role": "[CR-1]"
         },
         {
-          "case_id": "${${}[scenarioContext][siblingContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
+          "case_id": "${}${[scenarioContext][siblingContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
           "user_id": "${[scenarioContext][testData][users][userOlawale][id]}",
           "case_role": "[CR-2]"
         }

--- a/src/aat/resources/features/F-105/S-105.13.verify.td.json
+++ b/src/aat/resources/features/F-105/S-105.13.verify.td.json
@@ -18,12 +18,12 @@
           "__elementId__": "case_id,user_id,case_role"
         },
         {
-          "case_id": "${{{}}[scenarioContext][siblingContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
+          "case_id": "${${}[scenarioContext][siblingContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
           "user_id": "${[scenarioContext][testData][users][userOlawale][id]}",
           "case_role": "[CR-1]"
         },
         {
-          "case_id": "${{{}}[scenarioContext][siblingContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
+          "case_id": "${${}[scenarioContext][siblingContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
           "user_id": "${[scenarioContext][testData][users][userOlawale][id]}",
           "case_role": "[CR-2]"
         }

--- a/src/aat/resources/features/F-105/S-105.13.verify.td.json
+++ b/src/aat/resources/features/F-105/S-105.13.verify.td.json
@@ -1,0 +1,33 @@
+{
+  "_guid_": "S-105.13_Get_Case_Roles_for_Case_C1",
+  "_extends_": "F-105_Get_Case_Roles_for_Case_C1_Base",
+
+  "specs": [
+    "to verify Olawale's reception of the role CR-1 and CR-2 over the case C1"
+  ],
+
+  "users": {
+    "_extends_": "F-105_Users"    
+  },
+
+  "expectedResponse": {
+    "body": {
+      "case_users": [
+        {
+          "__ordering__": "UNORDERED",
+          "__elementId__": "case_id,user_id,case_role"
+        },
+        {
+          "case_id": "${[scenarioContext][siblingContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
+          "user_id": "${[scenarioContext][testData][users][userOlawale][id]}",
+          "case_role": "[CR-1]"
+        },
+        {
+          "case_id": "${[scenarioContext][siblingContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
+          "user_id": "${[scenarioContext][testData][users][userOlawale][id]}",
+          "case_role": "[CR-2]"
+        }
+      ]
+    }
+  }
+}

--- a/src/aat/resources/features/F-105/S-105.2.td.json
+++ b/src/aat/resources/features/F-105/S-105.2.td.json
@@ -2,9 +2,6 @@
   "title": "Must return an error response for a missing Case ID",
   "_guid_": "S-105.2",
   "_extends_": "F-105_Add_Case_Assigned_User_Roles_Base",
-  "productName": "CCD Data Store api",
-  "operationName": "Add Case-Assigned Users and Roles",
-  "s2sClientId": "aac_manage_case_assignment",
 
   "specs": [
     "Richard - who can create a case",

--- a/src/aat/resources/features/F-105/S-105.2.td.json
+++ b/src/aat/resources/features/F-105/S-105.2.td.json
@@ -1,0 +1,46 @@
+{
+  "title": "Must return an error response for a missing Case ID",
+  "_guid_": "S-105.2",
+  "_extends_": "F-105_Add_Case_Assigned_User_Roles_Base",
+  "productName": "CCD Data Store api",
+  "operationName": "Add Case-Assigned Users and Roles",
+  "s2sClientId": "aac_manage_case_assignment",
+
+  "specs": [
+    "Richard - who can create a case",
+    "Dil - who is to add some case role assignment for a case",
+    "Olawale - with an active solicitor profile and valid User ID",
+    "is made by Dil for 2 assignments each containing Olawale's User ID and a proper Case Role CR-1",
+    "contains the Case ID of C1 in one entry but no case ID in the other"
+  ],
+
+  "users": {
+    "_extends_": "F-105_Users"
+  },
+
+  "request": {
+    "headers": {
+      "Authorization": "Bearer ${[scenarioContext][testData][users][userDil][accessToken]}"
+    },
+    "body": {
+      "case_users": [
+        {
+          "case_id": "${[scenarioContext][childContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
+          "user_id": "${[scenarioContext][testData][users][userOlawale][id]}",
+          "case_role": "[CR-1]"
+        },
+        {
+          "user_id": "${[scenarioContext][testData][users][userOlawale][id]}",
+          "case_role": "[CR-1]"
+        }
+      ]
+    }
+  },
+
+  "expectedResponse": {
+    "_extends_": "F-105_Add_Case_Assigned_User_Roles_400_response",
+    "body": {
+      "message": "Invalid data provided for the following inputs to the request:\nCase ID is not valid"
+    }
+  }
+}

--- a/src/aat/resources/features/F-105/S-105.2.verify.td.json
+++ b/src/aat/resources/features/F-105/S-105.2.verify.td.json
@@ -1,0 +1,4 @@
+{
+  "_guid_": "S-105.2_Get_Case_Roles_for_Case_C1",
+  "_extends_": "F-105_Get_Case_Roles_for_Case_C1_Base"
+}

--- a/src/aat/resources/features/F-105/S-105.2.verify.td.json
+++ b/src/aat/resources/features/F-105/S-105.2.verify.td.json
@@ -1,4 +1,8 @@
 {
   "_guid_": "S-105.2_Get_Case_Roles_for_Case_C1",
-  "_extends_": "F-105_Get_Case_Roles_for_Case_C1_Base"
+  "_extends_": "F-105_Get_Case_Roles_for_Case_C1_Empty_Response_Base",
+
+  "specs": [
+    "to verify that Olawale hasn't received the role CR-1 over the case C1"
+  ]
 }

--- a/src/aat/resources/features/F-105/S-105.3.td.json
+++ b/src/aat/resources/features/F-105/S-105.3.td.json
@@ -2,9 +2,6 @@
   "title": "Must return an error response for a malformed Case ID",
   "_guid_": "S-105.3",
   "_extends_": "F-105_Add_Case_Assigned_User_Roles_Base",
-  "productName": "CCD Data Store api",
-  "operationName": "Add Case-Assigned Users and Roles",
-  "s2sClientId": "aac_manage_case_assignment",
 
   "specs": [
     "Richard - who can create a case",

--- a/src/aat/resources/features/F-105/S-105.3.td.json
+++ b/src/aat/resources/features/F-105/S-105.3.td.json
@@ -1,0 +1,47 @@
+{
+  "title": "Must return an error response for a malformed Case ID",
+  "_guid_": "S-105.3",
+  "_extends_": "F-105_Add_Case_Assigned_User_Roles_Base",
+  "productName": "CCD Data Store api",
+  "operationName": "Add Case-Assigned Users and Roles",
+  "s2sClientId": "aac_manage_case_assignment",
+
+  "specs": [
+    "Richard - who can create a case",
+    "Dil - who is to add some case role assignment for a case",
+    "Olawale - with an active solicitor profile and valid User ID",
+    "is made by Dil for 2 assignments each containing Olawale's User ID and a proper Case Role CR-1",
+    "contains the Case ID of C1 in one entry and a malformed case ID in the other"
+  ],
+
+  "users": {
+    "_extends_": "F-105_Users"
+  },
+
+  "request": {
+    "headers": {
+      "Authorization": "Bearer ${[scenarioContext][testData][users][userDil][accessToken]}"
+    },
+    "body": {
+      "case_users": [
+        {
+          "case_id": "${[scenarioContext][childContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
+          "user_id": "${[scenarioContext][testData][users][userOlawale][id]}",
+          "case_role": "[CR-1]"
+        },
+        {
+          "case_id": "1234567890123456",
+          "user_id": "${[scenarioContext][testData][users][userOlawale][id]}",
+          "case_role": "[CR-1]"
+        }
+      ]
+    }
+  },
+
+  "expectedResponse": {
+    "_extends_": "F-105_Add_Case_Assigned_User_Roles_400_response",
+    "body": {
+      "message": "Invalid data provided for the following inputs to the request:\nCase ID is not valid"
+    }
+  }
+}

--- a/src/aat/resources/features/F-105/S-105.3.verify.td.json
+++ b/src/aat/resources/features/F-105/S-105.3.verify.td.json
@@ -1,0 +1,4 @@
+{
+  "_guid_": "S-105.3_Get_Case_Roles_for_Case_C1",
+  "_extends_": "F-105_Get_Case_Roles_for_Case_C1_Base"
+}

--- a/src/aat/resources/features/F-105/S-105.3.verify.td.json
+++ b/src/aat/resources/features/F-105/S-105.3.verify.td.json
@@ -1,4 +1,8 @@
 {
   "_guid_": "S-105.3_Get_Case_Roles_for_Case_C1",
-  "_extends_": "F-105_Get_Case_Roles_for_Case_C1_Base"
+  "_extends_": "F-105_Get_Case_Roles_for_Case_C1_Empty_Response_Base",
+
+  "specs": [
+    "to verify that Olawale hasn't received the role CR-1 over the case C1"
+  ]
 }

--- a/src/aat/resources/features/F-105/S-105.4.td.json
+++ b/src/aat/resources/features/F-105/S-105.4.td.json
@@ -1,0 +1,46 @@
+{
+  "title": "Must return an error response for a missing User ID",
+  "_guid_": "S-105.4",
+  "_extends_": "F-105_Add_Case_Assigned_User_Roles_Base",
+  "productName": "CCD Data Store api",
+  "operationName": "Add Case-Assigned Users and Roles",
+  "s2sClientId": "aac_manage_case_assignment",
+
+  "specs": [
+    "Richard - who can create a case",
+    "Dil - who is to add some case role assignment for a case",
+    "Olawale - with an active solicitor profile and valid User ID",
+    "is made by Dil for 2 assignments each containing the Case ID of C1 and a proper Case Role CR-1",
+    "contains the User ID of Olawale in one entry but no User ID in the other"
+  ],
+
+  "users": {
+    "_extends_": "F-105_Users"
+  },
+
+  "request": {
+    "headers": {
+      "Authorization": "Bearer ${[scenarioContext][testData][users][userDil][accessToken]}"
+    },
+    "body": {
+      "case_users": [
+        {
+          "case_id": "${[scenarioContext][childContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
+          "user_id": "${[scenarioContext][testData][users][userOlawale][id]}",
+          "case_role": "[CR-1]"
+        },
+        {
+          "case_id": "${[scenarioContext][childContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
+          "case_role": "[CR-1]"
+        }
+      ]
+    }
+  },
+
+  "expectedResponse": {
+    "_extends_": "F-105_Add_Case_Assigned_User_Roles_400_response",
+    "body": {
+      "message": "Invalid data provided for the following inputs to the request:\nUser ID is not valid"
+    }
+  }
+}

--- a/src/aat/resources/features/F-105/S-105.4.td.json
+++ b/src/aat/resources/features/F-105/S-105.4.td.json
@@ -2,9 +2,6 @@
   "title": "Must return an error response for a missing User ID",
   "_guid_": "S-105.4",
   "_extends_": "F-105_Add_Case_Assigned_User_Roles_Base",
-  "productName": "CCD Data Store api",
-  "operationName": "Add Case-Assigned Users and Roles",
-  "s2sClientId": "aac_manage_case_assignment",
 
   "specs": [
     "Richard - who can create a case",

--- a/src/aat/resources/features/F-105/S-105.4.verify.td.json
+++ b/src/aat/resources/features/F-105/S-105.4.verify.td.json
@@ -1,4 +1,8 @@
 {
   "_guid_": "S-105.4_Get_Case_Roles_for_Case_C1",
-  "_extends_": "F-105_Get_Case_Roles_for_Case_C1_Base"
+  "_extends_": "F-105_Get_Case_Roles_for_Case_C1_Empty_Response_Base",
+
+  "specs": [
+    "to verify that Olawale hasn't received the role CR-1 over the case C1"
+  ]
 }

--- a/src/aat/resources/features/F-105/S-105.4.verify.td.json
+++ b/src/aat/resources/features/F-105/S-105.4.verify.td.json
@@ -1,0 +1,4 @@
+{
+  "_guid_": "S-105.4_Get_Case_Roles_for_Case_C1",
+  "_extends_": "F-105_Get_Case_Roles_for_Case_C1_Base"
+}

--- a/src/aat/resources/features/F-105/S-105.5.td.json
+++ b/src/aat/resources/features/F-105/S-105.5.td.json
@@ -1,0 +1,47 @@
+{
+  "title": "Must return an error response for a malformed User ID Provided",
+  "_guid_": "S-105.5",
+  "_extends_": "F-105_Add_Case_Assigned_User_Roles_Base",
+  "productName": "CCD Data Store api",
+  "operationName": "Add Case-Assigned Users and Roles",
+  "s2sClientId": "aac_manage_case_assignment",
+
+  "specs": [
+    "Richard - who can create a case",
+    "Dil - who is to add some case role assignment for a case",
+    "Olawale - with an active solicitor profile and valid User ID",
+    "is made by Dil for 2 assignments each containing the Case ID of C1 and a proper Case Role CR-1",
+    "contains the User ID of Olawale in one entry and a malformed User ID in the other"
+  ],
+
+  "users": {
+    "_extends_": "F-105_Users"
+  },
+
+  "request": {
+    "headers": {
+      "Authorization": "Bearer ${[scenarioContext][testData][users][userDil][accessToken]}"
+    },
+    "body": {
+      "case_users": [
+        {
+          "case_id": "${[scenarioContext][childContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
+          "user_id": "${[scenarioContext][testData][users][userOlawale][id]}",
+          "case_role": "[CR-1]"
+        },
+        {
+          "case_id": "${[scenarioContext][childContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
+          "user_id": "",
+          "case_role": "[CR-1]"
+        }
+      ]
+    }
+  },
+
+  "expectedResponse": {
+    "_extends_": "F-105_Add_Case_Assigned_User_Roles_400_response",
+    "body": {
+      "message": "Invalid data provided for the following inputs to the request:\nUser ID is not valid"
+    }
+  }
+}

--- a/src/aat/resources/features/F-105/S-105.5.td.json
+++ b/src/aat/resources/features/F-105/S-105.5.td.json
@@ -2,9 +2,6 @@
   "title": "Must return an error response for a malformed User ID Provided",
   "_guid_": "S-105.5",
   "_extends_": "F-105_Add_Case_Assigned_User_Roles_Base",
-  "productName": "CCD Data Store api",
-  "operationName": "Add Case-Assigned Users and Roles",
-  "s2sClientId": "aac_manage_case_assignment",
 
   "specs": [
     "Richard - who can create a case",

--- a/src/aat/resources/features/F-105/S-105.5.verify.td.json
+++ b/src/aat/resources/features/F-105/S-105.5.verify.td.json
@@ -1,0 +1,4 @@
+{
+  "_guid_": "S-105.5_Get_Case_Roles_for_Case_C1",
+  "_extends_": "F-105_Get_Case_Roles_for_Case_C1_Base"
+}

--- a/src/aat/resources/features/F-105/S-105.5.verify.td.json
+++ b/src/aat/resources/features/F-105/S-105.5.verify.td.json
@@ -1,4 +1,8 @@
 {
   "_guid_": "S-105.5_Get_Case_Roles_for_Case_C1",
-  "_extends_": "F-105_Get_Case_Roles_for_Case_C1_Base"
+  "_extends_": "F-105_Get_Case_Roles_for_Case_C1_Empty_Response_Base",
+
+  "specs": [
+    "to verify that Olawale hasn't received the role CR-1 over the case C1"
+  ]
 }

--- a/src/aat/resources/features/F-105/S-105.6.td.json
+++ b/src/aat/resources/features/F-105/S-105.6.td.json
@@ -1,0 +1,45 @@
+{
+  "title": "Must return an error response when the request is made from an un-authorised application",
+  "_guid_": "S-105.6",
+  "_extends_": "F-105_Add_Case_Assigned_User_Roles_Base",
+  "productName": "CCD Data Store api",
+  "operationName": "Add Case-Assigned Users and Roles",
+  "s2sClientId": "ccd_gw",
+
+  "specs": [
+    "Richard - who can create a case",
+    "Dil - with an active profile",
+    "Olawale - who is not a privileged user and is calling from an un-authorised application",
+    "is made by Olawale with the Case ID of C1 & Dil's User ID and a proper Case Role CR-1"
+  ],
+
+  "users": {
+    "_extends_": "F-105_Users"
+  },
+
+  "request": {
+    "headers": {
+      "Authorization": "Bearer ${[scenarioContext][testData][users][userOlawale][accessToken]}"
+    },
+    "body": {
+      "case_users": [
+        {
+          "case_id": "${[scenarioContext][childContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
+          "user_id": "${[scenarioContext][testData][users][userDil][id]}",
+          "case_role": "[CR-1]"
+        }
+      ]
+    }
+  },
+
+  "expectedResponse": {
+    "_extends_": "Common_403_Response",
+    "body": {
+      "exception": "uk.gov.hmcts.ccd.endpoint.exceptions.CaseRoleAccessException",
+      "message": "Client service not authorised to perform operation",
+      "details": null,
+      "callbackErrors": null,
+      "callbackWarnings": null
+    }
+  }
+}

--- a/src/aat/resources/features/F-105/S-105.6.td.json
+++ b/src/aat/resources/features/F-105/S-105.6.td.json
@@ -2,9 +2,6 @@
   "title": "Must return an error response when the request is made from an un-authorised application",
   "_guid_": "S-105.6",
   "_extends_": "F-105_Add_Case_Assigned_User_Roles_Base",
-  "productName": "CCD Data Store api",
-  "operationName": "Add Case-Assigned Users and Roles",
-  "s2sClientId": "ccd_gw",
 
   "specs": [
     "Richard - who can create a case",
@@ -12,6 +9,8 @@
     "Olawale - who is not a privileged user and is calling from an un-authorised application",
     "is made by Olawale with the Case ID of C1 & Dil's User ID and a proper Case Role CR-1"
   ],
+
+  "s2sClientId": "ccd_gw",
 
   "users": {
     "_extends_": "F-105_Users"

--- a/src/aat/resources/features/F-105/S-105.6.verify.td.json
+++ b/src/aat/resources/features/F-105/S-105.6.verify.td.json
@@ -1,0 +1,8 @@
+{
+  "_guid_": "S-105.6_Get_Case_Roles_for_Case_C1",
+  "_extends_": "F-105_Get_Case_Roles_for_Case_C1_Empty_Response_Base",
+
+  "specs": [
+    "to verify that Dil hasn't received the role CR-1 over the case C1"
+  ]
+}

--- a/src/aat/resources/features/F-105/S-105.7.td.json
+++ b/src/aat/resources/features/F-105/S-105.7.td.json
@@ -1,0 +1,47 @@
+{
+  "title": "Must return an error response for a malformed Case Role provided",
+  "_guid_": "S-105.7",
+  "_extends_": "F-105_Add_Case_Assigned_User_Roles_Base",
+  "productName": "CCD Data Store api",
+  "operationName": "Add Case-Assigned Users and Roles",
+  "s2sClientId": "aac_manage_case_assignment",
+
+  "specs": [
+    "Richard - who can create a case",
+    "Dil - who is to add some case role assignment for a case",
+    "Olawale - with an active solicitor profile and valid User ID",
+    "is made from an authorised application by Dil, for 2 assignments each containing the Case ID of C1 and User ID of Olawale",
+    "contains a proper Case Role CR-1 in one entry and an improper Case Role in the other"
+  ],
+
+  "users": {
+    "_extends_": "F-105_Users"
+  },
+
+  "request": {
+    "headers": {
+      "Authorization": "Bearer ${[scenarioContext][testData][users][userDil][accessToken]}"
+    },
+    "body": {
+      "case_users": [
+        {
+          "case_id": "${[scenarioContext][childContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
+          "user_id": "${[scenarioContext][testData][users][userOlawale][id]}",
+          "case_role": "[CR-1]"
+        },
+        {
+          "case_id": "${[scenarioContext][childContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
+          "user_id": "${[scenarioContext][testData][users][userOlawale][id]}",
+          "case_role": "bad-role"
+        }
+      ]
+    }
+  },
+
+  "expectedResponse": {
+    "_extends_": "F-105_Add_Case_Assigned_User_Roles_400_response",
+    "body": {
+      "message": "Invalid data provided for the following inputs to the request:\nCase role name format is invalid"
+    }
+  }
+}

--- a/src/aat/resources/features/F-105/S-105.7.td.json
+++ b/src/aat/resources/features/F-105/S-105.7.td.json
@@ -2,9 +2,6 @@
   "title": "Must return an error response for a malformed Case Role provided",
   "_guid_": "S-105.7",
   "_extends_": "F-105_Add_Case_Assigned_User_Roles_Base",
-  "productName": "CCD Data Store api",
-  "operationName": "Add Case-Assigned Users and Roles",
-  "s2sClientId": "aac_manage_case_assignment",
 
   "specs": [
     "Richard - who can create a case",

--- a/src/aat/resources/features/F-105/S-105.7.verify.td.json
+++ b/src/aat/resources/features/F-105/S-105.7.verify.td.json
@@ -1,0 +1,4 @@
+{
+  "_guid_": "S-105.7_Get_Case_Roles_for_Case_C1",
+  "_extends_": "F-105_Get_Case_Roles_for_Case_C1_Base"
+}

--- a/src/aat/resources/features/F-105/S-105.7.verify.td.json
+++ b/src/aat/resources/features/F-105/S-105.7.verify.td.json
@@ -1,4 +1,8 @@
 {
   "_guid_": "S-105.7_Get_Case_Roles_for_Case_C1",
-  "_extends_": "F-105_Get_Case_Roles_for_Case_C1_Base"
+  "_extends_": "F-105_Get_Case_Roles_for_Case_C1_Empty_Response_Base",
+
+  "specs": [
+    "to verify that Olawale hasn't received the role CR-1 over the case C1"
+  ]
 }

--- a/src/aat/resources/features/F-105/S-105.8.td.json
+++ b/src/aat/resources/features/F-105/S-105.8.td.json
@@ -2,9 +2,6 @@
   "title": "Must return an error response for a missing Case Role",
   "_guid_": "S-105.8",
   "_extends_": "F-105_Add_Case_Assigned_User_Roles_Base",
-  "productName": "CCD Data Store api",
-  "operationName": "Add Case-Assigned Users and Roles",
-  "s2sClientId": "aac_manage_case_assignment",
 
   "specs": [
     "Richard - who can create a case",

--- a/src/aat/resources/features/F-105/S-105.8.td.json
+++ b/src/aat/resources/features/F-105/S-105.8.td.json
@@ -1,0 +1,46 @@
+{
+  "title": "Must return an error response for a missing Case Role",
+  "_guid_": "S-105.8",
+  "_extends_": "F-105_Add_Case_Assigned_User_Roles_Base",
+  "productName": "CCD Data Store api",
+  "operationName": "Add Case-Assigned Users and Roles",
+  "s2sClientId": "aac_manage_case_assignment",
+
+  "specs": [
+    "Richard - who can create a case",
+    "Dil - who is to add some case role assignment for a case",
+    "Olawale - with an active solicitor profile and valid User ID",
+    "is made from an authorised application by Dil, for 2 assignments each containing the Case ID of C1 and User ID of Olawale",
+    "contains a proper Case Role CR-1 in one entry and no Case Role in the other"
+  ],
+
+  "users": {
+    "_extends_": "F-105_Users"
+  },
+
+  "request": {
+    "headers": {
+      "Authorization": "Bearer ${[scenarioContext][testData][users][userDil][accessToken]}"
+    },
+    "body": {
+      "case_users": [
+        {
+          "case_id": "${[scenarioContext][childContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
+          "user_id": "${[scenarioContext][testData][users][userOlawale][id]}",
+          "case_role": "[CR-1]"
+        },
+        {
+          "case_id": "${[scenarioContext][childContexts][F-105_Prerequisite_Case_Creation_Call_for_Case_Assignment][testData][actualResponse][body][id]}",
+          "user_id": "${[scenarioContext][testData][users][userOlawale][id]}"
+        }
+      ]
+    }
+  },
+
+  "expectedResponse": {
+    "_extends_": "F-105_Add_Case_Assigned_User_Roles_400_response",
+    "body": {
+      "message": "Invalid data provided for the following inputs to the request:\nCase role name format is invalid"
+    }
+  }
+}

--- a/src/aat/resources/features/F-105/S-105.8.verify.td.json
+++ b/src/aat/resources/features/F-105/S-105.8.verify.td.json
@@ -1,4 +1,8 @@
 {
   "_guid_": "S-105.8_Get_Case_Roles_for_Case_C1",
-  "_extends_": "F-105_Get_Case_Roles_for_Case_C1_Base"
+  "_extends_": "F-105_Get_Case_Roles_for_Case_C1_Empty_Response_Base",
+
+  "specs": [
+    "to verify that Olawale hasn't received the role CR-1 over the case C1"
+  ]
 }

--- a/src/aat/resources/features/F-105/S-105.8.verify.td.json
+++ b/src/aat/resources/features/F-105/S-105.8.verify.td.json
@@ -1,0 +1,4 @@
+{
+  "_guid_": "S-105.8_Get_Case_Roles_for_Case_C1",
+  "_extends_": "F-105_Get_Case_Roles_for_Case_C1_Base"
+}

--- a/src/aat/resources/features/F-105/S-105.9.td.json
+++ b/src/aat/resources/features/F-105/S-105.9.td.json
@@ -1,0 +1,35 @@
+{
+  "title": "Must return an error response for missing case_users list",
+  "_guid_": "S-105.9",
+  "_extends_": "F-105_Add_Case_Assigned_User_Roles_Base",
+  "productName": "CCD Data Store api",
+  "operationName": "Add Case-Assigned Users and Roles",
+  "s2sClientId": "aac_manage_case_assignment",
+
+  "specs": [
+    "Dil - who is to add some case role assignment for a case",
+    "is made from an authorised application by Dil, with no case_users supplied"
+  ],
+
+  "users": {
+    "userDil": {
+      "username": "befta.caseworker.2.solicitor.2@gmail.com",
+      "password": "[[$CCD_BEFTA_CASEWORKER_2_SOLICITOR_2_PWD]]"
+    }
+  },
+
+  "request": {
+    "headers": {
+      "Authorization": "Bearer ${[scenarioContext][testData][users][userDil][accessToken]}"
+    },
+    "body": {
+    }
+  },
+
+  "expectedResponse": {
+    "_extends_": "F-105_Add_Case_Assigned_User_Roles_400_response",
+    "body": {
+      "message": "Invalid data provided for the following inputs to the request:\nCase user roles list is empty"
+    }
+  }
+}

--- a/src/aat/resources/features/F-105/S-105.9.td.json
+++ b/src/aat/resources/features/F-105/S-105.9.td.json
@@ -2,9 +2,6 @@
   "title": "Must return an error response for missing case_users list",
   "_guid_": "S-105.9",
   "_extends_": "F-105_Add_Case_Assigned_User_Roles_Base",
-  "productName": "CCD Data Store api",
-  "operationName": "Add Case-Assigned Users and Roles",
-  "s2sClientId": "aac_manage_case_assignment",
 
   "specs": [
     "Dil - who is to add some case role assignment for a case",

--- a/src/main/java/uk/gov/hmcts/ccd/v2/external/controller/CaseAssignedUserRolesController.java
+++ b/src/main/java/uk/gov/hmcts/ccd/v2/external/controller/CaseAssignedUserRolesController.java
@@ -16,6 +16,7 @@ import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -72,7 +73,7 @@ public class CaseAssignedUserRolesController {
     )
     @ApiResponses({
         @ApiResponse(
-            code = 200,
+            code = 201,
             message = ADD_SUCCESS_MESSAGE,
             response = AddCaseAssignedUserRolesResponse.class
         ),
@@ -115,7 +116,7 @@ public class CaseAssignedUserRolesController {
         if (applicationParams.getAuthorisedServicesForAddUserCaseRoles().contains(clientServiceName)) {
             validateRequestParams(caseAssignedUserRoles);
             this.caseAssignedUserRolesOperation.addCaseUserRoles(caseAssignedUserRoles.getCaseAssignedUserRoles());
-            return ResponseEntity.ok(new AddCaseAssignedUserRolesResponse(ADD_SUCCESS_MESSAGE));
+            return ResponseEntity.status(HttpStatus.CREATED).body(new AddCaseAssignedUserRolesResponse(ADD_SUCCESS_MESSAGE));
         } else {
             throw new CaseRoleAccessException(V2.Error.CLIENT_SERVICE_NOT_AUTHORISED_FOR_OPERATION);
         }

--- a/src/test/java/uk/gov/hmcts/ccd/v2/external/controller/CaseAssignedUserRolesControllerIT.java
+++ b/src/test/java/uk/gov/hmcts/ccd/v2/external/controller/CaseAssignedUserRolesControllerIT.java
@@ -178,11 +178,11 @@ class CaseAssignedUserRolesControllerIT extends WireMockBaseTest {
             .contentType(JSON_CONTENT_TYPE)
             .content(mapper.writeValueAsBytes(new CaseAssignedUserRolesResource(caseUserRoles)))
             .headers(createHttpHeaders()))
-            .andExpect(status().isOk())
+            .andExpect(status().isCreated())
             .andReturn();
 
         // ASSERT
-        assertEquals(result.getResponse().getContentAsString(), 200, result.getResponse().getStatus());
+        assertEquals(result.getResponse().getContentAsString(), 201, result.getResponse().getStatus());
         String content = result.getResponse().getContentAsString();
         assertNotNull("Content Should not be null", content);
         AddCaseAssignedUserRolesResponse response = mapper.readValue(content, AddCaseAssignedUserRolesResponse.class);
@@ -194,7 +194,7 @@ class CaseAssignedUserRolesControllerIT extends WireMockBaseTest {
         assertEquals(1, caseRoles.size());
         assertThat(caseRoles, hasItems(CASE_ROLE_1));
 
-        verifyAuditForAddCaseUserRoles(HttpStatus.OK, caseUserRoles);
+        verifyAuditForAddCaseUserRoles(HttpStatus.CREATED, caseUserRoles);
     }
 
     // RDM-8606: AC-2
@@ -527,11 +527,11 @@ class CaseAssignedUserRolesControllerIT extends WireMockBaseTest {
             .contentType(JSON_CONTENT_TYPE)
             .content(mapper.writeValueAsBytes(new CaseAssignedUserRolesResource(caseUserRoles)))
             .headers(createHttpHeaders()))
-            .andExpect(status().isOk())
+            .andExpect(status().isCreated())
             .andReturn();
 
         // ASSERT
-        assertEquals(result.getResponse().getContentAsString(), 200, result.getResponse().getStatus());
+        assertEquals(result.getResponse().getContentAsString(), 201, result.getResponse().getStatus());
         String content = result.getResponse().getContentAsString();
         assertNotNull("Content Should not be null", content);
         AddCaseAssignedUserRolesResponse response = mapper.readValue(content, AddCaseAssignedUserRolesResponse.class);
@@ -543,7 +543,7 @@ class CaseAssignedUserRolesControllerIT extends WireMockBaseTest {
         assertEquals(1, caseRoles.size());
         assertThat(caseRoles, hasItems(CASE_ROLE_1));
 
-        verifyAuditForAddCaseUserRoles(HttpStatus.OK, caseUserRoles);
+        verifyAuditForAddCaseUserRoles(HttpStatus.CREATED, caseUserRoles);
     }
 
     // RDM-8606: multiple
@@ -572,11 +572,11 @@ class CaseAssignedUserRolesControllerIT extends WireMockBaseTest {
             .contentType(JSON_CONTENT_TYPE)
             .content(mapper.writeValueAsBytes(new CaseAssignedUserRolesResource(caseUserRoles)))
             .headers(httpHeaders))
-            .andExpect(status().isOk())
+            .andExpect(status().isCreated())
             .andReturn();
 
         // ASSERT
-        assertEquals(result.getResponse().getContentAsString(), 200, result.getResponse().getStatus());
+        assertEquals(result.getResponse().getContentAsString(), 201, result.getResponse().getStatus());
         String content = result.getResponse().getContentAsString();
         assertNotNull("Content Should not be null", content);
         AddCaseAssignedUserRolesResponse response = mapper.readValue(content, AddCaseAssignedUserRolesResponse.class);
@@ -589,7 +589,7 @@ class CaseAssignedUserRolesControllerIT extends WireMockBaseTest {
         assertThat(caseRoles, hasItems(CASE_ROLE_1));
         assertThat(caseRoles, hasItems(CASE_ROLE_2));
 
-        verifyAuditForAddCaseUserRoles(HttpStatus.OK, caseUserRoles);
+        verifyAuditForAddCaseUserRoles(HttpStatus.CREATED, caseUserRoles);
     }
 
     // AC-1

--- a/src/test/java/uk/gov/hmcts/ccd/v2/external/controller/CaseAssignedUserRolesControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/v2/external/controller/CaseAssignedUserRolesControllerTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import uk.gov.hmcts.ccd.ApplicationParams;
 import uk.gov.hmcts.ccd.data.SecurityUtils;
@@ -110,6 +111,7 @@ class CaseAssignedUserRolesControllerTest {
 
             // ASSERT
             assertNotNull(response);
+            assertEquals(HttpStatus.CREATED, response.getStatusCode());
             assertNotNull(response.getBody());
             assertEquals(ADD_SUCCESS_MESSAGE, response.getBody().getStatus());
             verify(caseAssignedUserRolesOperation, times(1)).addCaseUserRoles(caseUserRoles);
@@ -132,6 +134,7 @@ class CaseAssignedUserRolesControllerTest {
 
             // ASSERT
             assertNotNull(response);
+            assertEquals(HttpStatus.CREATED, response.getStatusCode());
             assertNotNull(response.getBody());
             assertEquals(ADD_SUCCESS_MESSAGE, response.getBody().getStatus());
             verify(caseAssignedUserRolesOperation, times(1)).addCaseUserRoles(caseUserRoles);


### PR DESCRIPTION
### JIRA link (if applicable) ###

   [RDM-8606](https://tools.hmcts.net/jira/browse/RDM-8606) Implement 'Add Case-Assigned User and Role'
   [RDM-8806](https://tools.hmcts.net/jira/browse/RDM-8806) FTA for 'Add Case-Assigned User and Role'

### Change description ###

FTA for 'Add Case-Assigned User and Role' (Dev ticket is [RDM-8606](https://tools.hmcts.net/jira/browse/RDM-8606) with PR #987).

Requires `ccd-docker` config change, see hmcts/ccd-docker#95.

LLD: [API Operation: Add Case-Assigned Users and Roles](https://tools.hmcts.net/confluence/display/RCCD/API+Operation%3A+Add+Case-Assigned+Users+and+Roles)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
