### PR TITLE
RDM-4449 - Moved the converters to RestTemplate...

### DIFF
--- a/charts/ccd-data-store-api/values.preview.template.yaml
+++ b/charts/ccd-data-store-api/values.preview.template.yaml
@@ -18,7 +18,7 @@ java:
     DATA_STORE_DB_PASSWORD: "{{ .Values.postgresql.postgresqlPassword}}"
     DATA_STORE_DB_OPTIONS: "?stringtype=unspecified"
     DATA_STORE_DB_MAX_POOL_SIZE: 10
-    DEFINITION_STORE_HOST: http://ccd-definition-store-api-pr-621.service.core-compute-preview.internal/
+    DEFINITION_STORE_HOST: http://ccd-definition-store-api-pr-575.service.core-compute-preview.internal/
 #    USER_PROFILE_HOST: http://ccd-user-profile-api-pr-224.service.core-compute-preview.internal/
 
     ENABLE_DB_MIGRATE: true

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -229,4 +229,18 @@
    <packageUrl regex="true">^pkg:maven/org\.dom4j/dom4j@.*$</packageUrl>
    <cve>CVE-2020-10683</cve>
 </suppress>
+    <suppress>
+   <notes><![CDATA[
+   file name: tomcat-embed-websocket-9.0.35.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat-embed-websocket@.*$</packageUrl>
+   <cve>CVE-2020-11996</cve>
+</suppress>
+    <suppress>
+   <notes><![CDATA[
+   file name: tomcat-embed-core-9.0.35.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat-embed-core@.*$</packageUrl>
+   <cve>CVE-2020-11996</cve>
+</suppress>
 </suppressions>

--- a/src/main/java/uk/gov/hmcts/ccd/RestTemplateConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/ccd/RestTemplateConfiguration.java
@@ -9,10 +9,16 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
 
 import javax.annotation.PreDestroy;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @Configuration
@@ -53,6 +59,27 @@ class RestTemplateConfiguration {
         requestFactory.setReadTimeout(readTimeout);
         LOG.info("readTimeout: {}", readTimeout);
         restTemplate.setRequestFactory(requestFactory);
+        return restTemplate;
+    }
+
+    @Bean(name = "documentRestTemplate")
+    public RestTemplate documentRestTemplate() {
+
+        final RestTemplate restTemplate = new RestTemplate();
+        HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory(getHttpClient());
+        requestFactory.setReadTimeout(readTimeout);
+        LOG.info("readTimeout: {}", readTimeout);
+        restTemplate.setRequestFactory(requestFactory);
+
+        List<HttpMessageConverter<?>> messageConverters = new ArrayList<>();
+        //Add the Jackson Message converter
+        MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter();
+        // Note: here we are making this converter to process any kind of response,
+        // not only application/*json, which is the default behaviour
+        converter.setSupportedMediaTypes(Collections.singletonList(MediaType.ALL));
+        messageConverters.add(converter);
+        restTemplate.setMessageConverters(messageConverters);
+
         return restTemplate;
     }
 

--- a/src/main/java/uk/gov/hmcts/ccd/domain/types/sanitiser/client/DocumentManagementRestClient.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/types/sanitiser/client/DocumentManagementRestClient.java
@@ -8,19 +8,14 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
-import org.springframework.http.converter.HttpMessageConverter;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.hmcts.ccd.data.SecurityUtils;
 import uk.gov.hmcts.ccd.domain.model.definition.FieldTypeDefinition;
 import uk.gov.hmcts.ccd.domain.types.sanitiser.document.Document;
-import uk.gov.hmcts.ccd.endpoint.exceptions.ApiException;
+import uk.gov.hmcts.ccd.endpoint.exceptions.ServiceException;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 @Named
 @Singleton
@@ -29,7 +24,7 @@ public class DocumentManagementRestClient {
     private static final Logger LOG = LoggerFactory.getLogger(DocumentManagementRestClient.class);
 
     private final SecurityUtils securityUtils;
-    @Qualifier("restTemplate")
+    @Qualifier("documentRestTemplate")
     @Autowired
     private final RestTemplate restTemplate;
 
@@ -44,17 +39,6 @@ public class DocumentManagementRestClient {
         headers.setContentType(MediaType.APPLICATION_JSON);
         final HttpEntity requestEntity = new HttpEntity(headers);
 
-        // Need to ignore the response Content Type header from Document Management because it is not the expected type
-        // of "application/json". See https://stackoverflow.com/a/44219832 for the same solution to a similar problem.
-        List<HttpMessageConverter<?>> messageConverters = new ArrayList<>();
-        //Add the Jackson Message converter
-        MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter();
-        // Note: here we are making this converter to process any kind of response,
-        // not only application/*json, which is the default behaviour
-        converter.setSupportedMediaTypes(Collections.singletonList(MediaType.ALL));
-        messageConverters.add(converter);
-        restTemplate.setMessageConverters(messageConverters);
-
         Document document = null;
         try {
             LOG.info("Requesting from Document management: {}", url);
@@ -63,7 +47,7 @@ public class DocumentManagementRestClient {
         } catch (Exception e) {
             LOG.error("Cannot sanitize document for the Case Field Type:{}, Case Field Type Id:{} because of unreachable url",
                 fieldTypeDefinition.getType(), fieldTypeDefinition.getId(), e);
-            throw new ApiException(String.format("Cannot sanitize document for the Case Field Type:%s, Case Field Type Id:%s because of %s",
+            throw new ServiceException(String.format("Cannot sanitize document for the Case Field Type:%s, Case Field Type Id:%s because of %s",
                 fieldTypeDefinition.getType(), fieldTypeDefinition.getId(), e));
         }
 

--- a/src/main/java/uk/gov/hmcts/ccd/domain/types/sanitiser/client/DocumentManagementRestClient.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/types/sanitiser/client/DocumentManagementRestClient.java
@@ -12,7 +12,7 @@ import org.springframework.web.client.RestTemplate;
 import uk.gov.hmcts.ccd.data.SecurityUtils;
 import uk.gov.hmcts.ccd.domain.model.definition.FieldTypeDefinition;
 import uk.gov.hmcts.ccd.domain.types.sanitiser.document.Document;
-import uk.gov.hmcts.ccd.endpoint.exceptions.ServiceException;
+import uk.gov.hmcts.ccd.endpoint.exceptions.ApiException;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -47,7 +47,7 @@ public class DocumentManagementRestClient {
         } catch (Exception e) {
             LOG.error("Cannot sanitize document for the Case Field Type:{}, Case Field Type Id:{} because of unreachable url",
                 fieldTypeDefinition.getType(), fieldTypeDefinition.getId(), e);
-            throw new ServiceException(String.format("Cannot sanitize document for the Case Field Type:%s, Case Field Type Id:%s because of %s",
+            throw new ApiException(String.format("Cannot sanitize document for the Case Field Type:%s, Case Field Type Id:%s because of %s",
                 fieldTypeDefinition.getType(), fieldTypeDefinition.getId(), e));
         }
 

--- a/src/test/java/uk/gov/hmcts/ccd/RestTemplateConfigurationTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/RestTemplateConfigurationTest.java
@@ -31,25 +31,7 @@ import static wiremock.org.apache.http.entity.ContentType.APPLICATION_JSON;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
-import org.springframework.http.RequestEntity;
-import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.web.client.ResourceAccessException;
-import org.springframework.web.client.RestTemplate;
 
-@ActiveProfiles("test")
-@RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = RANDOM_PORT)
 @TestPropertySource(properties = {"http.client.connection.timeout=1500",
     "http.client.max.total=1",
     "http.client.read.timeout=1500",
@@ -60,9 +42,6 @@ public class RestTemplateConfigurationTest extends WireMockBaseTest {
 
     @Autowired
     private RestTemplate restTemplate;
-
-    @Value("${wiremock.server.port}")
-    protected Integer wiremockPort;
 
     private static final String RESPONSE_BODY = "{ \"test\": \"name\"}";
     private static final String URL = "/ng/itb";

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/processor/DateTimeEntryProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/processor/DateTimeEntryProcessorTest.java
@@ -272,7 +272,7 @@ class DateTimeEntryProcessorTest {
     }
 
     private FieldTypeDefinition fieldType(String fieldType) {
-        return fieldType("DateTime", "DateTime", Collections.emptyList(), null);
+        return fieldType(fieldType, fieldType, Collections.emptyList(), null);
     }
 
     private void setUpBaseTypes() {

--- a/src/test/java/uk/gov/hmcts/ccd/domain/types/sanitiser/client/DocumentManagementRestClientTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/types/sanitiser/client/DocumentManagementRestClientTest.java
@@ -25,7 +25,7 @@ import uk.gov.hmcts.ccd.domain.model.definition.FieldTypeDefinition;
 import uk.gov.hmcts.ccd.domain.types.sanitiser.document.Binary;
 import uk.gov.hmcts.ccd.domain.types.sanitiser.document.Document;
 import uk.gov.hmcts.ccd.domain.types.sanitiser.document._links;
-import uk.gov.hmcts.ccd.endpoint.exceptions.ServiceException;
+import uk.gov.hmcts.ccd.endpoint.exceptions.ApiException;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -127,7 +127,7 @@ public class DocumentManagementRestClientTest extends StubServerDependent {
                 withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE));
     }
 
-    @Test(expected = ServiceException.class)
+    @Test(expected = ApiException.class)
     @NeedsServer
     public void shouldFailToSanitizeIfUnauthorized() throws Exception {
 
@@ -142,7 +142,7 @@ public class DocumentManagementRestClientTest extends StubServerDependent {
 
     }
 
-    @Test(expected = ServiceException.class)
+    @Test(expected = ApiException.class)
     @NeedsServer
     public void shouldFailToSanitizeIfServiceUnavailable() throws Exception {
 
@@ -159,7 +159,7 @@ public class DocumentManagementRestClientTest extends StubServerDependent {
         subject.getDocument(DOCUMENT_FIELD_TYPE, formatURL(DOCUMENT_URL));
     }
 
-    @Test(expected = ServiceException.class)
+    @Test(expected = ApiException.class)
     @NeedsServer
     public void shouldFailToSanitizeIfBadGateway() throws Exception {
 
@@ -176,7 +176,7 @@ public class DocumentManagementRestClientTest extends StubServerDependent {
         subject.getDocument(DOCUMENT_FIELD_TYPE, formatURL(DOCUMENT_URL));
     }
 
-    @Test(expected = ServiceException.class)
+    @Test(expected = ApiException.class)
     @NeedsServer
     public void shouldFailToSanitizeIfInternalServerError() throws Exception {
 

--- a/src/test/java/uk/gov/hmcts/ccd/domain/types/sanitiser/client/DocumentManagementRestClientTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/types/sanitiser/client/DocumentManagementRestClientTest.java
@@ -15,6 +15,8 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.hmcts.ccd.data.SecurityUtils;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseFieldDefinition;
@@ -23,9 +25,11 @@ import uk.gov.hmcts.ccd.domain.model.definition.FieldTypeDefinition;
 import uk.gov.hmcts.ccd.domain.types.sanitiser.document.Binary;
 import uk.gov.hmcts.ccd.domain.types.sanitiser.document.Document;
 import uk.gov.hmcts.ccd.domain.types.sanitiser.document._links;
-import uk.gov.hmcts.ccd.endpoint.exceptions.ApiException;
+import uk.gov.hmcts.ccd.endpoint.exceptions.ServiceException;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 import static com.xebialabs.restito.builder.stub.StubHttp.whenHttp;
 import static com.xebialabs.restito.builder.verify.VerifyHttp.verifyHttp;
@@ -91,6 +95,11 @@ public class DocumentManagementRestClientTest extends StubServerDependent {
         document.set_links(links);
         document.setOriginalDocumentName(FILENAME);
         subject = new DocumentManagementRestClient(securityUtils, restTemplate);
+        List<HttpMessageConverter<?>> messageConverters = new ArrayList<>();
+        MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter();
+        converter.setSupportedMediaTypes(Collections.singletonList(MediaType.ALL));
+        messageConverters.add(converter);
+        restTemplate.setMessageConverters(messageConverters);
     }
 
     @Test
@@ -118,7 +127,7 @@ public class DocumentManagementRestClientTest extends StubServerDependent {
                 withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE));
     }
 
-    @Test(expected = ApiException.class)
+    @Test(expected = ServiceException.class)
     @NeedsServer
     public void shouldFailToSanitizeIfUnauthorized() throws Exception {
 
@@ -133,7 +142,7 @@ public class DocumentManagementRestClientTest extends StubServerDependent {
 
     }
 
-    @Test(expected = ApiException.class)
+    @Test(expected = ServiceException.class)
     @NeedsServer
     public void shouldFailToSanitizeIfServiceUnavailable() throws Exception {
 
@@ -150,7 +159,7 @@ public class DocumentManagementRestClientTest extends StubServerDependent {
         subject.getDocument(DOCUMENT_FIELD_TYPE, formatURL(DOCUMENT_URL));
     }
 
-    @Test(expected = ApiException.class)
+    @Test(expected = ServiceException.class)
     @NeedsServer
     public void shouldFailToSanitizeIfBadGateway() throws Exception {
 
@@ -167,7 +176,7 @@ public class DocumentManagementRestClientTest extends StubServerDependent {
         subject.getDocument(DOCUMENT_FIELD_TYPE, formatURL(DOCUMENT_URL));
     }
 
-    @Test(expected = ApiException.class)
+    @Test(expected = ServiceException.class)
     @NeedsServer
     public void shouldFailToSanitizeIfInternalServerError() throws Exception {
 


### PR DESCRIPTION
…plateConfiguration into a new method documentRestTemplate specify to use the converters only for documents. Changed the exception to 500 instead of 422 in DocumentManagementRestClient

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
