### PR TITLE
19.1.1 release hot fix - temporarily removing 'case_type_results'

### DIFF
--- a/src/main/java/uk/gov/hmcts/ccd/domain/model/search/CaseSearchResult.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/model/search/CaseSearchResult.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.ccd.domain.model.search;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseDetails;
 
@@ -14,6 +15,7 @@ public class CaseSearchResult {
 
     private Long total;
     private List<CaseDetails> cases;
+    @JsonIgnore
     @JsonProperty("case_types_results")
     private List<CaseTypeResults> caseTypesResults;
 


### PR DESCRIPTION
temporarily excluding new property 'case_types_results' from serialisation to fix broken client 'core-case-data-store-client' library who is not expecting that property:
```
Request processing failed; nested exception is feign.FeignException: Unrecognized field "case_types_results" (class uk.gov.hmcts.reform.ccd.client.model.SearchResult), not marked as ignorable (2 known properties: "cases", "total"])
 at [Source: (BufferedReader); line: 1, column: 42617] (through reference chain: uk.gov.hmcts.reform.ccd.client.model.SearchResult["case_types_results"]) reading POST http://ccd-data-store-api-prod.service.core-compute-prod.internal/searchCases?ctid=GrantOfRepresentation Unrecognized field "case_types_results" (class uk.gov.hmcts.reform.ccd.client.model.SearchResult), not marked as ignorable (2 known properties: "cases", "total"])
 at [Source: (BufferedReader); line: 1, column: 42617] (through reference chain: uk.gov.hmcts.reform.ccd.client.model.SearchResult["case_types_results"]) reading POST http://ccd-data-store-api-prod.service.core-compute-prod.internal/searchCases?ctid=GrantOfRepresentation Unrecognized field "case_types_results" (class uk.gov.hmcts.reform.ccd.client.model.SearchResult), not marked as ignorable (2 known properties: "cases", "total"])
 at [Source: (BufferedReader); line: 1, column: 42617] (through reference chain: uk.gov.hmcts.reform.ccd.client.model.SearchResult["case_types_results"])
```