### PR TITLE
RDM-10616: Bump befta-fw version to 6.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -232,7 +232,7 @@ dependencies {
     }
     compile 'org.jooq:jool-java-8:0.9.14'
 
-    testCompile group: 'uk.gov.hmcts', name: 'befta-fw', version: '6.2.0'
+    testCompile group: 'uk.gov.hmcts', name: 'befta-fw', version: '6.3.0'
 }
 // end::dependencies[]
 


### PR DESCRIPTION
### JIRA link  ###

https://tools.hmcts.net/jira/browse/RDM-10616

### Change description ###

Bumped befta-fw version to 6.3.0

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
