### PR TITLE
RDM-10705 - Point to 6.5.3 befta-fw version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -233,7 +233,7 @@ dependencies {
     }
     compile 'org.jooq:jool-java-8:0.9.14'
 
-    testCompile group: 'uk.gov.hmcts', name: 'befta-fw', version: '6.5.3-RDM-10705'
+    testCompile group: 'uk.gov.hmcts', name: 'befta-fw', version: '6.5.3'
 }
 // end::dependencies[]
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

   [RDM-10705](https://tools.hmcts.net/jira/browse/RDM-10705) _"Data-store FTA 403 failures when running against a local ccd-docker environment"_

### Change description ###

Point to new release version of befta-fw.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
