### PR TITLE
RDM-11005: Refactor query so we do not fetch whole CaseDetails object

### DIFF
--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CachedCaseDetailsRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CachedCaseDetailsRepository.java
@@ -59,8 +59,8 @@ public class CachedCaseDetailsRepository implements CaseDetailsRepository {
     }
 
     @Override
-    public Long findCaseDetailsReferenceById(final Long id) {
-        return ofNullable(caseDetailsRepository.findCaseDetailsReferenceById(id)).orElse(null);
+    public List<Long> findCaseDetailsReferencesByIds(final List<Long> ids) {
+        return caseDetailsRepository.findCaseDetailsReferencesByIds(ids);
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CachedCaseDetailsRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CachedCaseDetailsRepository.java
@@ -59,8 +59,8 @@ public class CachedCaseDetailsRepository implements CaseDetailsRepository {
     }
 
     @Override
-    public List<Long> findCaseDetailsReferencesByIds(final List<Long> ids) {
-        return caseDetailsRepository.findCaseDetailsReferencesByIds(ids);
+    public List<Long> findCaseReferencesByIds(final List<Long> ids) {
+        return caseDetailsRepository.findCaseReferencesByIds(ids);
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CachedCaseDetailsRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CachedCaseDetailsRepository.java
@@ -59,6 +59,11 @@ public class CachedCaseDetailsRepository implements CaseDetailsRepository {
     }
 
     @Override
+    public Long findCaseDetailsReferenceById(final Long id) {
+        return ofNullable(caseDetailsRepository.findCaseDetailsReferenceById(id)).orElse(null);
+    }
+
+    @Override
     public CaseDetails findByReference(final Long caseReference) {
         final Function<String, Optional<CaseDetails>> findFunction = key ->
             ofNullable(caseDetailsRepository.findByReference(caseReference));

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CaseDetailsRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CaseDetailsRepository.java
@@ -23,7 +23,7 @@ public interface CaseDetailsRepository {
     @Deprecated
     CaseDetails findById(Long id);
 
-    Long findCaseDetailsReferenceById(Long id);
+    List<Long> findCaseDetailsReferencesByIds(List<Long> ids);
 
     Optional<CaseDetails> findByReferenceWithNoAccessControl(String reference);
 

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CaseDetailsRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CaseDetailsRepository.java
@@ -23,7 +23,7 @@ public interface CaseDetailsRepository {
     @Deprecated
     CaseDetails findById(Long id);
 
-    List<Long> findCaseDetailsReferencesByIds(List<Long> ids);
+    List<Long> findCaseReferencesByIds(List<Long> ids);
 
     Optional<CaseDetails> findByReferenceWithNoAccessControl(String reference);
 

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CaseDetailsRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/CaseDetailsRepository.java
@@ -23,6 +23,8 @@ public interface CaseDetailsRepository {
     @Deprecated
     CaseDetails findById(Long id);
 
+    Long findCaseDetailsReferenceById(Long id);
+
     Optional<CaseDetails> findByReferenceWithNoAccessControl(String reference);
 
     Optional<CaseDetails> findByReference(String jurisdiction, Long caseReference);

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/DefaultCaseDetailsRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/DefaultCaseDetailsRepository.java
@@ -106,8 +106,8 @@ public class DefaultCaseDetailsRepository implements CaseDetailsRepository {
     }
 
     @Override
-    public List<Long> findCaseDetailsReferencesByIds(final List<Long> ids) {
-        return findReferenceById(ids);
+    public List<Long> findCaseReferencesByIds(final List<Long> ids) {
+        return findReferencesByIds(ids);
     }
 
     @Override
@@ -183,9 +183,9 @@ public class DefaultCaseDetailsRepository implements CaseDetailsRepository {
         return getCaseDetailsEntity(id, reference, qb);
     }
 
-    private List<Long> findReferenceById(List<Long> ids) {
+    private List<Long> findReferencesByIds(List<Long> ids) {
         final CaseDetailsQueryBuilder<Long> qb = queryBuilderFactory.selectByReferenceSecured(em);
-        qb.whereIds(ids);
+        qb.whereIdsAreIn(ids);
 
         return qb.build().getResultList();
     }

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/DefaultCaseDetailsRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/DefaultCaseDetailsRepository.java
@@ -106,6 +106,11 @@ public class DefaultCaseDetailsRepository implements CaseDetailsRepository {
     }
 
     @Override
+    public Long findCaseDetailsReferenceById(final Long id) {
+        return findReferenceById(id).orElse(null);
+    }
+
+    @Override
     public Optional<CaseDetails> findByReference(String jurisdiction, Long caseReference) {
         return findByReference(jurisdiction, caseReference.toString());
     }
@@ -176,6 +181,13 @@ public class DefaultCaseDetailsRepository implements CaseDetailsRepository {
         }
 
         return getCaseDetailsEntity(id, reference, qb);
+    }
+
+    private Optional<Long> findReferenceById(Long id) {
+        final CaseDetailsQueryBuilder<Long> qb = queryBuilderFactory.selectByReferenceSecured(em);
+        qb.whereId(id);
+
+        return qb.getSingleResult();
     }
 
     /**

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/DefaultCaseDetailsRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/DefaultCaseDetailsRepository.java
@@ -106,8 +106,8 @@ public class DefaultCaseDetailsRepository implements CaseDetailsRepository {
     }
 
     @Override
-    public Long findCaseDetailsReferenceById(final Long id) {
-        return findReferenceById(id).orElse(null);
+    public List<Long> findCaseDetailsReferencesByIds(final List<Long> ids) {
+        return findReferenceById(ids);
     }
 
     @Override
@@ -183,11 +183,11 @@ public class DefaultCaseDetailsRepository implements CaseDetailsRepository {
         return getCaseDetailsEntity(id, reference, qb);
     }
 
-    private Optional<Long> findReferenceById(Long id) {
+    private List<Long> findReferenceById(List<Long> ids) {
         final CaseDetailsQueryBuilder<Long> qb = queryBuilderFactory.selectByReferenceSecured(em);
-        qb.whereId(id);
+        qb.whereIds(ids);
 
-        return qb.getSingleResult();
+        return qb.build().getResultList();
     }
 
     /**

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/query/CaseDetailsQueryBuilder.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/query/CaseDetailsQueryBuilder.java
@@ -70,10 +70,9 @@ public abstract class CaseDetailsQueryBuilder<T> {
         return this;
     }
 
-    public CaseDetailsQueryBuilder whereIds(List<Long> ids) {
-        if (CollectionUtils.isNotEmpty(ids)) {
-            predicates.add(cb.in(root.get("id")).value(ids));
-        }
+    public CaseDetailsQueryBuilder whereIdsAreIn(List<Long> ids) {
+        predicates.add(cb.in(root.get("id")).value(ids));
+
         return this;
     }
 

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/query/CaseDetailsQueryBuilder.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/query/CaseDetailsQueryBuilder.java
@@ -72,7 +72,7 @@ public abstract class CaseDetailsQueryBuilder<T> {
 
     public CaseDetailsQueryBuilder whereIds(List<Long> ids) {
         if (CollectionUtils.isNotEmpty(ids)) {
-            predicates.add(cb.in(root.get("reference")).value(ids));
+            predicates.add(cb.in(root.get("id")).value(ids));
         }
         return this;
     }

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/query/CaseDetailsQueryBuilder.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/query/CaseDetailsQueryBuilder.java
@@ -70,6 +70,13 @@ public abstract class CaseDetailsQueryBuilder<T> {
         return this;
     }
 
+    public CaseDetailsQueryBuilder whereIds(List<Long> ids) {
+        if (CollectionUtils.isNotEmpty(ids)) {
+            predicates.add(cb.in(root.get("reference")).value(ids));
+        }
+        return this;
+    }
+
     public CaseDetailsQueryBuilder whereCaseType(String caseType) {
         predicates.add(cb.equal(root.get("caseType"), caseType));
 

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/query/CaseDetailsQueryBuilderFactory.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/query/CaseDetailsQueryBuilderFactory.java
@@ -30,6 +30,14 @@ public class CaseDetailsQueryBuilderFactory {
         return selectSecured(em, null);
     }
 
+    public CaseDetailsQueryBuilder<Long> selectByReferenceSecured(EntityManager em, MetaData metaData) {
+        return secure(new SelectCaseDetailsReferenceQueryBuilder(em), metaData);
+    }
+
+    public CaseDetailsQueryBuilder<Long> selectByReferenceSecured(EntityManager em) {
+        return selectByReferenceSecured(em, null);
+    }
+
     public CaseDetailsQueryBuilder<Long> count(EntityManager em, MetaData metaData) {
         return secure(new CountCaseDetailsQueryBuilder(em), metaData);
     }

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/query/SelectCaseDetailsReferenceQueryBuilder.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/query/SelectCaseDetailsReferenceQueryBuilder.java
@@ -1,0 +1,25 @@
+package uk.gov.hmcts.ccd.data.casedetails.query;
+
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Predicate;
+
+public class SelectCaseDetailsReferenceQueryBuilder extends CaseDetailsQueryBuilder<Long> {
+
+    SelectCaseDetailsReferenceQueryBuilder(EntityManager em) {
+        super(em);
+    }
+
+    @Override
+    public TypedQuery<Long> build() {
+        return em.createQuery(query.select(root.get("reference"))
+            .orderBy(orders)
+            .where(predicates.toArray(new Predicate[]{})));
+    }
+
+    @Override
+    protected CriteriaQuery<Long> createQuery() {
+        return cb.createQuery(Long.class);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/caseaccess/CaseAccessOperation.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/caseaccess/CaseAccessOperation.java
@@ -73,11 +73,16 @@ public class CaseAccessOperation {
     }
 
     public List<String> findCasesUserIdHasAccessTo(final String userId) {
-        return caseDetailsRepository
-            .findCaseDetailsReferencesByIds(caseUserRepository.findCasesUserIdHasAccessTo(userId))
-            .stream()
-            .map(String::valueOf)
-            .collect(Collectors.toList());
+        List<Long> usersCases = caseUserRepository.findCasesUserIdHasAccessTo(userId);
+        if (usersCases.size() == 0) {
+            return List.of();
+        } else {
+            return caseDetailsRepository
+                .findCaseReferencesByIds(usersCases)
+                .stream()
+                .map(String::valueOf)
+                .collect(Collectors.toList());
+        }
     }
 
     @Transactional

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/caseaccess/CaseAccessOperation.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/caseaccess/CaseAccessOperation.java
@@ -75,7 +75,7 @@ public class CaseAccessOperation {
     public List<String> findCasesUserIdHasAccessTo(final String userId) {
         return caseUserRepository.findCasesUserIdHasAccessTo(userId)
             .stream()
-            .map(databaseId -> caseDetailsRepository.findById(databaseId).getReference() + "")
+            .map(databaseId -> String.valueOf(caseDetailsRepository.findCaseDetailsReferenceById(databaseId)))
             .collect(Collectors.toList());
     }
 
@@ -87,7 +87,7 @@ public class CaseAccessOperation {
 
         validateCaseRoles(Sets.union(globalCaseRoles, validCaseRoles), targetCaseRoles);
 
-        final Long caseId = new Long(caseDetails.getId());
+        final Long caseId = Long.valueOf(caseDetails.getId());
         final String userId = caseUser.getUserId();
         final List<String> currentCaseRoles = caseUserRepository.findCaseRoles(caseId, userId);
 

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/caseaccess/CaseAccessOperation.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/caseaccess/CaseAccessOperation.java
@@ -74,7 +74,7 @@ public class CaseAccessOperation {
 
     public List<String> findCasesUserIdHasAccessTo(final String userId) {
         List<Long> usersCases = caseUserRepository.findCasesUserIdHasAccessTo(userId);
-        if (usersCases.size() == 0) {
+        if (usersCases.isEmpty()) {
             return List.of();
         } else {
             return caseDetailsRepository

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/caseaccess/CaseAccessOperation.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/caseaccess/CaseAccessOperation.java
@@ -73,9 +73,10 @@ public class CaseAccessOperation {
     }
 
     public List<String> findCasesUserIdHasAccessTo(final String userId) {
-        return caseUserRepository.findCasesUserIdHasAccessTo(userId)
+        return caseDetailsRepository
+            .findCaseDetailsReferencesByIds(caseUserRepository.findCasesUserIdHasAccessTo(userId))
             .stream()
-            .map(databaseId -> String.valueOf(caseDetailsRepository.findCaseDetailsReferenceById(databaseId)))
+            .map(String::valueOf)
             .collect(Collectors.toList());
     }
 

--- a/src/test/java/uk/gov/hmcts/ccd/data/casedetails/query/CaseDetailsQueryBuilderFactoryTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/data/casedetails/query/CaseDetailsQueryBuilderFactoryTest.java
@@ -60,6 +60,7 @@ class CaseDetailsQueryBuilderFactoryTest {
         when(criteriaBuilder.createQuery(CaseDetailsEntity.class)).thenReturn(query);
         when(criteriaBuilder.createQuery(Long.class)).thenReturn(countQuery);
         when(query.from(CaseDetailsEntity.class)).thenReturn(root);
+        when(countQuery.from(CaseDetailsEntity.class)).thenReturn(root);
     }
 
     private void assertAllA(CaseDetailsQueryBuilder<CaseDetailsEntity> queryBuilder) {
@@ -184,4 +185,35 @@ class CaseDetailsQueryBuilderFactoryTest {
         }
     }
 
+    @Nested
+    @DisplayName("selectByReferenceSecured()")
+    class SelectByReferenceSecured {
+        @Test
+        @DisplayName("should selectByReferenceSecured query")
+        void shouldSecureSelectByReferenceQuery() {
+            CaseDetailsQueryBuilder<Long> queryBuilder = factory.selectByReferenceSecured(em);
+            assertAll(
+                () -> assertThat(queryBuilder, is(notNullValue())),
+                () -> verify(userAuthorisationSecurity).secure(queryBuilder, null),
+                () -> verify(caseStateAuthorisationSecurity).secure(queryBuilder, null)
+            );
+        }
+
+        @Test
+        @DisplayName("should add order by clause to select by reference query")
+        void shouldAddOrderByClauseToSelectByReferenceQuery() {
+            String sortDirection = "desc";
+            MetaData metaData = new MetaData("caseType", "jurisdiction");
+            metaData.setSortDirection(Optional.of(sortDirection));
+
+            CaseDetailsQueryBuilder<Long> queryBuilder = factory.selectByReferenceSecured(em);
+            queryBuilder.orderBy(metaData);
+
+            assertAll(
+                () -> assertThat(queryBuilder, is(notNullValue())),
+                () -> verify(root).get("createdDate"),
+                () -> verify(criteriaBuilder).desc(any())
+            );
+        }
+    }
 }

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/caseaccess/CaseAccessOperationTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/caseaccess/CaseAccessOperationTest.java
@@ -232,20 +232,23 @@ class CaseAccessOperationTest {
     @DisplayName("findCasesUserIdHasAccessTo(userId)")
     class FindCasesUserIdHasAccessTo {
 
+        private final List<Long> ids = Collections.singletonList(1L);
+
         @Test
         @DisplayName("should return cases that the user has access to")
         void shouldReturnCasesUserHasAccessTo() {
+
             when(caseUserRepository.findCasesUserIdHasAccessTo(USER_ID))
-                .thenReturn(Collections.singletonList(1L));
-            when(caseDetailsRepository.findCaseDetailsReferenceById(1L))
-                .thenReturn(1L);
+                .thenReturn(ids);
+            when(caseDetailsRepository.findCaseDetailsReferencesByIds(ids))
+                .thenReturn(ids);
 
             List<String> usersCases = caseAccessOperation.findCasesUserIdHasAccessTo(USER_ID);
 
             assertAll(
                 () -> assertEquals(1, usersCases.size()),
                 () -> assertEquals(String.valueOf(1L), usersCases.get(0)),
-                () -> verify(caseDetailsRepository, times(1)).findCaseDetailsReferenceById(1L)
+                () -> verify(caseDetailsRepository, times(1)).findCaseDetailsReferencesByIds(ids)
             );
         }
 
@@ -259,7 +262,7 @@ class CaseAccessOperationTest {
 
             assertAll(
                 () -> assertEquals(0, usersCases.size()),
-                () -> verify(caseDetailsRepository, times(0)).findCaseDetailsReferenceById(1L)
+                () -> verify(caseDetailsRepository, times(0)).findCaseDetailsReferencesByIds(ids)
             );
         }
 

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/caseaccess/CaseAccessOperationTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/caseaccess/CaseAccessOperationTest.java
@@ -228,6 +228,43 @@ class CaseAccessOperationTest {
         }
     }
 
+    @Nested
+    @DisplayName("findCasesUserIdHasAccessTo(userId)")
+    class FindCasesUserIdHasAccessTo {
+
+        @Test
+        @DisplayName("should return cases that the user has access to")
+        void shouldReturnCasesUserHasAccessTo() {
+            when(caseUserRepository.findCasesUserIdHasAccessTo(USER_ID))
+                .thenReturn(Collections.singletonList(1L));
+            when(caseDetailsRepository.findCaseDetailsReferenceById(1L))
+                .thenReturn(1L);
+
+            List<String> usersCases = caseAccessOperation.findCasesUserIdHasAccessTo(USER_ID);
+
+            assertAll(
+                () -> assertEquals(1, usersCases.size()),
+                () -> assertEquals(String.valueOf(1L), usersCases.get(0)),
+                () -> verify(caseDetailsRepository, times(1)).findCaseDetailsReferenceById(1L)
+            );
+        }
+
+        @Test
+        @DisplayName("should return zero cases if the user has no access to any cases")
+        void shouldReturnEmptyListIfUserHasAccessToNoCases() {
+            when(caseUserRepository.findCasesUserIdHasAccessTo(USER_ID))
+                .thenReturn(new ArrayList<>());
+
+            List<String> usersCases = caseAccessOperation.findCasesUserIdHasAccessTo(USER_ID);
+
+            assertAll(
+                () -> assertEquals(0, usersCases.size()),
+                () -> verify(caseDetailsRepository, times(0)).findCaseDetailsReferenceById(1L)
+            );
+        }
+
+    }
+
     @Nested()
     @DisplayName("addCaseUserRoles(caseUserRoles)")
     class AddCaseAssignUserRoles {

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/caseaccess/CaseAccessOperationTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/caseaccess/CaseAccessOperationTest.java
@@ -240,7 +240,7 @@ class CaseAccessOperationTest {
 
             when(caseUserRepository.findCasesUserIdHasAccessTo(USER_ID))
                 .thenReturn(ids);
-            when(caseDetailsRepository.findCaseDetailsReferencesByIds(ids))
+            when(caseDetailsRepository.findCaseReferencesByIds(ids))
                 .thenReturn(ids);
 
             List<String> usersCases = caseAccessOperation.findCasesUserIdHasAccessTo(USER_ID);
@@ -248,7 +248,7 @@ class CaseAccessOperationTest {
             assertAll(
                 () -> assertEquals(1, usersCases.size()),
                 () -> assertEquals(String.valueOf(1L), usersCases.get(0)),
-                () -> verify(caseDetailsRepository, times(1)).findCaseDetailsReferencesByIds(ids)
+                () -> verify(caseDetailsRepository, times(1)).findCaseReferencesByIds(ids)
             );
         }
 
@@ -262,7 +262,7 @@ class CaseAccessOperationTest {
 
             assertAll(
                 () -> assertEquals(0, usersCases.size()),
-                () -> verify(caseDetailsRepository, times(0)).findCaseDetailsReferencesByIds(ids)
+                () -> verify(caseDetailsRepository, times(0)).findCaseReferencesByIds(ids)
             );
         }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDM-11005

### Change description ###
Refactor query so we do not fetch whole CaseDetails objects for listing cases accessible by a user


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
