### PR TITLE
RDM-11850: [CASE REFERENCE] metadata field type still returned as 'Number' and not as a String via ES api

### DIFF
--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/search/CaseSearchResultViewGenerator.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/search/CaseSearchResultViewGenerator.java
@@ -224,8 +224,10 @@ public class CaseSearchResultViewGenerator {
     }
 
     private Map<String, Object> convertReferenceToString(Map<String, Object> caseMetadata) {
-        final String convertedCaseReference = String.valueOf(caseMetadata.get(CASE_REFERENCE.getReference()));
-        caseMetadata.put(CASE_REFERENCE.getReference(), convertedCaseReference);
-        return caseMetadata;
+        Map<String, Object> caseMetaDataMap = new HashMap<>();
+        caseMetaDataMap.putAll(caseMetadata);
+        final String convertedCaseReference = String.valueOf(caseMetaDataMap.get(CASE_REFERENCE.getReference()));
+        caseMetaDataMap.put(CASE_REFERENCE.getReference(), convertedCaseReference);
+        return caseMetaDataMap;
     }
 }

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/search/CaseSearchResultViewGenerator.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/search/CaseSearchResultViewGenerator.java
@@ -1,6 +1,12 @@
 package uk.gov.hmcts.ccd.domain.service.search;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
@@ -20,19 +26,12 @@ import uk.gov.hmcts.ccd.domain.model.search.elasticsearch.SearchResultViewHeader
 import uk.gov.hmcts.ccd.domain.model.search.elasticsearch.SearchResultViewItem;
 import uk.gov.hmcts.ccd.domain.service.common.CaseTypeService;
 import uk.gov.hmcts.ccd.domain.service.processor.date.DateTimeSearchResultProcessor;
-
 import uk.gov.hmcts.ccd.endpoint.exceptions.BadRequestException;
 import uk.gov.hmcts.ccd.endpoint.exceptions.BadSearchRequest;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
+import static uk.gov.hmcts.ccd.data.casedetails.search.MetaData.CaseField.CASE_REFERENCE;
 import static uk.gov.hmcts.ccd.domain.model.common.CaseFieldPathUtils.getNestedCaseFieldByPath;
 
 @Service
@@ -220,7 +219,13 @@ public class CaseSearchResultViewGenerator {
         });
 
         newResults.putAll(caseData);
-        newResults.putAll(metadata);
+        newResults.putAll(convertReferenceToString(metadata));
         return newResults;
+    }
+
+    private Map<String, Object> convertReferenceToString(Map<String, Object> caseMetadata) {
+        final String convertedCaseReference = caseMetadata.get(CASE_REFERENCE.getReference()).toString();
+        caseMetadata.put(CASE_REFERENCE.getReference(), convertedCaseReference);
+        return caseMetadata;
     }
 }

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/search/CaseSearchResultViewGenerator.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/search/CaseSearchResultViewGenerator.java
@@ -224,7 +224,7 @@ public class CaseSearchResultViewGenerator {
     }
 
     private Map<String, Object> convertReferenceToString(Map<String, Object> caseMetadata) {
-        final String convertedCaseReference = caseMetadata.get(CASE_REFERENCE.getReference()).toString();
+        final String convertedCaseReference = String.valueOf(caseMetadata.get(CASE_REFERENCE.getReference()));
         caseMetadata.put(CASE_REFERENCE.getReference(), convertedCaseReference);
         return caseMetadata;
     }

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/aggregated/CaseSearchResultViewGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/aggregated/CaseSearchResultViewGeneratorTest.java
@@ -341,7 +341,7 @@ class CaseSearchResultViewGeneratorTest {
                 is(LAST_STATE_MODIFIED_DATE)),
             () -> assertThat(caseSearchResultView.getCases().get(0).getFields().get("[CREATED_DATE]"),
                 is(CREATED_DATE)),
-            () -> assertThat(caseSearchResultView.getCases().get(0).getFields().get("[CASE_REFERENCE]"), is(999L)),
+            () -> assertThat(caseSearchResultView.getCases().get(0).getFields().get("[CASE_REFERENCE]"), is("999")),
             () -> assertThat(caseSearchResultView.getCases().get(0).getFields().get("[SECURITY_CLASSIFICATION]"),
                     is(SECURITY_CLASSIFICATION)),
             () -> assertThat(caseSearchResultView.getCases().get(0).getFields().get("[CASE_TYPE]"), is(CASE_TYPE_ID_1)),

--- a/src/test/java/uk/gov/hmcts/ccd/v2/internal/controller/UICaseSearchControllerIT.java
+++ b/src/test/java/uk/gov/hmcts/ccd/v2/internal/controller/UICaseSearchControllerIT.java
@@ -626,7 +626,7 @@ class UICaseSearchControllerIT extends ElasticsearchBaseTest {
             () -> assertThat(data.get(MetaData.CaseField.LAST_STATE_MODIFIED_DATE.getReference()),
                 is(LAST_STATE_MODIFIED_DATE_VALUE)),
             () -> assertThat(data.get(MetaData.CaseField.CASE_REFERENCE.getReference()),
-                is(Long.parseLong(DEFAULT_CASE_REFERENCE))),
+                is(DEFAULT_CASE_REFERENCE)),
             () -> assertThat(data.get(MetaData.CaseField.STATE.getReference()), is(STATE_VALUE)),
             () -> assertThat(data.get(MetaData.CaseField.SECURITY_CLASSIFICATION.getReference()),
                 is(SecurityClassification.PUBLIC.name()))


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDM-11850

### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
