### PR TITLE
RDM-11956 Extend allowed list of document domains to include em-hrs-api

### DIFF
--- a/src/contractTest/resources/application.properties
+++ b/src/contractTest/resources/application.properties
@@ -62,6 +62,7 @@ ccd.callback.retries=1,5,10
 ccd.case.search.wildcards.allowed=false
 
 ccd.dm.domain=${CCD_DM_DOMAIN:http://localhost:4603}
+ccd.document.url.pattern=${CCD_DOCUMENT_URL_PATTERN:/documents/[A-Za-z0-9-]+(?:/binary)?}
 
 idam.api.url=${IDAM_USER_URL:http://localhost:5000}
 # open id

--- a/src/main/java/uk/gov/hmcts/ccd/ApplicationParams.java
+++ b/src/main/java/uk/gov/hmcts/ccd/ApplicationParams.java
@@ -277,9 +277,11 @@ public class ApplicationParams {
     public String getValidDMDomain() {
         return validDMDomain;
     }
+
     public String getDocumentURLPattern() {
         return documentURLPattern;
     }
+
     public String getDefaultPrintUrl() {
         return defaultPrintUrl;
     }

--- a/src/main/java/uk/gov/hmcts/ccd/ApplicationParams.java
+++ b/src/main/java/uk/gov/hmcts/ccd/ApplicationParams.java
@@ -68,6 +68,9 @@ public class ApplicationParams {
     @Value("${ccd.dm.domain}")
     private String validDMDomain;
 
+    @Value("${ccd.document.url.pattern}")
+    private String documentURLPattern;
+
     @Value("${ccd.defaultPrintUrl}")
     private String defaultPrintUrl;
 
@@ -274,7 +277,9 @@ public class ApplicationParams {
     public String getValidDMDomain() {
         return validDMDomain;
     }
-
+    public String getDocumentURLPattern() {
+        return documentURLPattern;
+    }
     public String getDefaultPrintUrl() {
         return defaultPrintUrl;
     }

--- a/src/main/java/uk/gov/hmcts/ccd/domain/types/DocumentValidator.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/types/DocumentValidator.java
@@ -61,7 +61,8 @@ public class DocumentValidator implements BaseTypeValidator {
         }
 
         final String documentUrlValue = documentUrl.textValue();
-        final String urlPatternString = applicationParams.getValidDMDomain() + "/documents/[A-Za-z0-9-]+(?:/binary)?";
+        final String urlPatternString =
+            applicationParams.getValidDMDomain() + applicationParams.getDocumentURLPattern();
         final Pattern urlPattern = Pattern.compile(urlPatternString);
         final Matcher documentUrlMatcher = urlPattern.matcher(documentUrlValue);
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -62,6 +62,7 @@ ccd.callback.retries=1,5,10
 ccd.case.search.wildcards.allowed=false
 
 ccd.dm.domain=${CCD_DM_DOMAIN:http://localhost:4603}
+ccd.document.url.pattern=${CCD_DOCUMENT_URL_PATTERN:/documents/[A-Za-z0-9-]+(?:/binary)?}
 
 idam.api.url=${IDAM_USER_URL:http://localhost:5000}
 # open id

--- a/src/test/java/uk/gov/hmcts/ccd/domain/types/DocumentValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/types/DocumentValidatorTest.java
@@ -138,7 +138,7 @@ public class DocumentValidatorTest implements IVallidatorTest {
     }
 
     @Test
-    public void shouldValidateDocumentWithValidEMHRSUrlAndDomain() {
+    public void shouldValidateDocumentWithValidEmHrsUrlAndDomain() {
         final ApplicationParams applicationParams = mock(ApplicationParams.class);
 
         when(applicationParams.getValidDMDomain()).thenReturn("https://em-hrs-api.service.core-compute-aat.internal");


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-11956


### Change description ###
Extend allowed list of document domains to include em-hrs-api


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
