### PR TITLE
RDM-12143 CVE-2021-29425 - bump up dependencies to resolve CVE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -294,6 +294,11 @@ dependencyManagement {
             entry 'groovy-xml'
             entry 'groovy-json'
         }
+
+        // CVE-2021-29425
+        dependencySet(group: 'commons-io', version: '2.8.0') {
+            entry 'commons-io'
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -296,7 +296,7 @@ dependencyManagement {
         }
 
         // CVE-2021-29425
-        dependency 'commons-io:commons-io:2.8.0'
+        dependency 'org.commons-io:commons-io:2.8.0'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -296,9 +296,7 @@ dependencyManagement {
         }
 
         // CVE-2021-29425
-        dependencySet(group: 'commons-io', version: '2.8.0') {
-            entry 'commons-io'
-        }
+        dependency 'commons-io:commons-io:2.8.0'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -194,7 +194,7 @@ dependencies {
     compile group: 'org.awaitility', name: 'awaitility', version: '3.1.6'
 
     // CVE-2021-29425
-    compile 'commons-io:commons-io:2.8.0'
+    compile group: 'commons-io', name: 'commons-io', version: '2.8.0'
 
     compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.10.3'
     compile "com.fasterxml.jackson.core:jackson-databind:2.11.1"

--- a/build.gradle
+++ b/build.gradle
@@ -193,6 +193,9 @@ dependencies {
     compile group: 'com.jayway.jsonpath', name: 'json-path', version: '2.4.0'
     compile group: 'org.awaitility', name: 'awaitility', version: '3.1.6'
 
+    // CVE-2021-29425
+    compile 'commons-io:commons-io:2.8.0'
+
     compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.10.3'
     compile "com.fasterxml.jackson.core:jackson-databind:2.11.1"
 
@@ -294,9 +297,6 @@ dependencyManagement {
             entry 'groovy-xml'
             entry 'groovy-json'
         }
-
-        // CVE-2021-29425
-        dependency 'org.commons-io:commons-io:2.8.0'
     }
 }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-12143


### Change description ###
bump up dependencies to resolve CVE-2021-29425

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```