### PR TITLE
RDM-11352 - renamed case data doc json hasToken to "document_hash"

### DIFF
--- a/src/aat/resources/features/F-032/F-032_Case_Creation_Data_With_Document.td.json
+++ b/src/aat/resources/features/F-032/F-032_Case_Creation_Data_With_Document.td.json
@@ -13,7 +13,7 @@
           "document_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][siblingContexts][Befta_Jurisdiction2_Document_Upload_1][customValues][documentIdInTheResponse]}",
           "document_binary_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][siblingContexts][Befta_Jurisdiction2_Document_Upload_1][customValues][documentIdInTheResponse]}/binary",
           "document_filename": "${[scenarioContext][siblingContexts][Befta_Jurisdiction2_Document_Upload_1][testData][actualResponse][body][documents][0][originalDocumentName]}",
-          "hashToken": "${[scenarioContext][siblingContexts][Befta_Jurisdiction2_Document_Upload_1][testData][actualResponse][body][documents][0][hashToken]}"
+          "document_hash": "${[scenarioContext][siblingContexts][Befta_Jurisdiction2_Document_Upload_1][testData][actualResponse][body][documents][0][hashToken]}"
         }
 			}
 		}

--- a/src/aat/resources/features/F-037/S-577.td.json
+++ b/src/aat/resources/features/F-037/S-577.td.json
@@ -22,7 +22,7 @@
           "document_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Befta_Jurisdiction2_Document_Upload_2][customValues][documentIdInTheResponse]}",
           "document_binary_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Befta_Jurisdiction2_Document_Upload_2][customValues][documentIdInTheResponse]}/binary",
 					"document_filename":"Elastic Search test Case.png --> updated by Solicitor 2",
-          "hashToken": "${[scenarioContext][childContexts][Befta_Jurisdiction2_Document_Upload_2][testData][actualResponse][body][documents][0][hashToken]}"
+          "document_hash": "${[scenarioContext][childContexts][Befta_Jurisdiction2_Document_Upload_2][testData][actualResponse][body][documents][0][hashToken]}"
 				}
 			}
 		}

--- a/src/aat/resources/features/F-1001/F-1001-Base-Root.td.json
+++ b/src/aat/resources/features/F-1001/F-1001-Base-Root.td.json
@@ -48,7 +48,7 @@
           "document_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][parentContext][childContexts][Default_Document_Upload_Data][customValues][documentIdInTheResponse]}",
           "document_filename": "${[scenarioContext][parentContext][childContexts][Default_Document_Upload_Data][testData][actualResponse][body][documents][0][originalDocumentName]}",
           "document_binary_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][parentContext][childContexts][Default_Document_Upload_Data][customValues][documentIdInTheResponse]}/binary",
-          "hashToken": "${[scenarioContext][parentContext][childContexts][Default_Document_Upload_Data][testData][actualResponse][body][documents][0][hashToken]}"
+          "document_hash": "${[scenarioContext][parentContext][childContexts][Default_Document_Upload_Data][testData][actualResponse][body][documents][0][hashToken]}"
         },
         "FixedListField": "VALUE2",
         "CollectionField": [],

--- a/src/aat/resources/features/F-1002 - Case Update With Documents/S-1011.td.json
+++ b/src/aat/resources/features/F-1002 - Case Update With Documents/S-1011.td.json
@@ -12,7 +12,7 @@
           "document_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_Data][customValues][documentIdInTheResponse]}",
           "document_filename": "${[scenarioContext][childContexts][Default_Document_Upload_Data][testData][actualResponse][body][documents][0][originalDocumentName]}",
           "document_binary_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_Data][customValues][documentIdInTheResponse]}/binary",
-          "hashToken": "${[scenarioContext][childContexts][Default_Document_Upload_Data][testData][actualResponse][body][documents][0][hashToken]}"
+          "document_hash": "${[scenarioContext][childContexts][Default_Document_Upload_Data][testData][actualResponse][body][documents][0][hashToken]}"
         }
       },
       "event_token": "${[scenarioContext][childContexts][S-1011-Update_Event_Token_Creation][testData][actualResponse][body][token]}"

--- a/src/aat/resources/features/F-1002 - Case Update With Documents/S-1013.td.json
+++ b/src/aat/resources/features/F-1002 - Case Update With Documents/S-1013.td.json
@@ -18,19 +18,19 @@
           "document_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_1][customValues][documentIdInTheResponse]}",
           "document_filename": "${[scenarioContext][childContexts][Default_Document_Upload_1][testData][actualResponse][body][documents][0][originalDocumentName]}",
           "document_binary_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_1][customValues][documentIdInTheResponse]}/binary",
-          "hashToken": "${[scenarioContext][childContexts][Default_Document_Upload_1][testData][actualResponse][body][documents][0][hashToken]}"
+          "document_hash": "${[scenarioContext][childContexts][Default_Document_Upload_1][testData][actualResponse][body][documents][0][hashToken]}"
         },
         "DocumentField2": {
           "document_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_2][customValues][documentIdInTheResponse]}",
           "document_filename": "${[scenarioContext][childContexts][Default_Document_Upload_2][testData][actualResponse][body][documents][0][originalDocumentName]}",
           "document_binary_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_2][customValues][documentIdInTheResponse]}/binary",
-          "hashToken": "${[scenarioContext][childContexts][Default_Document_Upload_2][testData][actualResponse][body][documents][0][hashToken]}"
+          "document_hash": "${[scenarioContext][childContexts][Default_Document_Upload_2][testData][actualResponse][body][documents][0][hashToken]}"
         },
         "DocumentField3": {
           "document_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_3][customValues][documentIdInTheResponse]}",
           "document_filename": "${[scenarioContext][childContexts][Default_Document_Upload_3][testData][actualResponse][body][documents][0][originalDocumentName]}",
           "document_binary_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_3][customValues][documentIdInTheResponse]}/binary",
-          "hashToken": "${[scenarioContext][childContexts][Default_Document_Upload_3][testData][actualResponse][body][documents][0][hashToken]}"
+          "document_hash": "${[scenarioContext][childContexts][Default_Document_Upload_3][testData][actualResponse][body][documents][0][hashToken]}"
         }
       },
       "data_classification": {

--- a/src/aat/resources/features/F-1002 - Case Update With Documents/S-1014.td.json
+++ b/src/aat/resources/features/F-1002 - Case Update With Documents/S-1014.td.json
@@ -18,7 +18,7 @@
           "document_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_Data][customValues][documentIdInTheResponse]}",
           "document_filename": "${[scenarioContext][childContexts][Default_Document_Upload_Data][testData][actualResponse][body][documents][0][originalDocumentName]}",
           "document_binary_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_Data][customValues][documentIdInTheResponse]}/binary",
-          "hashToken": "00000adba426c8f8b00000eb69eb9c000f501eb67c4c52c7fc37c1a000000000"
+          "document_hash": "00000adba426c8f8b00000eb69eb9c000f501eb67c4c52c7fc37c1a000000000"
         }
       },
       "data_classification": {

--- a/src/aat/resources/features/F-1002 - Case Update With Documents/S-1015.td.json
+++ b/src/aat/resources/features/F-1002 - Case Update With Documents/S-1015.td.json
@@ -17,7 +17,7 @@
           "document_url": "{{DM_STORE_BASE_URL}}/documents/00000000-0000-0000-0000-000000000000",
           "document_filename": "${[scenarioContext][childContexts][Default_Document_Upload_Data][testData][actualResponse][body][documents][0][originalDocumentName]}",
           "document_binary_url": "{{DM_STORE_BASE_URL}}/documents/00000000-0000-0000-0000-000000000000/binary",
-          "hashToken": "${[scenarioContext][childContexts][Default_Document_Upload_Data][testData][actualResponse][body][documents][0][hashToken]}"
+          "document_hash": "${[scenarioContext][childContexts][Default_Document_Upload_Data][testData][actualResponse][body][documents][0][hashToken]}"
         }
       },
       "event_token": "${[scenarioContext][childContexts][S-1015-Update_Event_Token_Creation][testData][actualResponse][body][token]}"

--- a/src/aat/resources/features/F-1002 - Case Update With Documents/S-1016.td.json
+++ b/src/aat/resources/features/F-1002 - Case Update With Documents/S-1016.td.json
@@ -17,7 +17,7 @@
           "document_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_Data][customValues][documentIdInTheResponse]}",
           "document_filename": "${[scenarioContext][childContexts][Default_Document_Upload_Data][testData][actualResponse][body][documents][0][originalDocumentName]}",
           "document_binary_url": "{{DM_STORE_BASE_URL}}/documents/00000000-@@@@-^&*$-0000-000000000000/binary",
-          "hashToken": "${[scenarioContext][childContexts][Default_Document_Upload_Data][testData][actualResponse][body][documents][0][hashToken]}"
+          "document_hash": "${[scenarioContext][childContexts][Default_Document_Upload_Data][testData][actualResponse][body][documents][0][hashToken]}"
         }
       },
       "event_token": "${[scenarioContext][childContexts][S-1016-Update_Event_Token_Creation][testData][actualResponse][body][token]}"

--- a/src/aat/resources/features/F-1002 - Case Update With Documents/S-1017.td.json
+++ b/src/aat/resources/features/F-1002 - Case Update With Documents/S-1017.td.json
@@ -20,7 +20,7 @@
           "document_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_Data][customValues][documentIdInTheResponse]}",
           "document_filename": "${[scenarioContext][childContexts][Default_Document_Upload_Data][testData][actualResponse][body][documents][0][originalDocumentName]}",
           "document_binary_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_Data][customValues][documentIdInTheResponse]}/binary",
-          "hashToken": "${[scenarioContext][childContexts][Default_Document_Upload_Data][testData][actualResponse][body][documents][0][hashToken]}"
+          "document_hash": "${[scenarioContext][childContexts][Default_Document_Upload_Data][testData][actualResponse][body][documents][0][hashToken]}"
         }
       },
       "event_token": "${[scenarioContext][childContexts][S-1017-Update_Event_Token_Creation][testData][actualResponse][body][token]}"

--- a/src/aat/resources/features/F-1002 - Case Update With Documents/S-1018.td.json
+++ b/src/aat/resources/features/F-1002 - Case Update With Documents/S-1018.td.json
@@ -20,7 +20,7 @@
           "document_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_Data][customValues][documentIdInTheResponse]}",
           "document_filename": "${[scenarioContext][childContexts][Default_Document_Upload_Data][testData][actualResponse][body][documents][0][originalDocumentName]}",
           "document_binary_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_Data][customValues][documentIdInTheResponse]}/binary",
-          "hashToken": "${[scenarioContext][childContexts][Default_Document_Upload_Data][testData][actualResponse][body][documents][0][hashToken]}"
+          "document_hash": "${[scenarioContext][childContexts][Default_Document_Upload_Data][testData][actualResponse][body][documents][0][hashToken]}"
         }
       },
       "event_token": "${[scenarioContext][childContexts][S-1018-Update_Event_Token_Creation][testData][actualResponse][body][token]}"

--- a/src/aat/resources/features/F-1003 - Case Creation With Documents/F-1003-Base-Root.td.json
+++ b/src/aat/resources/features/F-1003 - Case Creation With Documents/F-1003-Base-Root.td.json
@@ -48,7 +48,7 @@
           "document_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_Data][customValues][documentIdInTheResponse]}",
           "document_filename": "${[scenarioContext][childContexts][Default_Document_Upload_Data][testData][actualResponse][body][documents][0][originalDocumentName]}",
           "document_binary_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_Data][customValues][documentIdInTheResponse]}/binary",
-          "hashToken": "${[scenarioContext][childContexts][Default_Document_Upload_Data][testData][actualResponse][body][documents][0][hashToken]}"
+          "document_hash": "${[scenarioContext][childContexts][Default_Document_Upload_Data][testData][actualResponse][body][documents][0][hashToken]}"
         },
         "FixedListField": "VALUE2",
         "CollectionField": [],

--- a/src/aat/resources/features/F-1003 - Case Creation With Documents/S-1031.td.json
+++ b/src/aat/resources/features/F-1003 - Case Creation With Documents/S-1031.td.json
@@ -9,43 +9,43 @@
           "document_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_Data][customValues][documentIdInTheResponse]}",
           "document_filename": "${[scenarioContext][childContexts][Default_Document_Upload_Data][testData][actualResponse][body][documents][0][originalDocumentName]}",
           "document_binary_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_Data][customValues][documentIdInTheResponse]}/binary",
-          "hashToken": "${[scenarioContext][childContexts][Default_Document_Upload_Data][testData][actualResponse][body][documents][0][hashToken]}"
+          "document_hash": "${[scenarioContext][childContexts][Default_Document_Upload_Data][testData][actualResponse][body][documents][0][hashToken]}"
         },
         "DocumentField2": {
           "document_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_Data_01][customValues][documentIdInTheResponse]}",
           "document_filename": "${[scenarioContext][childContexts][Default_Document_Upload_Data_01][testData][actualResponse][body][documents][0][originalDocumentName]}",
           "document_binary_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_Data_01][customValues][documentIdInTheResponse]}/binary",
-          "hashToken": "${[scenarioContext][childContexts][Default_Document_Upload_Data_01][testData][actualResponse][body][documents][0][hashToken]}"
+          "document_hash": "${[scenarioContext][childContexts][Default_Document_Upload_Data_01][testData][actualResponse][body][documents][0][hashToken]}"
         },
         "DocumentField3": {
           "document_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_Data_02][customValues][documentIdInTheResponse]}",
           "document_filename": "${[scenarioContext][childContexts][Default_Document_Upload_Data_02][testData][actualResponse][body][documents][0][originalDocumentName]}",
           "document_binary_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_Data_02][customValues][documentIdInTheResponse]}/binary",
-          "hashToken": "${[scenarioContext][childContexts][Default_Document_Upload_Data_02][testData][actualResponse][body][documents][0][hashToken]}"
+          "document_hash": "${[scenarioContext][childContexts][Default_Document_Upload_Data_02][testData][actualResponse][body][documents][0][hashToken]}"
         },
         "DocumentField4": {
           "document_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_Data_03][customValues][documentIdInTheResponse]}",
           "document_filename": "${[scenarioContext][childContexts][Default_Document_Upload_Data_03][testData][actualResponse][body][documents][0][originalDocumentName]}",
           "document_binary_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_Data_03][customValues][documentIdInTheResponse]}/binary",
-          "hashToken": "${[scenarioContext][childContexts][Default_Document_Upload_Data_03][testData][actualResponse][body][documents][0][hashToken]}"
+          "document_hash": "${[scenarioContext][childContexts][Default_Document_Upload_Data_03][testData][actualResponse][body][documents][0][hashToken]}"
         },
         "DocumentField5": {
           "document_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_Data_04][customValues][documentIdInTheResponse]}",
           "document_filename": "${[scenarioContext][childContexts][Default_Document_Upload_Data_04][testData][actualResponse][body][documents][0][originalDocumentName]}",
           "document_binary_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_Data_04][customValues][documentIdInTheResponse]}/binary",
-          "hashToken": "${[scenarioContext][childContexts][Default_Document_Upload_Data_04][testData][actualResponse][body][documents][0][hashToken]}"
+          "document_hash": "${[scenarioContext][childContexts][Default_Document_Upload_Data_04][testData][actualResponse][body][documents][0][hashToken]}"
         },
         "DocumentField6": {
           "document_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_Data_05][customValues][documentIdInTheResponse]}",
           "document_filename": "${[scenarioContext][childContexts][Default_Document_Upload_Data_05][testData][actualResponse][body][documents][0][originalDocumentName]}",
           "document_binary_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_Data_05][customValues][documentIdInTheResponse]}/binary",
-          "hashToken": "${[scenarioContext][childContexts][Default_Document_Upload_Data_05][testData][actualResponse][body][documents][0][hashToken]}"
+          "document_hash": "${[scenarioContext][childContexts][Default_Document_Upload_Data_05][testData][actualResponse][body][documents][0][hashToken]}"
         },
         "DocumentField7": {
           "document_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_Data_06][customValues][documentIdInTheResponse]}",
           "document_filename": "${[scenarioContext][childContexts][Default_Document_Upload_Data_06][testData][actualResponse][body][documents][0][originalDocumentName]}",
           "document_binary_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_Data_06][customValues][documentIdInTheResponse]}/binary",
-          "hashToken": "${[scenarioContext][childContexts][Default_Document_Upload_Data_06][testData][actualResponse][body][documents][0][hashToken]}"
+          "document_hash": "${[scenarioContext][childContexts][Default_Document_Upload_Data_06][testData][actualResponse][body][documents][0][hashToken]}"
         }
       }
     }

--- a/src/aat/resources/features/F-1003 - Case Creation With Documents/S-1034.td.json
+++ b/src/aat/resources/features/F-1003 - Case Creation With Documents/S-1034.td.json
@@ -12,7 +12,7 @@
           "document_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_Data][customValues][documentIdInTheResponse]}",
           "document_filename": "${[scenarioContext][childContexts][Default_Document_Upload_Data][testData][actualResponse][body][documents][0][originalDocumentName]}",
           "document_binary_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_Data][customValues][documentIdInTheResponse]}/binary",
-          "hashToken": "Non Existing Hash Token"
+          "document_hash": "Non Existing Hash Token"
         }
       }
     }

--- a/src/aat/resources/features/F-1003 - Case Creation With Documents/S-1035.td.json
+++ b/src/aat/resources/features/F-1003 - Case Creation With Documents/S-1035.td.json
@@ -12,7 +12,7 @@
           "document_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_Data][customValues][documentIdInTheResponse]}",
           "document_filename": "${[scenarioContext][childContexts][Default_Document_Upload_Data][testData][actualResponse][body][documents][0][originalDocumentName]}",
           "document_binary_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_Data][customValues][documentIdInTheResponse]}/binary",
-          "hashToken": "bc7d8530b97077ba09d42730b114455769cc7703a2fa585b24a80131aa2a^&%$"
+          "document_hash": "bc7d8530b97077ba09d42730b114455769cc7703a2fa585b24a80131aa2a^&%$"
         }
       }
     }

--- a/src/aat/resources/features/F-1003 - Case Creation With Documents/S-1036.td.json
+++ b/src/aat/resources/features/F-1003 - Case Creation With Documents/S-1036.td.json
@@ -12,7 +12,7 @@
           "document_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_Data][customValues][documentIdInTheResponse]}",
           "document_filename": "${[scenarioContext][childContexts][Default_Document_Upload_Data][testData][actualResponse][body][documents][0][originalDocumentName]}",
           "document_binary_url": "{{DM_STORE_BASE_URL}}/documents/123e4567-e89b-12d3-a456-426655440000/binary",
-          "hashToken": "${[scenarioContext][childContexts][Default_Document_Upload_Data][testData][actualResponse][body][documents][0][hashToken]}"
+          "document_hash": "${[scenarioContext][childContexts][Default_Document_Upload_Data][testData][actualResponse][body][documents][0][hashToken]}"
         }
       }
     }

--- a/src/aat/resources/features/F-1003 - Case Creation With Documents/S-1037.td.json
+++ b/src/aat/resources/features/F-1003 - Case Creation With Documents/S-1037.td.json
@@ -12,7 +12,7 @@
           "document_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_Data][customValues][documentIdInTheResponse]}",
           "document_filename": "${[scenarioContext][childContexts][Default_Document_Upload_Data][testData][actualResponse][body][documents][0][originalDocumentName]}",
           "document_binary_url": "{{DM_STORE_BASE_URL}}/documents/123e4567-e89b-12d3-&^%$-426655440000/binary",
-          "hashToken": "${[scenarioContext][childContexts][Default_Document_Upload_Data][testData][actualResponse][body][documents][0][hashToken]}"
+          "document_hash": "${[scenarioContext][childContexts][Default_Document_Upload_Data][testData][actualResponse][body][documents][0][hashToken]}"
         }
       }
     }

--- a/src/aat/resources/features/common/case/befta-jurisdiction2-citizen-case-creation/Befta_Jurisdiction2_Default_Citizen_Case_Creation_Data.td.json
+++ b/src/aat/resources/features/common/case/befta-jurisdiction2-citizen-case-creation/Befta_Jurisdiction2_Default_Citizen_Case_Creation_Data.td.json
@@ -20,19 +20,19 @@
           "document_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][siblingContexts][Befta_Jurisdiction2_Document_Upload_1][customValues][documentIdInTheResponse]}",
           "document_filename": "${[scenarioContext][siblingContexts][Befta_Jurisdiction2_Document_Upload_1][testData][actualResponse][body][documents][0][originalDocumentName]}",
           "document_binary_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][siblingContexts][Befta_Jurisdiction2_Document_Upload_1][customValues][documentIdInTheResponse]}/binary",
-          "hashToken": "${[scenarioContext][siblingContexts][Befta_Jurisdiction2_Document_Upload_1][testData][actualResponse][body][documents][0][hashToken]}"
+          "document_hash": "${[scenarioContext][siblingContexts][Befta_Jurisdiction2_Document_Upload_1][testData][actualResponse][body][documents][0][hashToken]}"
         },
         "DocumentField2": {
           "document_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][siblingContexts][Befta_Jurisdiction2_Document_Upload_2][customValues][documentIdInTheResponse]}",
           "document_filename": "${[scenarioContext][siblingContexts][Befta_Jurisdiction2_Document_Upload_2][testData][actualResponse][body][documents][0][originalDocumentName]}",
           "document_binary_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][siblingContexts][Befta_Jurisdiction2_Document_Upload_2][customValues][documentIdInTheResponse]}/binary",
-          "hashToken": "${[scenarioContext][siblingContexts][Befta_Jurisdiction2_Document_Upload_2][testData][actualResponse][body][documents][0][hashToken]}"
+          "document_hash": "${[scenarioContext][siblingContexts][Befta_Jurisdiction2_Document_Upload_2][testData][actualResponse][body][documents][0][hashToken]}"
         },
         "DocumentField4": {
           "document_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][siblingContexts][Befta_Jurisdiction2_Document_Upload_3][customValues][documentIdInTheResponse]}",
           "document_filename": "${[scenarioContext][siblingContexts][Befta_Jurisdiction2_Document_Upload_3][testData][actualResponse][body][documents][0][originalDocumentName]}",
           "document_binary_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][siblingContexts][Befta_Jurisdiction2_Document_Upload_3][customValues][documentIdInTheResponse]}/binary",
-          "hashToken": "${[scenarioContext][siblingContexts][Befta_Jurisdiction2_Document_Upload_3][testData][actualResponse][body][documents][0][hashToken]}"
+          "document_hash": "${[scenarioContext][siblingContexts][Befta_Jurisdiction2_Document_Upload_3][testData][actualResponse][body][documents][0][hashToken]}"
         }
 			}
 		}

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/getcasedocument/CaseDocumentUtils.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/getcasedocument/CaseDocumentUtils.java
@@ -30,7 +30,7 @@ public class CaseDocumentUtils {
 
     public static final String DOCUMENT_URL = "document_url";
     public static final String DOCUMENT_BINARY_URL = "document_url";
-    public static final String DOCUMENT_HASH = "hashToken";// TODO: replace hashToken to "document_hash";
+    public static final String DOCUMENT_HASH = "document_hash";
     public static final String BINARY = "/binary";
 
     public List<Tuple2<String, String>> findDocumentsHashes(@NonNull final Map<String, JsonNode> data) {

--- a/src/test/resources/tests/A-case-detail-after-update.json
+++ b/src/test/resources/tests/A-case-detail-after-update.json
@@ -54,7 +54,7 @@
             "document_url": "http://dm-store:8080/documents/8da17150-c001-47d7-bfeb-3dabed9e0976",
             "document_filename": "Screenshot 2020-02-24 at 13.32.03.png",
             "document_binary_url": "http://dm-store:8080/documents/8da17150-c001-47d7-bfeb-3dabed9e0976/binary",
-            "hashToken": "dummyToken"
+            "document_hash": "dummyToken"
           }
         }
       ]

--- a/src/test/resources/tests/A-case-detail-update.json
+++ b/src/test/resources/tests/A-case-detail-update.json
@@ -9,7 +9,7 @@
             "document_url": "http://dm-store:8080/documents/8da17150-c001-47d7-bfeb-3dabed9e0976",
             "document_filename": "Screenshot 2020-02-24 at 13.32.03.png",
             "document_binary_url": "http://dm-store:8080/documents/8da17150-c001-47d7-bfeb-3dabed9e0976/binary",
-            "hashToken": "dummyToken"
+            "document_hash": "dummyToken"
           }
         }
       ]

--- a/src/test/resources/tests/SubmitTransactionBadDocumentUpload.json
+++ b/src/test/resources/tests/SubmitTransactionBadDocumentUpload.json
@@ -4,7 +4,7 @@
   "DocumentFieldWithoutHashToken": {
     "document_url": "http://dm-store:8080/documents/5c4b5564-a29f-47d3-8c51-50einvalid",
     "document_filename": "File2.cr2",
-    "hashToken": "6a7e12164534a0c2252a94b308a2a185e46f89ab639c5342027b9cd393068bc"
+    "document_hash": "6a7e12164534a0c2252a94b308a2a185e46f89ab639c5342027b9cd393068bc"
   },
   "FixedListField": "VALUE2",
   "CollectionField": []

--- a/src/test/resources/tests/SubmitTransactionDocumentUpload.json
+++ b/src/test/resources/tests/SubmitTransactionDocumentUpload.json
@@ -12,7 +12,7 @@
     "DocumentField8": {
       "document_url": "http://dm-store:8080/documents/f0550adc-eaea-4232-b52f-1c4ac0534d60",
       "document_filename": "Test.png",
-      "hashToken": "UyWGSBgJexcS1i0fTp6QUyWGSBgJexcS1i0fTp6QUyWGSBgJexcS1i0fTp6QUyWGSBgJexcS1i0fTp6Q"
+      "document_hash": "UyWGSBgJexcS1i0fTp6QUyWGSBgJexcS1i0fTp6QUyWGSBgJexcS1i0fTp6QUyWGSBgJexcS1i0fTp6Q"
     },
     "ComplexFixedListField": "VALUE2"
   },
@@ -25,19 +25,19 @@
       "document_url": "http://dm-store:8080/documents/7b8930ef-2bcd-44cd-8a78-1ae0b1f5a0ec",
       "document_filename": "Test.png",
       "document_binary_url": "http://dm-store:8080/documents/7b8930ef-2bcd-44cd-8a78-1ae0b1f5a0ec/binary",
-      "hashToken": "7b8930ef-2bcd-44cd-8a78-17b8930ef-27b8930ef-2bcd-44cd-8a78-1ae0b1f5a0ec"
+      "document_hash": "7b8930ef-2bcd-44cd-8a78-17b8930ef-27b8930ef-2bcd-44cd-8a78-1ae0b1f5a0ec"
     }
   },
   "DocumentField4": {
     "document_url": "http://dm-store:8080/documents/388a1ce0-f132-4680-90e9-5e782721cabb",
     "document_filename": "Screenshot 2020-03-17 at 1.24.43 pm.png",
     "document_binary_url": "http://dm-store:8080/documents/388a1ce0-f132-4680-90e9-5e782721cabb/binary",
-    "hashToken": "57e7fdf75e281aaa03a0f50f93e7b10bbebff162cf67a4531c4ec2509d615c0a"
+    "document_hash": "57e7fdf75e281aaa03a0f50f93e7b10bbebff162cf67a4531c4ec2509d615c0a"
   },
   "DocumentFieldWithoutBinaryUrl": {
     "document_url": "http://dm-store:8080/documents/5c4b5564-a29f-47d3-8c51-50e2d4629435",
     "document_filename": "File2.cr2",
-    "hashToken": "6a7e12164534a0c2252a94b308a2a185e46f89ab639c5342027b9cd393068bc"
+    "document_hash": "6a7e12164534a0c2252a94b308a2a185e46f89ab639c5342027b9cd393068bc"
   },
   "FixedListField": "VALUE2",
   "CollectionField": [
@@ -46,7 +46,7 @@
         "document_url": "http://dm-store:8080/documents/95f048e7-9574-4a3d-9189-986015276fd7",
         "document_filename": "DocumentField1InsideCollectionArray.png",
         "document_binary_url": "http://dm-store:8080/documents/95f048e7-9574-4a3d-9189-986015276fd7/binary",
-        "hashToken": "adfadfafgsdgsadgwrgsrg"
+        "document_hash": "adfadfafgsdgsadgwrgsrg"
       }
     },
     {
@@ -54,7 +54,7 @@
         "document_url": "http://dm-store:8080/documents/3ca8b55e-76fe-4723-bb60-4e14e950bb0c",
         "document_filename": "DocumentField2InsideCollectionArray.jpeg",
         "document_binary_url": "http://dm-store:8080/documents/3ca8b55e-76fe-4723-bb60-4e14e950bb0c/binary",
-        "hashToken": "sdg455sfgsfgfsgfsgsgsdgsdgsdgdsgs"
+        "document_hash": "sdg455sfgsfgfsgfsgsgsdgsdgsdgdsgs"
       }
     }
   ]

--- a/src/test/resources/tests/case-detail-after-update.json
+++ b/src/test/resources/tests/case-detail-after-update.json
@@ -54,7 +54,7 @@
     "DocumentField7" : {
       "document_url": "http://dm-store:8080/documents/8da17150-c001-47d7-bfeb-3dabed9e0976",
       "document_filename": "Screenshot 2020-02-24 at 13.32.03.Jpeg",
-      "hashToken": "41134reqrfadfed49edc151423fb7b2e1f22d87b2d041b34"
+      "document_hash": "41134reqrfadfed49edc151423fb7b2e1f22d87b2d041b34"
     },
     "NumberField" : null,
     "MultiSelectListField" : [ ],

--- a/src/test/resources/tests/case-detail-before.json
+++ b/src/test/resources/tests/case-detail-before.json
@@ -9,7 +9,7 @@
             "document_url": "http://dm-store:8080/documents/8da17150-c001-47d7-bfeb-3dabed9e0976",
             "document_filename": "Screenshot 2020-02-24 at 13.32.03.png",
             "document_binary_url": "http://dm-store:8080/documents/8da17150-c001-47d7-bfeb-3dabed9e0976/binary",
-            "hashToken": "dummyToken"
+            "document_hash": "dummyToken"
           }
         }
       ]

--- a/src/test/resources/tests/case-detail-plain-fields-update.json
+++ b/src/test/resources/tests/case-detail-plain-fields-update.json
@@ -9,7 +9,7 @@
             "document_url": "http://dm-store:8080/documents/8da17150-c001-47d7-bfeb-3dabed9e0976",
             "document_filename": "Screenshot 2020-02-24 at 13.32.03.png",
             "document_binary_url": "http://dm-store:8080/documents/8da17150-c001-47d7-bfeb-3dabed9e0976/binary",
-            "hashToken": "dummyToken"
+            "document_hash": "dummyToken"
           }
         }
       ]

--- a/src/test/resources/tests/new-document-with-hashtoken.json
+++ b/src/test/resources/tests/new-document-with-hashtoken.json
@@ -20,7 +20,7 @@
     "document_url": "http://dm-store:8080/documents/8da17150-c001-47d7-bfeb-3dabed9e0976",
     "document_filename": "Screenshot 2020-02-24 at 13.32.03.Jpeg",
     "document_binary_url": "http://dm-store:8080/documents/8da17150-c001-47d7-bfeb-3dabed9e0976/binary",
-    "hashToken": "36fc7aa586a54bffc2982ed490c4503f4aca875b7160c9d24b6690276886tytu"
+    "document_hash": "36fc7aa586a54bffc2982ed490c4503f4aca875b7160c9d24b6690276886tytu"
   },
   "timeline": [
     {
@@ -30,7 +30,7 @@
           "document_url": "http://dm-store:8080/documents/c1f160ca-cf52-4c0a-8376-3b51c340d00c",
           "document_filename": "AM-592 Attach case with V3 version.png",
           "document_binary_url": "http://dm-store:8080/documents/c1f160ca-cf52-4c0a-8376-3b51c340d00c/binary",
-          "hashToken": "36fc7aa586a54bffc2982ed490c4503f4aca875b7160c9d24b6690276886617d"
+          "document_hash": "36fc7aa586a54bffc2982ed490c4503f4aca875b7160c9d24b6690276886617d"
         },
         "description": null
       }


### PR DESCRIPTION
Addressed TODO in CaseDocumentUtils.java  : Renamed case data document json field hasToken to "document_hash". 

https://tools.hmcts.net/confluence/display/EUI/Expert+UI+-+Feature+Design+-+Secure+docstore

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
