### PR TITLE
RDM-12659 - Checking document id is accessible to user

### DIFF
--- a/src/aat/resources/features/F-1001/S-1052.td.json
+++ b/src/aat/resources/features/F-1001/S-1052.td.json
@@ -35,7 +35,7 @@
     "_extends_": "Common_404_Response",
     "body": {
       "exception" : "uk.gov.hmcts.ccd.domain.service.getcasedocument.CaseDocumentNotFoundException",
-      "message" : "No document found for this case reference: ${[scenarioContext][childContexts][S-1052-Case_Creation_Main][testData][actualResponse][body][id]}",
+      "message" : "Document ${[scenarioContext][testData][request][pathVariables][documentId]} is not found in the case : ${[scenarioContext][childContexts][S-1052-Case_Creation_Main][testData][actualResponse][body][id]}",
       "path" : "/cases/${[scenarioContext][childContexts][S-1052-Case_Creation_Main][testData][actualResponse][body][id]}/documents/${[scenarioContext][testData][request][pathVariables][documentId]}",
       "details" : null,
       "callbackErrors" : null,

--- a/src/aat/resources/features/F-1001/S-1053.td.json
+++ b/src/aat/resources/features/F-1001/S-1053.td.json
@@ -26,7 +26,7 @@
     "_extends_": "Common_404_Response",
     "body": {
       "exception" : "uk.gov.hmcts.ccd.domain.service.getcasedocument.CaseDocumentNotFoundException",
-      "message" : "No document found for this case reference: ${[scenarioContext][childContexts][S-1053-Case_Creation_Main][testData][actualResponse][body][id]}",
+      "message" : "Document ${[scenarioContext][testData][request][pathVariables][documentId]} is not found in the case : ${[scenarioContext][childContexts][S-1053-Case_Creation_Main][testData][actualResponse][body][id]}",
       "path" : "/cases/${[scenarioContext][childContexts][S-1053-Case_Creation_Main][testData][actualResponse][body][id]}/documents/${[scenarioContext][testData][request][pathVariables][documentId]}",
       "details" : null,
       "callbackErrors" : null,

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/getcasedocument/GetCaseDocumentOperation.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/getcasedocument/GetCaseDocumentOperation.java
@@ -1,20 +1,10 @@
 package uk.gov.hmcts.ccd.domain.service.getcasedocument;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Sets;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
-import uk.gov.hmcts.ccd.data.caseaccess.CachedCaseUserRepository;
-import uk.gov.hmcts.ccd.data.caseaccess.CaseUserRepository;
-import uk.gov.hmcts.ccd.data.user.CachedUserRepository;
-import uk.gov.hmcts.ccd.data.user.UserRepository;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseDetails;
-import uk.gov.hmcts.ccd.domain.model.definition.CaseFieldDefinition;
-import uk.gov.hmcts.ccd.domain.model.definition.CaseTypeDefinition;
-import uk.gov.hmcts.ccd.domain.service.common.AccessControlService;
-import uk.gov.hmcts.ccd.domain.service.common.CaseTypeService;
 import uk.gov.hmcts.ccd.domain.service.getcase.CaseNotFoundException;
 import uk.gov.hmcts.ccd.domain.service.getcase.CreatorGetCaseOperation;
 import uk.gov.hmcts.ccd.domain.service.getcase.GetCaseOperation;
@@ -23,173 +13,63 @@ import uk.gov.hmcts.ccd.v2.external.domain.CaseDocumentMetadata;
 import uk.gov.hmcts.ccd.v2.external.domain.DocumentPermissions;
 import uk.gov.hmcts.ccd.v2.external.domain.Permission;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import static uk.gov.hmcts.ccd.domain.service.common.AccessControlService.CAN_READ;
+import java.util.Map;
 
 @Service
 public class GetCaseDocumentOperation {
 
-    private final GetCaseOperation getCaseOperation;
-    private final CaseTypeService caseTypeService;
-    private final UserRepository userRepository;
-    private final CaseUserRepository caseUserRepository;
-    private final DocumentIdValidationService documentIdValidationService;
-    private final AccessControlService accessControlService;
+    private static final String DOCUMENT_BINARY_URL = "document_url";
+    private static final String BINARY_SUFFIX = "/binary";
+    private static final int DOC_UUID_LENGTH = 36;
+    private static final String BAD_REQUEST_EXCEPTION_DOCUMENT_INVALID = "DocumentId is not valid";
 
-    public static final String COMPLEX = "Complex";
-    public static final String COLLECTION = "Collection";
-    public static final String DOCUMENT = "Document";
-    public static final String DOCUMENT_CASE_FIELD_URL_ATTRIBUTE = "document_url";
-    public static final String DOCUMENT_CASE_FIELD_BINARY_ATTRIBUTE = "document_binary_url";
-    public static final String BAD_REQUEST_EXCEPTION_DOCUMENT_INVALID = "DocumentId is not valid";
-    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private final GetCaseOperation getCaseOperation;
+    private final DocumentIdValidationService documentIdValidationService;
 
     @Autowired
     public GetCaseDocumentOperation(
         @Qualifier(CreatorGetCaseOperation.QUALIFIER) final GetCaseOperation getCaseOperation,
-        final CaseTypeService caseTypeService,
-        @Qualifier(CachedUserRepository.QUALIFIER) UserRepository userRepository,
-        @Qualifier(CachedCaseUserRepository.QUALIFIER) CaseUserRepository caseUserRepository,
-        DocumentIdValidationService documentIdValidationService,
-        AccessControlService accessControlService) {
-
+        DocumentIdValidationService documentIdValidationService) {
         this.getCaseOperation = getCaseOperation;
-        this.caseTypeService = caseTypeService;
-        this.userRepository = userRepository;
-        this.caseUserRepository = caseUserRepository;
         this.documentIdValidationService = documentIdValidationService;
-        this.accessControlService = accessControlService;
     }
 
-
-    public CaseDocumentMetadata getCaseDocumentMetadata(String caseId, String documentId) {
+    public CaseDocumentMetadata getCaseDocumentMetadata(String caseReference, String documentId) {
 
         if (!documentIdValidationService.validateDocumentUUID(documentId)) {
             throw new BadRequestException(BAD_REQUEST_EXCEPTION_DOCUMENT_INVALID);
         }
 
-        final CaseDetails caseDetails = this.getCaseOperation.execute(caseId)
-            .orElseThrow(() -> new CaseNotFoundException(caseId));
+        // at this stage case data is filtered by user access permissions already.
+        final CaseDetails caseDetails = this.getCaseOperation.execute(caseReference)
+            .orElseThrow(() -> new CaseNotFoundException(caseReference));
 
-        if (caseDetails.getReferenceAsString() == null) {
-            throw new CaseNotFoundException(caseId);
-        }
+        boolean documentAccessible = isDocumentPresentInTheCaseData(documentId, caseDetails.getData());
 
-        return CaseDocumentMetadata.builder()
-            .caseId(caseDetails.getReferenceAsString())
-            .documentPermissions(getCaseDocument(caseDetails, documentId))
-            .build();
-
-    }
-
-    private DocumentPermissions getCaseDocument(CaseDetails caseDetails, String documentId) {
-
-        String caseTypeId = caseDetails.getCaseTypeId();
-        String jurisdictionId = caseDetails.getJurisdiction();
-        final CaseTypeDefinition caseType = caseTypeService.getCaseTypeForJurisdiction(caseTypeId, jurisdictionId);
-
-        List<CaseFieldDefinition> documentCaseFields = new ArrayList<>();
-        List<CaseFieldDefinition> documentAndComplexFields = caseType.getCaseFieldDefinitions()
-            .stream()
-            .filter(caseField -> (DOCUMENT.equalsIgnoreCase(caseField.getFieldTypeDefinition().getType()))
-                    || (COMPLEX.equalsIgnoreCase(caseField.getFieldTypeDefinition().getType()))
-                    || (COLLECTION.equalsIgnoreCase(caseField.getFieldTypeDefinition().getType())))
-            .collect(Collectors.toList());
-
-        if (documentAndComplexFields.isEmpty()) {
-            throw new CaseDocumentNotFoundException(
-                String.format("No document field found for CaseType : %s", caseType.getId()));
-        }
-
-        extractDocumentFieldsFromCaseDefinition(documentAndComplexFields, documentCaseFields);
-        JsonNode documentFieldsWithReadPermission = getDocumentFieldsWithReadPermission(caseDetails, documentCaseFields)
-            .orElseThrow((() ->
-                new CaseDocumentNotFoundException("User does not has read permissions on any document field")));
-
-
-        if (Boolean.TRUE.equals(isDocumentPresent(documentId, documentFieldsWithReadPermission))) {
-            //build caseDocument and set permissions
-            return DocumentPermissions.builder()
-                .id(documentId)
-                .permissions(Arrays.asList(Permission.READ))
+        if (documentAccessible) {
+            return CaseDocumentMetadata.builder()
+                .caseId(caseReference)
+                .documentPermissions(DocumentPermissions.builder()
+                    .id(documentId)
+                    .permissions(List.of(Permission.READ))
+                    .build())
                 .build();
-        } else {
-            throw new CaseDocumentNotFoundException(
-                String.format("No document found for this case reference: %s",
-                    caseDetails.getReferenceAsString()));
         }
+        throw new CaseDocumentNotFoundException(
+            String.format("Document %s is not found in the case : %s", documentId, caseReference));
     }
 
-    private Boolean isDocumentPresent(String documentId, JsonNode documentFieldsWithReadPermission) {
-        for (JsonNode jsonNode : documentFieldsWithReadPermission) {
-            if ((jsonNode.get(DOCUMENT_CASE_FIELD_BINARY_ATTRIBUTE) != null
-                && jsonNode.get(DOCUMENT_CASE_FIELD_BINARY_ATTRIBUTE).asText().contains(documentId))
-                || (jsonNode.get(DOCUMENT_CASE_FIELD_URL_ATTRIBUTE) != null
-                && jsonNode.get(DOCUMENT_CASE_FIELD_URL_ATTRIBUTE).asText().contains(documentId))) {
-                return true;
-            }
-        }
-        return false;
+    private boolean isDocumentPresentInTheCaseData(String documentId, Map<String, JsonNode> data) {
+        return data.values().stream()
+            .map(node -> node.findValuesAsText(DOCUMENT_BINARY_URL))
+            .flatMap(List::stream)
+            .anyMatch(binaryLink -> isDocumentIdMatches(binaryLink, documentId));
     }
 
-    void extractDocumentFieldsFromCaseDefinition(List<CaseFieldDefinition> complexCaseFieldList,
-                                                  List<CaseFieldDefinition> documentCaseFields) {
-        if (complexCaseFieldList != null && !complexCaseFieldList.isEmpty()) {
-            for (CaseFieldDefinition caseField : complexCaseFieldList) {
-                getDocumentFields(documentCaseFields, caseField);
-            }
-        }
+    private boolean isDocumentIdMatches(String binaryLink, String documentId) {
+        String selfHref = binaryLink.replace(BINARY_SUFFIX, "");
+        return documentId.equalsIgnoreCase(selfHref.substring(selfHref.length() - DOC_UUID_LENGTH));
     }
 
-    private void getDocumentFields(List<CaseFieldDefinition> documentCaseFields, CaseFieldDefinition caseField) {
-        switch (caseField.getFieldTypeDefinition().getType()) {
-            case DOCUMENT:
-                documentCaseFields.add(caseField);
-                break;
-            case COMPLEX:
-            case COLLECTION:
-                if (caseField.getFieldTypeDefinition().getCollectionFieldTypeDefinition() != null) {
-                    if (caseField.getFieldTypeDefinition().getCollectionFieldTypeDefinition().getComplexFields()
-                            != null) {
-                        extractDocumentFieldsFromCaseDefinition(
-                            caseField.getFieldTypeDefinition().getCollectionFieldTypeDefinition().getComplexFields(),
-                            documentCaseFields);
-                    }
-                    if (caseField.getFieldTypeDefinition().getCollectionFieldTypeDefinition()
-                            .getCollectionFieldTypeDefinition() != null) {
-                        extractDocumentFieldsFromCaseDefinition(
-                            caseField.getFieldTypeDefinition().getCollectionFieldTypeDefinition()
-                                .getCollectionFieldTypeDefinition().getComplexFields(), documentCaseFields);
-                    }
-                }
-                extractDocumentFieldsFromCaseDefinition(caseField.getFieldTypeDefinition().getComplexFields(),
-                                                        documentCaseFields);
-                break;
-            default:
-                break;
-        }
-    }
-
-    private Optional<JsonNode> getDocumentFieldsWithReadPermission(CaseDetails caseDetails,
-                                                                   List<CaseFieldDefinition> documentFields) {
-        Set<String> roles = getUserRoles(caseDetails.getId());
-        return Optional.of(accessControlService.filterCaseFieldsByAccess(
-            MAPPER.convertValue(caseDetails.getData(), JsonNode.class),
-            documentFields,
-            roles,
-            CAN_READ, true));
-    }
-
-    private Set<String> getUserRoles(String caseId) {
-        return Sets.union(userRepository.getUserRoles(),
-            new HashSet<>(caseUserRepository
-                .findCaseRoles(Long.valueOf(caseId), userRepository.getUserId())));
-    }
 }

--- a/src/main/java/uk/gov/hmcts/ccd/v2/external/controller/CaseDocumentController.java
+++ b/src/main/java/uk/gov/hmcts/ccd/v2/external/controller/CaseDocumentController.java
@@ -28,16 +28,12 @@ public class CaseDocumentController {
 
     @GetMapping(
         path = "/{caseId}/documents/{documentId}",
-        headers = {
-            V2.EXPERIMENTAL_HEADER
-        },
         produces = {
             V2.MediaType.CASE_DOCUMENT
         }
     )
     @ApiOperation(
-        value = "Retrieve a case document metadata by case and document Id",
-        notes = V2.EXPERIMENTAL_WARNING
+        value = "Retrieve a case document metadata by case and document Id"
     )
     @ApiResponses({
         @ApiResponse(

--- a/src/test/java/uk/gov/hmcts/ccd/v2/external/controller/CaseControllerEventsIT.java
+++ b/src/test/java/uk/gov/hmcts/ccd/v2/external/controller/CaseControllerEventsIT.java
@@ -1,8 +1,6 @@
 package uk.gov.hmcts.ccd.v2.external.controller;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import org.apache.commons.lang.RandomStringUtils;
 import org.junit.Before;
@@ -16,14 +14,10 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import uk.gov.hmcts.ccd.MockUtils;
 import uk.gov.hmcts.ccd.WireMockBaseTest;
-import uk.gov.hmcts.ccd.domain.service.getcasedocument.GetCaseDocumentsOperationTest;
 import uk.gov.hmcts.ccd.v2.V2;
 import uk.gov.hmcts.ccd.v2.external.resource.CaseEventsResource;
 
 import javax.inject.Inject;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.HashMap;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
@@ -124,11 +118,5 @@ public class CaseControllerEventsIT extends WireMockBaseTest {
     private void assertCaseDataResultSetSize() {
         final int count = template.queryForObject("SELECT count(1) as n FROM case_data", Integer.class);
         assertEquals("Incorrect case data size", NUMBER_OF_CASES, count);
-    }
-
-    static HashMap<String, JsonNode> buildCaseDetailData(String fileName) throws IOException {
-        InputStream inputStream =
-            GetCaseDocumentsOperationTest.class.getClassLoader().getResourceAsStream("tests/".concat(fileName));
-        return mapper.readValue(inputStream, new TypeReference<>() {});
     }
 }

--- a/src/test/resources/tests/case-details-data.json
+++ b/src/test/resources/tests/case-details-data.json
@@ -1,50 +1,163 @@
 {
-  "DocumentField4" : {
-    "document_url" : "http://dm-store:8080/documents/f5bd63a2-65c5-435e-a972-98ed658ad7d6",
-    "document_filename" : "Screenshot 2020-03-05 at 08.53.03.png",
-    "document_binary_url" : "http://dm-store:8080/documents/f5bd63a2-65c5-435e-a972-98ed658ad7d6/binary"
+
+  "state": [
+    {
+      "id": "01827252-e41c-476a-aec0-29ef33fdb8f9",
+      "value": {
+        "partyName": null,
+        "partyDetail": [
+          {
+            "id": "bf0c087a-cee6-4e6e-b91c-b06a5b4c2e1f",
+            "value": {
+              "type": {
+                "document_url": "http://dm-store:8080/documents/5a16b8ed-c62f-41b3-b3c9-1df20b6a9979",
+                "document_filename": "E_1_AA_Claimant details.xlsx",
+                "document_binary_url": "http://dm-store:8080/documents/5a16b8ed-c62f-41b3-b3c9-1df20b6a9979/binary"
+              },
+              "description": null
+            }
+          },
+          {
+            "id": "6dc61824-49f8-413e-b61f-a399b9c8436b",
+            "value": {
+              "type": {
+                "document_url": "http://dm-store:8080/documents/19de0db3-37c6-4191-a81d-c31a1379a9ca",
+                "document_filename": "E_1_BBClaimant details.xlsx",
+                "document_binary_url": "http://dm-store:8080/documents/19de0db3-37c6-4191-a81d-c31a1379a9ca/binary"
+              },
+              "description": null
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "c7327e34-48b1-4b5f-8663-5bad84964fb9",
+      "value": {
+        "partyName": null,
+        "partyDetail": [
+          {
+            "id": "f63ebcbc-9abf-40f9-9546-8da5375de65c",
+            "value": {
+              "type": {
+                "document_url": "http://dm-store:8080/documents/f51456a2-7b25-4855-844a-81c9763bc02c",
+                "document_filename": "E_2_AA_Claimant details.xlsx",
+                "document_binary_url": "http://dm-store:8080/documents/f51456a2-7b25-4855-844a-81c9763bc02c/binary"
+              },
+              "description": null
+            }
+          },
+          {
+            "id": "81998007-6fe6-4e1e-97ab-cd8e8fb05090",
+            "value": {
+              "type": {
+                "document_url": "http://dm-store:8080/documents/2b01ebbc-d6e5-4ee5-9a80-58b28cb623ec",
+                "document_filename": "E_2_BB_Claimant details.xlsx",
+                "document_binary_url": "http://dm-store:8080/documents/2b01ebbc-d6e5-4ee5-9a80-58b28cb623ec/binary"
+              },
+              "description": null
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "afa735d8-686d-40ed-b43d-0bd875b771b1",
+      "value": {
+        "partyName": null,
+        "partyDetail": [
+          {
+            "id": "45c8633f-6298-4f4f-97df-016e16a18d35",
+            "value": {
+              "type": {
+                "document_url": "http://dm-store:8080/documents/c6924316-4146-441d-a66d-6e181c48cb09",
+                "document_filename": "E_3_AA_Claimant details.pdf",
+                "document_binary_url": "http://dm-store:8080/documents/c6924316-4146-441d-a66d-6e181c48cb09/binary"
+              },
+              "description": null
+            }
+          },
+          {
+            "id": "958df3a9-9a57-4717-99ed-63a7cfc3e0e2",
+            "value": {
+              "type": {
+                "document_url": "http://dm-store:8080/documents/77ad6295-59ce-4167-8f1e-4aa711ba2c00",
+                "document_filename": "E_3_BB_Claimant details.pdf",
+                "document_binary_url": "http://dm-store:8080/documents/77ad6295-59ce-4167-8f1e-4aa711ba2c00/binary"
+              },
+              "description": null
+            }
+          },
+          {
+            "id": "930d2fe8-c0fa-4cde-9e81-6fa39ddf4441",
+            "value": {
+              "type": {
+                "document_url": "http://dm-store:8080/documents/80e9471e-0f67-42ef-8739-170aa1942363",
+                "document_filename": "E_3_CC_Claimant details.pdf",
+                "document_binary_url": "http://dm-store:8080/documents/80e9471e-0f67-42ef-8739-170aa1942363/binary"
+              },
+              "description": null
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "evidence": {
+    "type": {
+      "document_url": "http://dm-store:8080/documents/84f04693-56ae-4aad-97e8-d1fc7592acea",
+      "document_filename": "B_Document Inside Complex Type.docx",
+      "document_binary_url": "http://dm-store:8080/documents/84f04693-56ae-4aad-97e8-d1fc7592acea/binary"
+    },
+    "description": null
   },
-  "MoneyGBPField" : "750000",
-  "DocumentField3" : {
-    "document_url" : "http://dm-store:8080/documents/320233b8-fb61-4b58-8731-23c83638c9c6",
-    "document_filename" : "Screenshot 2020-02-26 at 10.07.51.png",
-    "document_binary_url" : "http://dm-store:8080/documents/320233b8-fb61-4b58-8731-23c83638c9c6/binary"
+  "timeline": [
+    {
+      "id": "a9d8c414-32c5-4b8c-bfa1-a56d5aa95233",
+      "value": {
+        "type": {
+          "document_url": "http://dm-store:8080/documents/f8e7f506-e8bd-4886-bd08-d4f70e9c84f6",
+          "document_filename": "D_1_Collection of Complex Type with Documents.docx",
+          "document_binary_url": "http://dm-store:8080/documents/f8e7f506-e8bd-4886-bd08-d4f70e9c84f6/binary"
+        },
+        "description": null
+      }
+    },
+    {
+      "id": "12f2e482-b8e3-48cf-8c14-feaefdb09018",
+      "value": {
+        "type": {
+          "document_url": "http://dm-store:8080/documents/cdab9cf7-1b38-4245-9c91-e098d28f6404",
+          "document_filename": "D_2_Collection of Complex Type with Documents.docx",
+          "document_binary_url": "http://dm-store:8080/documents/cdab9cf7-1b38-4245-9c91-e098d28f6404/binary"
+        },
+        "description": null
+      }
+    }
+  ],
+  "draftOrderDoc": {
+    "document_url": "http://dm-store:8080/documents/a780ee98-3136-4be9-bf56-a46f8da1bc97",
+    "document_filename": "A_Simple Document.docx",
+    "document_binary_url": "http://dm-store:8080/documents/a780ee98-3136-4be9-bf56-a46f8da1bc97/binary"
   },
-  "DocumentField7" : {
-    "document_url": "http://dm-store:8080/documents/8da17150-c001-47d7-bfeb-3dabed9e0976",
-    "document_filename": "Screenshot 2020-02-24 at 13.32.03.png",
-    "document_binary_url": "http://dm-store:8080/documents/8da17150-c001-47d7-bfeb-3dabed9e0976/binary"
-  },
-  "FixedListField" : null,
-  "AddressUKField" : {
-    "County" : null,
-    "Country" : null,
-    "PostCode" : null,
-    "PostTown" : null,
-    "AddressLine1" : null,
-    "AddressLine2" : null,
-    "AddressLine3" : null
-  },
-  "DocumentField6" : {
-    "document_url" : "http://dm-store:8080/documents/b5eb1f0e-64cd-4ccb-996a-6915c28fa65d",
-    "document_filename" : "Screenshot 2020-03-24 at 08.38.47.png",
-    "document_binary_url" : "http://dm-store:8080/documents/b5eb1f0e-64cd-4ccb-996a-6915c28fa65d/binary"
-  },
-  "DocumentField5" : {
-    "document_url" : "http://dm-store:8080/documents/0dfa903c-993d-4fa4-9bc4-b97d6352b862",
-    "document_filename" : "Screenshot 2020-03-03 at 16.56.56.png",
-    "document_binary_url" : "http://dm-store:8080/documents/0dfa903c-993d-4fa4-9bc4-b97d6352b862/binary"
-  },
-  "DocumentField2" : {
-    "document_url" : "http://dm-store:8080/documents/e16f2ae0-d6ce-4bd0-a652-47b3c4d86292",
-    "document_filename" : "Screenshot 2020-02-19 at 17.17.42.png",
-    "document_binary_url" : "http://dm-store:8080/documents/e16f2ae0-d6ce-4bd0-a652-47b3c4d86292/binary"
-  },
-  "DocumentField1" : {
-    "document_url" : "http://dm-store:8080/documents/b5eb1f0e-64cd-4ccb-996a-6915c28fa65d",
-    "document_filename" : "Screenshot 2020-03-24 at 08.38.47.png",
-    "document_binary_url" : "http://dm-store:8080/documents/b5eb1f0e-64cd-4ccb-996a-6915c28fa65d/binary"
-  },
+  "extraDocUploadList": [
+    {
+      "id": "90a2df83-f256-43ec-aaa0-48e127a44402",
+      "value": {
+        "document_url": "http://dm-store:8080/documents/7654b1e0-5df6-47c4-a5a0-3ec79fc78cfb",
+        "document_filename": "C_1_Collection of Documents.docx",
+        "document_binary_url": "http://dm-store:8080/documents/7654b1e0-5df6-47c4-a5a0-3ec79fc78cfb/binary"
+      }
+    },
+    {
+      "id": "84e22baf-5bec-4eec-a31f-7a3954efc9c3",
+      "value": {
+        "document_url": "http://dm-store:8080/documents/f6d623f2-db67-4a01-ae6e-3b6ee14a8b20",
+        "document_filename": "C_2_Collection of Documents.docx",
+        "document_binary_url": "http://dm-store:8080/documents/f6d623f2-db67-4a01-ae6e-3b6ee14a8b20/binary"
+      }
+    }
+  ],
   "ComplexField" : {
     "ComplexTextField" : null,
     "ComplexNestedField" : {


### PR DESCRIPTION
This PR re-implemented  logic to find out case document access for the invoked user. API retrieves the case data and applies standard case access control based on the user details passed in the Authorization header token. It then traverses the case to build a list of the documents which have passed access control.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDM-12659

### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
