### PR TITLE
adding Scenario: User submits case creation with no CaseType R Access…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -787,7 +787,7 @@ task functional() {
             args = [
                      '--threads', '10',
                      '--plugin', "json:${rootDir}/target/cucumber.json",
-                     '--tags', '@F-130',
+                     '--tags', 'not @Ignore',
                      '--glue', 'uk.gov.hmcts.befta.player',
                      '--glue', 'uk.gov.hmcts.ccd.datastore.befta', 'src/aat/resources/features'
                    ]

--- a/build.gradle
+++ b/build.gradle
@@ -249,7 +249,7 @@ dependencies {
         exclude group: 'org.apache.logging.log4j', module: 'log4j-api'
     }
     compile 'org.jooq:jool-java-8:0.9.14'
-    testCompile group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.3.2-prerelease'
+    testCompile group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.3.3-prerelease'
     testCompile group: 'com.github.hmcts', name: 'befta-fw', version: '8.2.0'
 
     contractTestCompile group: 'au.com.dius.pact.provider', name: 'junit5', version: versions.pact_version
@@ -787,7 +787,7 @@ task functional() {
             args = [
                      '--threads', '10',
                      '--plugin', "json:${rootDir}/target/cucumber.json",
-                     '--tags', 'not @Ignore',
+                     '--tags', '@F-130',
                      '--glue', 'uk.gov.hmcts.befta.player',
                      '--glue', 'uk.gov.hmcts.ccd.datastore.befta', 'src/aat/resources/features'
                    ]

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -30,6 +30,8 @@
 	<suppress>
 		<cve>CVE-2021-29425</cve>
 		<cve>CVE-2021-27568</cve>
+		<cve>CVE-2021-33037</cve>
+		<cve>CVE-2021-30640</cve>
 	</suppress>
 
 </suppressions>

--- a/src/aat/resources/features/F-130 - Access Control CRUD/F-130.feature
+++ b/src/aat/resources/features/F-130 - Access Control CRUD/F-130.feature
@@ -26,3 +26,13 @@ Feature: Create Case External API CRUD Tests
     Then a negative response is received
     And the response has all other details as expected
     And the response [contains an error stating that the field cannot be found]
+
+  @S-130.7
+  Scenario: User submits case creation with no CaseType R Access does not return the case after successful case creation
+    Given a user with [an active profile in CCD]
+    And a successful call [to create a token for case creation] as in [S-130.1_Get_Event_Trigger]
+    When a request is prepared with appropriate values,
+    And it is submitted to call the [external create case] operation of [CCD Data Store],
+    Then a negative response is received
+    And the response has all other details as expected
+    And the response [contains an error stating that the case details is marked as non-null but is null]

--- a/src/aat/resources/features/F-130 - Access Control CRUD/S-130.7.td.json
+++ b/src/aat/resources/features/F-130 - Access Control CRUD/S-130.7.td.json
@@ -8,7 +8,7 @@
 
   "request": {
     "pathVariables": {
-      "ctid": "FT_CRUD_4"
+      "ctid": "FT_CRUD_2"
     },
     "body": {
       "data":
@@ -33,7 +33,7 @@
       "status": 500,
       "error": "Unexpected Error",
       "message": "caseDetails is marked non-null but is null",
-      "path": "/case-types/FT_CRUD_4/cases",
+      "path": "/case-types/FT_CRUD_2/cases",
       "details": null,
       "callbackErrors": null,
       "callbackWarnings": null

--- a/src/aat/resources/features/F-130 - Access Control CRUD/S-130.7.td.json
+++ b/src/aat/resources/features/F-130 - Access Control CRUD/S-130.7.td.json
@@ -1,0 +1,42 @@
+{
+  "_guid_": "S-130.7",
+  "_extends_" : "F-130_Test_Data_Base",
+
+  "specs" : [
+    "contains an error stating that the case details is marked as non-null but is null"
+  ],
+
+  "request": {
+    "pathVariables": {
+      "ctid": "FT_CRUD_4"
+    },
+    "body": {
+      "data":
+      {
+        "TextField": "value1"
+      },
+      "event": {
+        "id": "createCase"
+      },
+      "event_token": "${[scenarioContext][childContexts][S-130.1_Get_Event_Trigger][testData][actualResponse][body][token]}",
+      "event_data": {
+        "TextField": "value1"
+      }
+    }
+  },
+
+  "expectedResponse": {
+    "responseCode": 500,
+    "body" : {
+      "exception": "java.lang.NullPointerException",
+      "timestamp": "[[ANYTHING_PRESENT]]",
+      "status": 500,
+      "error": "Unexpected Error",
+      "message": "caseDetails is marked non-null but is null",
+      "path": "/case-types/FT_CRUD_4/cases",
+      "details": null,
+      "callbackErrors": null,
+      "callbackWarnings": null
+    }
+  }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDM-12531

### Change description ###

Added the following:
Scenario: User submits case creation with no CaseType R Access does not return the case after successful case creation

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
