### PR TITLE
CCD-1330: Updated CVE suppression dates to 25/08/2021

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -2,17 +2,19 @@
 <suppressions
 	xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
 
-	<suppress until="2021-07-25">
+	<suppress until="2021-08-25">
 		<notes>We do not use: Spring Framework 5.0.5.RELEASE + Spring Security
 			(any version), see https://pivotal.io/security/cve-2018-1258
 			False positive confirmed.
+			Last control version: 5.5.1
 		</notes>
 		<cve>CVE-2018-1258</cve>
 	</suppress>
 
-	<suppress until="2021-07-25">
+	<suppress until="2021-08-25">
 		<notes>These CVE's are coming from Dhowden tag library and it impacts only MP3/MP4/OGG/FLAC metadata parsing
 			library. Also it is declared as false positive in https://github.com/jeremylong/DependencyCheck/issues/3043
+			Last control version: 1.5
 		</notes>
 		<cve>CVE-2020-29242</cve>
 		<cve>CVE-2020-29243</cve>
@@ -20,9 +22,10 @@
 		<cve>CVE-2020-29245</cve>
 	</suppress>
 
-	<suppress until="2021-07-25">
+	<suppress until="2021-08-25">
 		<notes>Declared as False Positive on com.nimbusds:oauth2-oidc-sdk #2866
 			https://github.com/jeremylong/DependencyCheck/issues/2866
+			Last control version: 9.10.1
 		</notes>
 		<cve>CVE-2007-1651</cve>
 		<cve>CVE-2007-1652</cve>


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-1330 (https://tools.hmcts.net/jira/browse/CCD-1330)
https://tools.hmcts.net/jira/browse/CCD-1677
https://tools.hmcts.net/jira/browse/CCD-1678
https://tools.hmcts.net/jira/browse/CCD-1679
https://tools.hmcts.net/jira/browse/CCD-1680
https://tools.hmcts.net/jira/browse/CCD-1681
https://tools.hmcts.net/jira/browse/CCD-1682
https://tools.hmcts.net/jira/browse/CCD-1683

### Change description ###
Updated CVE suppression dates to 25/08/2021


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
