### PR TITLE
RDM-10918: Migrate Revoke Access APIs to new Access Control

### DIFF
--- a/src/main/java/uk/gov/hmcts/ccd/ApplicationParams.java
+++ b/src/main/java/uk/gov/hmcts/ccd/ApplicationParams.java
@@ -303,6 +303,10 @@ public class ApplicationParams {
         return roleAssignmentServiceHost + "/am/role-assignments";
     }
 
+    public String amDeleteByQueryRoleAssignmentsURL() {
+        return roleAssignmentBaseURL() + "/query/delete";
+    }
+
     public String amGetRoleAssignmentsURL() {
         return roleAssignmentBaseURL() + "/actors/{uid}";
     }

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedataaccesscontrol/CachedRoleAssignmentRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedataaccesscontrol/CachedRoleAssignmentRepository.java
@@ -31,6 +31,11 @@ public class CachedRoleAssignmentRepository implements RoleAssignmentRepository 
     }
 
     @Override
+    public void deleteRoleAssignmentsByQuery(List<RoleAssignmentQuery> queryRequests) {
+        roleAssignmentRepository.deleteRoleAssignmentsByQuery(queryRequests);
+    }
+
+    @Override
     public RoleAssignmentResponse getRoleAssignments(String userId) {
         return roleAssignments.computeIfAbsent(userId, e -> roleAssignmentRepository.getRoleAssignments(userId));
     }
@@ -39,4 +44,5 @@ public class CachedRoleAssignmentRepository implements RoleAssignmentRepository 
     public RoleAssignmentResponse findRoleAssignmentsByCasesAndUsers(List<String> caseIds, List<String> userIds) {
         return roleAssignmentRepository.findRoleAssignmentsByCasesAndUsers(caseIds,userIds);
     }
+
 }

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedataaccesscontrol/DefaultRoleAssignmentRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedataaccesscontrol/DefaultRoleAssignmentRepository.java
@@ -83,6 +83,28 @@ public class DefaultRoleAssignmentRepository implements RoleAssignmentRepository
     }
 
     @Override
+    public void deleteRoleAssignmentsByQuery(List<RoleAssignmentQuery> queryRequests) {
+        try {
+            final HttpEntity<Object> requestEntity = new HttpEntity<>(
+                MultipleQueryRequestResource.builder().queryRequests(queryRequests).build(),
+                securityUtils.authorizationHeaders()
+            );
+
+            restTemplate.exchange(
+                applicationParams.amDeleteByQueryRoleAssignmentsURL(),
+                HttpMethod.POST,
+                requestEntity,
+                Void.class
+            );
+
+        } catch (HttpStatusCodeException e) {
+            log.warn("Error while deleting Role Assignments", e);
+            throw mapException(e, "deleting");
+        }
+
+    }
+
+    @Override
     public RoleAssignmentResponse getRoleAssignments(String userId) {
         try {
             HttpHeaders headers = securityUtils.authorizationHeaders();

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedataaccesscontrol/MultipleQueryRequestResource.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedataaccesscontrol/MultipleQueryRequestResource.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.ccd.data.casedataaccesscontrol;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.extern.jackson.Jacksonized;
+
+import java.util.List;
+
+@Builder
+@Getter
+@Jacksonized
+public class MultipleQueryRequestResource {
+
+    List<RoleAssignmentQuery> queryRequests;
+
+}

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedataaccesscontrol/MultipleQueryRequestResource.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedataaccesscontrol/MultipleQueryRequestResource.java
@@ -11,6 +11,6 @@ import java.util.List;
 @Jacksonized
 public class MultipleQueryRequestResource {
 
-    List<RoleAssignmentQuery> queryRequests;
+    private final List<RoleAssignmentQuery> queryRequests;
 
 }

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedataaccesscontrol/RoleAssignmentQuery.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedataaccesscontrol/RoleAssignmentQuery.java
@@ -26,4 +26,12 @@ public class RoleAssignmentQuery {
         this.attributes = Attributes.builder().caseId(caseIds).build();
         this.roleType = List.of(RoleType.CASE.name());
     }
+
+    public RoleAssignmentQuery(String caseId, String userId, List<String> roleNames) {
+        this.actorId = List.of(userId);
+        this.attributes = Attributes.builder().caseId(List.of(caseId)).build();
+        this.roleType = List.of(RoleType.CASE.name());
+        this.roleName = roleNames;
+    }
+
 }

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedataaccesscontrol/RoleAssignmentRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedataaccesscontrol/RoleAssignmentRepository.java
@@ -8,6 +8,8 @@ public interface RoleAssignmentRepository {
 
     RoleAssignmentRequestResponse createRoleAssignment(RoleAssignmentRequestResource assignmentRequest);
 
+    void deleteRoleAssignmentsByQuery(List<RoleAssignmentQuery> queryRequests);
+
     RoleAssignmentResponse getRoleAssignments(String userId);
 
     RoleAssignmentResponse findRoleAssignmentsByCasesAndUsers(List<String> caseIds, List<String> userIds);

--- a/src/main/java/uk/gov/hmcts/ccd/domain/model/casedataaccesscontrol/RoleAssignmentsDeleteRequest.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/model/casedataaccesscontrol/RoleAssignmentsDeleteRequest.java
@@ -1,0 +1,18 @@
+package uk.gov.hmcts.ccd.domain.model.casedataaccesscontrol;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Builder
+@Getter
+public class RoleAssignmentsDeleteRequest {
+
+    String caseId;
+
+    String userId;
+
+    List<String> roleNames;
+
+}

--- a/src/main/java/uk/gov/hmcts/ccd/domain/model/casedataaccesscontrol/RoleAssignmentsDeleteRequest.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/model/casedataaccesscontrol/RoleAssignmentsDeleteRequest.java
@@ -9,10 +9,10 @@ import java.util.List;
 @Getter
 public class RoleAssignmentsDeleteRequest {
 
-    String caseId;
+    private final String caseId;
 
-    String userId;
+    private final String userId;
 
-    List<String> roleNames;
+    private final List<String> roleNames;
 
 }

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/caseaccess/CaseAccessOperation.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/caseaccess/CaseAccessOperation.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.ccd.data.caseaccess.GlobalCaseRole;
 import uk.gov.hmcts.ccd.data.casedetails.CachedCaseDetailsRepository;
 import uk.gov.hmcts.ccd.data.casedetails.CaseDetailsRepository;
 import uk.gov.hmcts.ccd.data.casedetails.supplementarydata.SupplementaryDataRepository;
+import uk.gov.hmcts.ccd.domain.model.casedataaccesscontrol.RoleAssignmentsDeleteRequest;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseDetails;
 import uk.gov.hmcts.ccd.domain.model.std.CaseAssignedUserRole;
 import uk.gov.hmcts.ccd.domain.model.std.CaseAssignedUserRoleWithOrganisation;
@@ -83,7 +84,17 @@ public class CaseAccessOperation {
         final Optional<CaseDetails> maybeCase = caseDetailsRepository.findByReference(jurisdictionId,
             Long.valueOf(caseReference));
         final var caseDetails = maybeCase.orElseThrow(() -> new CaseNotFoundException(caseReference));
-        caseUserRepository.revokeAccess(Long.valueOf(caseDetails.getId()), userId, CREATOR.getRole());
+
+        if (applicationParams.getEnableAttributeBasedAccessControl()) {
+            var deleteRequest = RoleAssignmentsDeleteRequest.builder()
+                    .caseId(caseReference)
+                    .userId(userId)
+                    .roleNames(List.of(CREATOR.getRole()))
+                    .build();
+            roleAssignmentService.deleteRoleAssignments(List.of(deleteRequest));
+        } else {
+            caseUserRepository.revokeAccess(Long.valueOf(caseDetails.getId()), userId, CREATOR.getRole());
+        }
     }
 
     @Transactional
@@ -186,19 +197,49 @@ public class CaseAccessOperation {
         Map<CaseDetails, List<CaseAssignedUserRoleWithOrganisation>> cauRolesByCaseDetails =
             getMapOfCaseAssignedUserRolesByCaseDetails(caseUserRoles);
 
-        // Ignore case user role mappings that are NOT exist in the database silently.
-        // Also they shouldn't effect counters.
+        // Ignore case user role mappings that DO NOT exist
+        // NB: also required so they don't effect revoked user counts.
         Map<CaseDetails, List<CaseAssignedUserRoleWithOrganisation>> filteredCauRolesByCaseDetails =
-            filterExistingCauRoles(cauRolesByCaseDetails);
+            findAndFilterOnExistingCauRoles(cauRolesByCaseDetails);
 
-        filteredCauRolesByCaseDetails.forEach((caseDetails, requestedAssignments) -> {
-                Long caseId = Long.parseLong(caseDetails.getId());
-                requestedAssignments.forEach(requestedAssignment ->
-                    caseUserRepository.revokeAccess(caseId, requestedAssignment.getUserId(),
-                        requestedAssignment.getCaseRole())
-                );
-            }
-        );
+        if (applicationParams.getEnableAttributeBasedAccessControl()) {
+            List<RoleAssignmentsDeleteRequest> deleteRequests = new ArrayList<>();
+
+            // group by case
+            filteredCauRolesByCaseDetails.forEach((caseDetails, requestedAssignments) -> {
+                // group by user
+                Map<String, List<String>> caseRolesByUserAndCase = requestedAssignments.stream()
+                    .collect(Collectors.groupingBy(
+                        CaseAssignedUserRoleWithOrganisation::getUserId,
+                        Collectors.collectingAndThen(
+                            Collectors.toList(),
+                            roles -> roles.stream()
+                                .map(CaseAssignedUserRoleWithOrganisation::getCaseRole)
+                                .collect(Collectors.toList())
+                        )));
+
+                // for each user in case: add list of all case-roles to revoke to the delete requests
+                caseRolesByUserAndCase.forEach((userId, roleNames) ->
+                    deleteRequests.add(RoleAssignmentsDeleteRequest.builder()
+                        .caseId(caseDetails.getReferenceAsString())
+                        .userId(userId)
+                        .roleNames(roleNames)
+                        .build()
+                ));
+            });
+
+            // submit list of all delete requests
+            roleAssignmentService.deleteRoleAssignments(deleteRequests);
+        } else {
+            filteredCauRolesByCaseDetails.forEach((caseDetails, requestedAssignments) -> {
+                    Long caseId = Long.parseLong(caseDetails.getId());
+                    requestedAssignments.forEach(requestedAssignment ->
+                        caseUserRepository.revokeAccess(caseId, requestedAssignment.getUserId(),
+                            requestedAssignment.getCaseRole())
+                    );
+                }
+            );
+        }
 
         // determine counters after removal of requested mappings so that same function can be re-used
         // (i.e user still has an association to a case).
@@ -213,45 +254,37 @@ public class CaseAccessOperation {
         );
     }
 
-    private Map<CaseDetails, List<CaseAssignedUserRoleWithOrganisation>> filterExistingCauRoles(
+    private Map<CaseDetails, List<CaseAssignedUserRoleWithOrganisation>> findAndFilterOnExistingCauRoles(
         Map<CaseDetails, List<CaseAssignedUserRoleWithOrganisation>> cauRolesByCaseDetails
     ) {
-        List<Long> caseIds = getCaseIdsFromMap(cauRolesByCaseDetails);
-        List<String> userIds = getUserIdsFromMap(cauRolesByCaseDetails);
-
-        // find existing Case-User relationships for all the cases + users found
-        Map<Long, List<CaseUserEntity>> existingCaseUserRolesByCaseId =
-            caseUserRepository.findCaseUserRoles(caseIds, userIds).stream()
+        // find existing Case-User relationships and group by case reference
+        Map<String, List<CaseAssignedUserRole>> existingCaseUserRolesByCaseReference =
+            findCaseUserRoles(cauRolesByCaseDetails).stream()
                 .collect(Collectors.groupingBy(
-                    caseUserEntity -> caseUserEntity.getCasePrimaryKey().getCaseDataId(),
+                    CaseAssignedUserRole::getCaseDataId,
                     Collectors.toList()
                 ));
 
         return cauRolesByCaseDetails.entrySet().stream()
             .collect(Collectors.toMap(Map.Entry::getKey,
-                entry -> filterExistingCauRoles(
+                entry -> filterOnExistingCauRoles(
                     entry.getValue(),
-                    existingCaseUserRolesByCaseId.getOrDefault(
-                        Long.parseLong(entry.getKey().getId()),
+                    existingCaseUserRolesByCaseReference.getOrDefault(
+                        entry.getKey().getReferenceAsString(),
                         new ArrayList<>()
                     )
                 )));
     }
 
-    private List<CaseAssignedUserRoleWithOrganisation> filterExistingCauRoles(
+    private List<CaseAssignedUserRoleWithOrganisation> filterOnExistingCauRoles(
         List<CaseAssignedUserRoleWithOrganisation> inputCauRoles,
-        List<CaseUserEntity> existingCauRoles) {
+        List<CaseAssignedUserRole> existingCauRoles) {
         return inputCauRoles.stream()
             .filter(cauRole -> existingCauRoles.stream()
-                .anyMatch(entity -> entity.getCasePrimaryKey().getCaseRole().equalsIgnoreCase(cauRole.getCaseRole())
-                    && entity.getCasePrimaryKey().getUserId().equalsIgnoreCase(cauRole.getUserId())))
+                .anyMatch(entity -> entity.getCaseRole().equalsIgnoreCase(cauRole.getCaseRole())
+                    && entity.getUserId().equalsIgnoreCase(cauRole.getUserId())
+                    && entity.getCaseDataId().equalsIgnoreCase(cauRole.getCaseDataId())))
             .collect(Collectors.toList());
-    }
-
-    private List<Long> getCaseIdsFromMap(
-        Map<CaseDetails, List<CaseAssignedUserRoleWithOrganisation>> cauRolesByCaseDetails
-    ) {
-        return getCaseIdsFromCaseDetailsList(new ArrayList<>(cauRolesByCaseDetails.keySet()));
     }
 
     private List<Long> getCaseIdsFromCaseDetailsList(List<CaseDetails> caseDetailsList) {

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/caseaccess/CaseAccessOperation.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/caseaccess/CaseAccessOperation.java
@@ -205,7 +205,7 @@ public class CaseAccessOperation {
         if (applicationParams.getEnableAttributeBasedAccessControl()) {
             List<RoleAssignmentsDeleteRequest> deleteRequests = new ArrayList<>();
 
-            // group by case
+            // for each case
             filteredCauRolesByCaseDetails.forEach((caseDetails, requestedAssignments) -> {
                 // group by user
                 Map<String, List<String>> caseRolesByUserAndCase = requestedAssignments.stream()
@@ -218,7 +218,7 @@ public class CaseAccessOperation {
                                 .collect(Collectors.toList())
                         )));
 
-                // for each user in case: add list of all case-roles to revoke to the delete requests
+                // for each user in current case: add list of all case-roles to revoke to the delete requests
                 caseRolesByUserAndCase.forEach((userId, roleNames) ->
                     deleteRequests.add(RoleAssignmentsDeleteRequest.builder()
                         .caseId(caseDetails.getReferenceAsString())
@@ -228,7 +228,7 @@ public class CaseAccessOperation {
                 ));
             });
 
-            // submit list of all delete requests
+            // submit list of all delete requests from all cases
             roleAssignmentService.deleteRoleAssignments(deleteRequests);
         } else {
             filteredCauRolesByCaseDetails.forEach((caseDetails, requestedAssignments) -> {

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/casedataaccesscontrol/RoleAssignmentService.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/casedataaccesscontrol/RoleAssignmentService.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.ccd.data.casedataaccesscontrol.CachedRoleAssignmentRepository;
 import uk.gov.hmcts.ccd.data.casedataaccesscontrol.RoleAssignmentAttributesResource;
+import uk.gov.hmcts.ccd.data.casedataaccesscontrol.RoleAssignmentQuery;
 import uk.gov.hmcts.ccd.data.casedataaccesscontrol.RoleAssignmentRepository;
 import uk.gov.hmcts.ccd.data.casedataaccesscontrol.RoleAssignmentRequestResource;
 import uk.gov.hmcts.ccd.data.casedataaccesscontrol.RoleAssignmentResource;
@@ -13,6 +14,7 @@ import uk.gov.hmcts.ccd.data.casedataaccesscontrol.RoleRequestResource;
 import uk.gov.hmcts.ccd.domain.model.casedataaccesscontrol.RoleAssignment;
 import uk.gov.hmcts.ccd.domain.model.casedataaccesscontrol.RoleAssignmentAttributes;
 import uk.gov.hmcts.ccd.domain.model.casedataaccesscontrol.RoleAssignments;
+import uk.gov.hmcts.ccd.domain.model.casedataaccesscontrol.RoleAssignmentsDeleteRequest;
 import uk.gov.hmcts.ccd.domain.model.casedataaccesscontrol.enums.ActorIdType;
 import uk.gov.hmcts.ccd.domain.model.casedataaccesscontrol.enums.Classification;
 import uk.gov.hmcts.ccd.domain.model.casedataaccesscontrol.enums.GrantType;
@@ -91,6 +93,20 @@ public class RoleAssignmentService implements AccessControl {
 
         var roleAssignmentRequestResponse = roleAssignmentRepository.createRoleAssignment(assignmentRequest);
         return roleAssignmentsMapper.toRoleAssignments(roleAssignmentRequestResponse);
+    }
+
+    public void deleteRoleAssignments(List<RoleAssignmentsDeleteRequest> deleteRequests) {
+        if (deleteRequests != null && !deleteRequests.isEmpty()) {
+            List<RoleAssignmentQuery> queryRequests = deleteRequests.stream()
+                .map(request -> new RoleAssignmentQuery(
+                    request.getCaseId(),
+                    request.getUserId(),
+                    request.getRoleNames())
+                )
+                .collect(Collectors.toList());
+
+            roleAssignmentRepository.deleteRoleAssignmentsByQuery(queryRequests);
+        }
     }
 
     public RoleAssignments getRoleAssignments(String userId) {

--- a/src/test/java/uk/gov/hmcts/ccd/data/casedataaccesscontrol/CachedRoleAssignmentRepositoryTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/data/casedataaccesscontrol/CachedRoleAssignmentRepositoryTest.java
@@ -6,6 +6,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.ccd.data.caseaccess.GlobalCaseRole;
+
+import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -17,7 +20,8 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 @ExtendWith(MockitoExtension.class)
 class CachedRoleAssignmentRepositoryTest {
 
-    private final String userId = "USERID1";
+    private static final String USER_ID = "user1";
+    private static final String CASE_ID = "111111";
 
     @Mock
     private RoleAssignmentRepository roleAssignmentRepositoryMock;
@@ -51,23 +55,39 @@ class CachedRoleAssignmentRepositoryTest {
     }
 
     @Test
+    @DisplayName("should delete role assignments by query in decorated repository")
+    void shouldDeleteRoleAssignmentByQueryInDefaultRepository() {
+
+        // GIVEN
+        List<RoleAssignmentQuery> queryRequests = List.of(
+            new RoleAssignmentQuery(CASE_ID, USER_ID, List.of(GlobalCaseRole.CREATOR.getRole()))
+        );
+
+        // WHEN
+        classUnderTest.deleteRoleAssignmentsByQuery(queryRequests);
+
+        // THEN
+        verify(roleAssignmentRepositoryMock).deleteRoleAssignmentsByQuery(queryRequests);
+    }
+
+    @Test
     @DisplayName("should initially retrieve role assignments from decorated repository")
     void shouldGetRoleAssignmentsFromDefaultRepository() {
 
         // GIVEN
-        doReturn(roleAssignmentResponse).when(roleAssignmentRepositoryMock).getRoleAssignments(userId);
+        doReturn(roleAssignmentResponse).when(roleAssignmentRepositoryMock).getRoleAssignments(USER_ID);
 
         // WHEN 1
-        RoleAssignmentResponse roleAssignments = classUnderTest.getRoleAssignments(userId);
+        RoleAssignmentResponse roleAssignments = classUnderTest.getRoleAssignments(USER_ID);
 
         // THEN 1
         assertAll(
             () -> assertThat(roleAssignments, is(roleAssignmentResponse)),
-            () -> verify(roleAssignmentRepositoryMock).getRoleAssignments(userId)
+            () -> verify(roleAssignmentRepositoryMock).getRoleAssignments(USER_ID)
         );
 
         // WHEN 2
-        RoleAssignmentResponse roleAssignments2 = classUnderTest.getRoleAssignments(userId);
+        RoleAssignmentResponse roleAssignments2 = classUnderTest.getRoleAssignments(USER_ID);
 
         // THEN 2
         assertAll(

--- a/src/test/java/uk/gov/hmcts/ccd/data/casedataaccesscontrol/DefaultRoleAssignmentRepositoryIT.java
+++ b/src/test/java/uk/gov/hmcts/ccd/data/casedataaccesscontrol/DefaultRoleAssignmentRepositoryIT.java
@@ -84,7 +84,7 @@ class DefaultRoleAssignmentRepositoryIT extends WireMockBaseTest {
     class CreateRoleAssignment {
 
         private StubMapping badRasStub;
-        private final String createUrl = "/am/role-assignments";
+        private static final String CREATE_URL = "/am/role-assignments";
 
         @BeforeEach
         void setUp() {
@@ -149,7 +149,7 @@ class DefaultRoleAssignmentRepositoryIT extends WireMockBaseTest {
 
             // GIVEN
             RoleAssignmentRequestResource assignmentRequest = createAssignmentRequest(Set.of("[ROLE1]"));
-            badRasStub = WireMock.stubFor(WireMock.post(urlMatching(createUrl)).willReturn(badRequest()));
+            badRasStub = WireMock.stubFor(WireMock.post(urlMatching(CREATE_URL)).willReturn(badRequest()));
 
             // WHEN / THEN
             final BadRequestException exception = assertThrows(BadRequestException.class,
@@ -168,7 +168,7 @@ class DefaultRoleAssignmentRepositoryIT extends WireMockBaseTest {
 
             // GIVEN
             RoleAssignmentRequestResource assignmentRequest = createAssignmentRequest(Set.of("[ROLE1]"));
-            badRasStub = WireMock.stubFor(WireMock.post(urlMatching(createUrl)).willReturn(serverError()));
+            badRasStub = WireMock.stubFor(WireMock.post(urlMatching(CREATE_URL)).willReturn(serverError()));
 
             // WHEN / THEN
             final ServiceException exception = assertThrows(ServiceException.class,
@@ -248,16 +248,17 @@ class DefaultRoleAssignmentRepositoryIT extends WireMockBaseTest {
     class DeleteRoleAssignmentsByQuery {
 
         private StubMapping badRasStub;
-        private final String deleteUrl = "/am/role-assignments/query/delete";
 
-        private final String caseId1 = "11111";
-        private final String caseId2 = "22222";
+        private static final String DELETE_URL = "/am/role-assignments/query/delete";
 
-        private final String userId1 = "12345";
-        private final String userId2 = "23456";
+        private static final String CASE_ID_1 = "11111";
+        private static final String CASE_ID_2 = "22222";
 
-        private final String role1 = "[ROLE1]";
-        private final String role2 = "[ROLE2]";
+        private static final String USER_ID_1 = "12345";
+        private static final String USER_ID_2 = "23456";
+
+        private static final String ROLE_1 = "[ROLE1]";
+        private static final String ROLE_2 = "[ROLE2]";
 
         @BeforeEach
         void setUp() {
@@ -278,45 +279,45 @@ class DefaultRoleAssignmentRepositoryIT extends WireMockBaseTest {
 
             // GIVEN
             List<RoleAssignmentQuery> queryRequests = List.of(
-                new RoleAssignmentQuery(caseId1, userId1, List.of(role1))
+                new RoleAssignmentQuery(CASE_ID_1, USER_ID_1, List.of(ROLE_1))
             );
 
             // WHEN
             roleAssignmentRepository.deleteRoleAssignmentsByQuery(queryRequests);
 
             // THEN
-            verify(1, postRequestedFor(urlMatching(deleteUrl))
-                .withRequestBody(matchingJsonPath("$.queryRequests[0].attributes.caseId[0]", equalTo(caseId1)))
-                .withRequestBody(matchingJsonPath("$.queryRequests[0].actorId[0]", equalTo(userId1)))
+            verify(1, postRequestedFor(urlMatching(DELETE_URL))
+                .withRequestBody(matchingJsonPath("$.queryRequests[0].attributes.caseId[0]", equalTo(CASE_ID_1)))
+                .withRequestBody(matchingJsonPath("$.queryRequests[0].actorId[0]", equalTo(USER_ID_1)))
                 .withRequestBody(matchingJsonPath("$.queryRequests[0].roleType[0]", equalTo(RoleType.CASE.name())))
-                .withRequestBody(matchingJsonPath("$.queryRequests[0].roleName[0]", equalTo(role1))));
+                .withRequestBody(matchingJsonPath("$.queryRequests[0].roleName[0]", equalTo(ROLE_1))));
         }
 
-        @DisplayName("should make a call to the delete role assignment by query end point for single case roles")
+        @DisplayName("should make a call to the delete role assignment by query end point for multiple case roles")
         @Test
         void shouldMakeCallToDeleteByQueryApiForMultipleCaseRoles() {
 
             // GIVEN
             List<RoleAssignmentQuery> queryRequests = List.of(
-                new RoleAssignmentQuery(caseId1, userId1, List.of(role1)),
-                new RoleAssignmentQuery(caseId2, userId2, List.of(role1, role2))
+                new RoleAssignmentQuery(CASE_ID_1, USER_ID_1, List.of(ROLE_1)),
+                new RoleAssignmentQuery(CASE_ID_2, USER_ID_2, List.of(ROLE_1, ROLE_2))
             );
 
             // WHEN
             roleAssignmentRepository.deleteRoleAssignmentsByQuery(queryRequests);
 
             // THEN
-            verify(1, postRequestedFor(urlMatching(deleteUrl))
-                .withRequestBody(matchingJsonPath("$.queryRequests[0].attributes.caseId[0]", equalTo(caseId1)))
-                .withRequestBody(matchingJsonPath("$.queryRequests[0].actorId[0]", equalTo(userId1)))
+            verify(1, postRequestedFor(urlMatching(DELETE_URL))
+                .withRequestBody(matchingJsonPath("$.queryRequests[0].attributes.caseId[0]", equalTo(CASE_ID_1)))
+                .withRequestBody(matchingJsonPath("$.queryRequests[0].actorId[0]", equalTo(USER_ID_1)))
                 .withRequestBody(matchingJsonPath("$.queryRequests[0].roleType[0]", equalTo(RoleType.CASE.name())))
-                .withRequestBody(matchingJsonPath("$.queryRequests[0].roleName[0]", equalTo(role1)))
+                .withRequestBody(matchingJsonPath("$.queryRequests[0].roleName[0]", equalTo(ROLE_1)))
 
-                .withRequestBody(matchingJsonPath("$.queryRequests[1].attributes.caseId[0]", equalTo(caseId2)))
-                .withRequestBody(matchingJsonPath("$.queryRequests[1].actorId[0]", equalTo(userId2)))
+                .withRequestBody(matchingJsonPath("$.queryRequests[1].attributes.caseId[0]", equalTo(CASE_ID_2)))
+                .withRequestBody(matchingJsonPath("$.queryRequests[1].actorId[0]", equalTo(USER_ID_2)))
                 .withRequestBody(matchingJsonPath("$.queryRequests[1].roleType[0]", equalTo(RoleType.CASE.name())))
-                .withRequestBody(matchingJsonPath("$.queryRequests[1].roleName[0]", equalTo(role1)))
-                .withRequestBody(matchingJsonPath("$.queryRequests[1].roleName[1]", equalTo(role2))));
+                .withRequestBody(matchingJsonPath("$.queryRequests[1].roleName[0]", equalTo(ROLE_1)))
+                .withRequestBody(matchingJsonPath("$.queryRequests[1].roleName[1]", equalTo(ROLE_2))));
         }
 
         @DisplayName("should throw BadRequestException when POST RoleAssignments Query Delete returns a client error")
@@ -325,10 +326,10 @@ class DefaultRoleAssignmentRepositoryIT extends WireMockBaseTest {
 
             // GIVEN
             List<RoleAssignmentQuery> queryRequests = List.of(
-                new RoleAssignmentQuery(caseId1, userId1, List.of(role1))
+                new RoleAssignmentQuery(CASE_ID_1, USER_ID_1, List.of(ROLE_1))
             );
 
-            badRasStub = WireMock.stubFor(WireMock.post(urlMatching(deleteUrl)).willReturn(badRequest()));
+            badRasStub = WireMock.stubFor(WireMock.post(urlMatching(DELETE_URL)).willReturn(badRequest()));
 
             // WHEN / THEN
             final BadRequestException exception = assertThrows(BadRequestException.class,
@@ -347,10 +348,10 @@ class DefaultRoleAssignmentRepositoryIT extends WireMockBaseTest {
 
             // GIVEN
             List<RoleAssignmentQuery> queryRequests = List.of(
-                new RoleAssignmentQuery(caseId2, userId2, List.of(role2))
+                new RoleAssignmentQuery(CASE_ID_2, USER_ID_2, List.of(ROLE_2))
             );
 
-            badRasStub = WireMock.stubFor(WireMock.post(urlMatching(deleteUrl)).willReturn(serverError()));
+            badRasStub = WireMock.stubFor(WireMock.post(urlMatching(DELETE_URL)).willReturn(serverError()));
 
             // WHEN / THEN
             final ServiceException exception = assertThrows(ServiceException.class,

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/caseaccess/CaseAccessOperationTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/caseaccess/CaseAccessOperationTest.java
@@ -122,13 +122,13 @@ class CaseAccessOperationTest {
         @DisplayName("should grant access to user")
         void shouldGrantAccess() {
 
-            // GIVEN
+            // ARRANGE
             when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(false);
 
-            // WHEN
+            // ACT
             caseAccessOperation.grantAccess(JURISDICTION, CASE_REFERENCE.toString(), USER_ID);
 
-            // THEN
+            // ASSERT
             assertAll(
                 () -> verify(caseDetailsRepository).findByReference(JURISDICTION, CASE_REFERENCE),
                 () -> verify(caseUserRepository).grantAccess(CASE_ID, USER_ID, CREATOR.getRole()),
@@ -140,13 +140,13 @@ class CaseAccessOperationTest {
         @DisplayName("RA set to true, should grant access to user")
         void shouldGrantAccessForRA() {
 
-            // GIVEN
+            // ARRANGE
             when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(true);
 
-            // WHEN
+            // ACT
             caseAccessOperation.grantAccess(JURISDICTION, CASE_REFERENCE.toString(), USER_ID);
 
-            // THEN
+            // ASSERT
             assertAll(
                 () -> verify(caseDetailsRepository).findByReference(JURISDICTION, CASE_REFERENCE),
                 () -> {
@@ -239,13 +239,13 @@ class CaseAccessOperationTest {
         @DisplayName("should grant access when added case role valid")
         void shouldGrantAccessForCaseRole() {
 
-            // GIVEN
+            // ARRANGE
             when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(false);
 
-            // WHEN
+            // ACT
             caseAccessOperation.updateUserAccess(caseDetails, caseUser(CASE_ROLE));
 
-            // THEN
+            // ASSERT
             verify(caseUserRepository).grantAccess(CASE_ID, USER_ID, CASE_ROLE);
         }
 
@@ -253,13 +253,13 @@ class CaseAccessOperationTest {
         @DisplayName("RA set to true, should grant access when added case role valid")
         void shouldGrantAccessForCaseRoleForRA() {
 
-            // GIVEN
+            // ARRANGE
             when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(true);
 
-            // WHEN
+            // ACT
             caseAccessOperation.updateUserAccess(caseDetails, caseUser(CASE_ROLE));
 
-            // THEN
+            // ASSERT
             verify(roleAssignmentService).createCaseRoleAssignments(
                 eq(caseDetails),
                 eq(USER_ID),
@@ -282,13 +282,13 @@ class CaseAccessOperationTest {
         @DisplayName("should grant access when added case roles contains global [CREATOR]")
         void shouldGrantAccessForCaseRoleCreator() {
 
-            // GIVEN
+            // ARRANGE
             when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(false);
 
-            // WHEN
+            // ACT
             caseAccessOperation.updateUserAccess(caseDetails, caseUser(CASE_ROLE, CREATOR.getRole()));
 
-            // THEN
+            // ASSERT
             assertAll(
                 () -> verify(caseUserRepository).grantAccess(CASE_ID, USER_ID, CASE_ROLE),
                 () -> verify(caseUserRepository).grantAccess(CASE_ID, USER_ID, CREATOR.getRole()),
@@ -300,13 +300,13 @@ class CaseAccessOperationTest {
         @DisplayName("RA set to true, should grant access when added case roles contains global [CREATOR]")
         void shouldGrantAccessForCaseRoleCreatorForRA() {
 
-            // GIVEN
+            // ARRANGE
             when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(true);
 
-            // WHEN
+            // ACT
             caseAccessOperation.updateUserAccess(caseDetails, caseUser(CASE_ROLE, CREATOR.getRole()));
 
-            // THEN
+            // ASSERT
             verify(roleAssignmentService).createCaseRoleAssignments(
                 eq(caseDetails),
                 eq(USER_ID),
@@ -332,14 +332,14 @@ class CaseAccessOperationTest {
             // NB: test not valid for 'Attribute Based Access Control' as :
             //     RAS submission with `replaceExisting = true` does not require us to revokeRemoved.
 
-            // GIVEN
+            // ARRANGE
             when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(false);
             when(caseUserRepository.findCaseRoles(CASE_ID, USER_ID)).thenReturn(List.of(CASE_ROLE_GRANTED));
 
-            // WHEN
+            // ACT
             caseAccessOperation.updateUserAccess(caseDetails, caseUser(CASE_ROLE));
 
-            // THEN
+            // ASSERT
             assertAll(
                 () -> verify(caseUserRepository).revokeAccess(CASE_ID, USER_ID, CASE_ROLE_GRANTED),
                 () -> verifyNoInteractions(roleAssignmentService)
@@ -352,14 +352,14 @@ class CaseAccessOperationTest {
             // NB: test not valid for 'Attribute Based Access Control' as :
             //     RAS submission with `replaceExisting = true` does not require us to ignoreGranted.
 
-            // GIVEN
+            // ARRANGE
             when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(false);
             when(caseUserRepository.findCaseRoles(CASE_ID, USER_ID)).thenReturn(List.of(CASE_ROLE_GRANTED));
 
-            // WHEN
+            // ACT
             caseAccessOperation.updateUserAccess(caseDetails, caseUser(CASE_ROLE_GRANTED));
 
-            // THEN
+            // ASSERT
             assertAll(
                 () -> verify(caseUserRepository, never()).grantAccess(CASE_ID, USER_ID, CASE_ROLE_GRANTED),
                 () -> verifyNoInteractions(roleAssignmentService)
@@ -379,13 +379,13 @@ class CaseAccessOperationTest {
         @DisplayName("should revoke access to user")
         void shouldRevokeAccess() {
 
-            // GIVEN
+            // ARRANGE
             when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(false);
 
-            // WHEN
+            // ACT
             caseAccessOperation.revokeAccess(JURISDICTION, CASE_REFERENCE.toString(), USER_ID);
 
-            // THEN
+            // ASSERT
             assertAll(
                 () -> verify(caseDetailsRepository).findByReference(JURISDICTION, CASE_REFERENCE),
                 () -> verify(caseUserRepository).revokeAccess(CASE_ID, USER_ID, CREATOR.getRole()),
@@ -397,13 +397,13 @@ class CaseAccessOperationTest {
         @DisplayName("RA set to true, should revoke access to user")
         void shouldRevokeAccessForRA() {
 
-            // GIVEN
+            // ARRANGE
             when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(true);
 
-            // WHEN
+            // ACT
             caseAccessOperation.revokeAccess(JURISDICTION, CASE_REFERENCE.toString(), USER_ID);
 
-            // THEN
+            // ASSERT
             assertAll(
                 () -> verify(caseDetailsRepository).findByReference(JURISDICTION, CASE_REFERENCE),
                 () -> {
@@ -2203,7 +2203,7 @@ class CaseAccessOperationTest {
         @DisplayName("should find case assigned user roles")
         void shouldGetCaseAssignedUserRoles() {
 
-            // GIVEN
+            // ARRANGE
             when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(false);
 
             // register existing case role
@@ -2215,11 +2215,11 @@ class CaseAccessOperationTest {
             List<Long> caseReferences = Lists.newArrayList(CASE_REFERENCE);
             final List<String> userIds = Lists.newArrayList();
 
-            // WHEN
+            // ACT
             List<CaseAssignedUserRole> caseAssignedUserRoles = caseAccessOperation.findCaseUserRoles(caseReferences,
                 userIds);
 
-            // THEN
+            // ASSERT
             assertNotNull(caseAssignedUserRoles);
             assertEquals(2, caseAssignedUserRoles.size());
             assertEquals(CASE_ROLE, caseAssignedUserRoles.get(0).getCaseRole());
@@ -2230,7 +2230,7 @@ class CaseAccessOperationTest {
         @DisplayName("RA set to true, should find case assigned user roles")
         void shouldGetCaseAssignedUserRolesForRA() {
 
-            // GIVEN
+            // ARRANGE
             when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(true);
 
             // register existing case role
@@ -2242,11 +2242,11 @@ class CaseAccessOperationTest {
             final var caseReferences = Lists.newArrayList(CASE_REFERENCE);
             final List<String> userIds = Lists.newArrayList();
 
-            // WHEN
+            // ACT
             List<CaseAssignedUserRole> caseAssignedUserRoles = caseAccessOperation.findCaseUserRoles(caseReferences,
                 userIds);
 
-            // THEN
+            // ASSERT
             assertNotNull(caseAssignedUserRoles);
             assertEquals(2, caseAssignedUserRoles.size());
             assertEquals(CASE_ROLE, caseAssignedUserRoles.get(0).getCaseRole());
@@ -2257,15 +2257,15 @@ class CaseAccessOperationTest {
         @DisplayName("should return empty result for non existing cases")
         void shouldReturnEmptyResultOnNonExistingCases() {
 
-            // GIVEN
+            // ARRANGE
             when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(false);
             List<Long> caseReferences = Lists.newArrayList(CASE_NOT_FOUND);
 
-            // WHEN
+            // ACT
             List<CaseAssignedUserRole> caseAssignedUserRoles = caseAccessOperation.findCaseUserRoles(caseReferences,
                 Lists.newArrayList());
 
-            // THEN
+            // ASSERT
             assertNotNull(caseAssignedUserRoles);
             assertEquals(0, caseAssignedUserRoles.size());
         }
@@ -2274,16 +2274,16 @@ class CaseAccessOperationTest {
         @DisplayName("RA set to true, should return empty result for non existing cases")
         void shouldReturnEmptyResultOnNonExistingCasesForRA() {
 
-            // GIVEN
+            // ARRANGE
             when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(true);
 
             List<Long> caseReferences = Lists.newArrayList(CASE_NOT_FOUND);
 
-            // WHEN
+            // ACT
             List<CaseAssignedUserRole> caseAssignedUserRoles = caseAccessOperation.findCaseUserRoles(caseReferences,
                 Lists.newArrayList());
 
-            // THEN
+            // ASSERT
             assertNotNull(caseAssignedUserRoles);
             assertEquals(0, caseAssignedUserRoles.size());
         }

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/caseaccess/CaseAccessOperationTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/caseaccess/CaseAccessOperationTest.java
@@ -13,12 +13,14 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.OngoingStubbing;
 import uk.gov.hmcts.ccd.ApplicationParams;
 import uk.gov.hmcts.ccd.data.caseaccess.CaseRoleRepository;
 import uk.gov.hmcts.ccd.data.caseaccess.CaseUserEntity;
 import uk.gov.hmcts.ccd.data.caseaccess.CaseUserRepository;
 import uk.gov.hmcts.ccd.data.casedetails.CaseDetailsRepository;
 import uk.gov.hmcts.ccd.data.casedetails.supplementarydata.SupplementaryDataRepository;
+import uk.gov.hmcts.ccd.domain.model.casedataaccesscontrol.RoleAssignmentsDeleteRequest;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseDetails;
 import uk.gov.hmcts.ccd.domain.model.std.CaseAssignedUserRole;
 import uk.gov.hmcts.ccd.domain.model.std.CaseAssignedUserRoleWithOrganisation;
@@ -37,6 +39,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -58,6 +62,7 @@ import static uk.gov.hmcts.ccd.data.caseaccess.GlobalCaseRole.CREATOR;
 
 @ExtendWith(MockitoExtension.class)
 class CaseAccessOperationTest {
+
     private static final String JURISDICTION = "CMC";
     private static final String WRONG_JURISDICTION = "DIVORCE";
     private static final String CASE_TYPE_ID = "Application";
@@ -367,14 +372,53 @@ class CaseAccessOperationTest {
     @DisplayName("revokeAccess()")
     class RevokeAccess {
 
+        @Captor
+        private ArgumentCaptor<List<RoleAssignmentsDeleteRequest>> deleteRequestsCaptor;
+
         @Test
         @DisplayName("should revoke access to user")
         void shouldRevokeAccess() {
+
+            // GIVEN
+            when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(false);
+
+            // WHEN
             caseAccessOperation.revokeAccess(JURISDICTION, CASE_REFERENCE.toString(), USER_ID);
 
+            // THEN
             assertAll(
                 () -> verify(caseDetailsRepository).findByReference(JURISDICTION, CASE_REFERENCE),
-                () -> verify(caseUserRepository).revokeAccess(CASE_ID, USER_ID, CREATOR.getRole())
+                () -> verify(caseUserRepository).revokeAccess(CASE_ID, USER_ID, CREATOR.getRole()),
+                () -> verifyNoInteractions(roleAssignmentService)
+            );
+        }
+
+        @Test
+        @DisplayName("RA set to true, should revoke access to user")
+        void shouldRevokeAccessForRA() {
+
+            // GIVEN
+            when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(true);
+
+            // WHEN
+            caseAccessOperation.revokeAccess(JURISDICTION, CASE_REFERENCE.toString(), USER_ID);
+
+            // THEN
+            assertAll(
+                () -> verify(caseDetailsRepository).findByReference(JURISDICTION, CASE_REFERENCE),
+                () -> {
+                    verify(roleAssignmentService).deleteRoleAssignments(deleteRequestsCaptor.capture());
+
+                    List<RoleAssignmentsDeleteRequest> deleteRequests = deleteRequestsCaptor.getValue();
+                    assertAll(
+                        () -> assertEquals(1, deleteRequests.size()),
+                        () -> assertCorrectlyPopulatedRoleAssignmentsDeleteRequest(
+                            CASE_REFERENCE.toString(), USER_ID, List.of(CREATOR.getRole()),
+                            deleteRequests.get(0)
+                        )
+                    );
+                },
+                () -> verifyNoInteractions(caseUserRepository)
             );
         }
 
@@ -387,7 +431,8 @@ class CaseAccessOperationTest {
                 () -> assertThrows(CaseNotFoundException.class,
                     () -> caseAccessOperation.revokeAccess(JURISDICTION, caseNotFound, USER_ID)),
                 () -> verify(caseDetailsRepository).findByReference(JURISDICTION, CASE_NOT_FOUND),
-                () -> verify(caseUserRepository, never()).revokeAccess(CASE_ID, USER_ID, CREATOR.getRole())
+                () -> verifyNoInteractions(caseUserRepository),
+                () -> verifyNoInteractions(roleAssignmentService)
             );
         }
 
@@ -400,7 +445,8 @@ class CaseAccessOperationTest {
                 () -> assertThrows(CaseNotFoundException.class,
                     () -> caseAccessOperation.revokeAccess(WRONG_JURISDICTION, caseReference, USER_ID)),
                 () -> verify(caseDetailsRepository).findByReference(WRONG_JURISDICTION, CASE_REFERENCE),
-                () -> verify(caseUserRepository, never()).revokeAccess(CASE_ID, USER_ID, CREATOR.getRole())
+                () -> verifyNoInteractions(caseUserRepository),
+                () -> verifyNoInteractions(roleAssignmentService)
             );
         }
     }
@@ -1292,6 +1338,9 @@ class CaseAccessOperationTest {
     @DisplayName("removeCaseUserRoles(caseUserRoles)")
     class RemoveCaseAssignUserRoles {
 
+        @Captor
+        private ArgumentCaptor<List<RoleAssignmentsDeleteRequest>> deleteRequestsCaptor;
+
         @BeforeEach
         void setUp() {
             configureCaseRepository(null);
@@ -1300,53 +1349,140 @@ class CaseAccessOperationTest {
         @Test
         @DisplayName("should remove single case user role")
         void shouldRemoveSingleCaseUserRole() {
+
             // ARRANGE
+            when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(false);
+
             List<CaseAssignedUserRoleWithOrganisation> caseUserRoles = Lists.newArrayList(
                 new CaseAssignedUserRoleWithOrganisation(CASE_REFERENCE.toString(), USER_ID, CASE_ROLE)
             );
 
             // for an existing relation and then after removal
-            when(caseUserRepository.findCaseUserRoles(
-                argThat(arg -> arg.contains(CASE_ID)),
-                argThat(arg -> arg.contains(USER_ID))
-            )).thenReturn(List.of(
-                createCaseUserEntity(CASE_ID, CASE_ROLE, USER_ID)
-            )).thenReturn(new ArrayList<>());
+            mockExistingCaseUserRoles(
+                // before
+                List.of(createCaseUserEntity(CASE_ID, CASE_ROLE, USER_ID)),
+                // after
+                new ArrayList<>()
+            );
 
             // ACT
             caseAccessOperation.removeCaseUserRoles(caseUserRoles);
 
             // ASSERT
             verify(caseUserRepository, times(1)).revokeAccess(CASE_ID, USER_ID, CASE_ROLE);
+
+            verifyNoInteractions(roleAssignmentService);
+        }
+
+        @Test
+        @DisplayName("RA set to true, should remove single case user role")
+        void shouldRemoveSingleCaseUserRoleForRA() {
+
+            // ARRANGE
+            when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(true);
+
+            List<CaseAssignedUserRoleWithOrganisation> caseUserRoles = Lists.newArrayList(
+                new CaseAssignedUserRoleWithOrganisation(CASE_REFERENCE.toString(), USER_ID, CASE_ROLE)
+            );
+
+            // for an existing relation and then after removal
+            mockExistingCaseUserRolesForRA(
+                // before
+                List.of(new CaseAssignedUserRole(CASE_REFERENCE.toString(), USER_ID, CASE_ROLE)),
+                // after
+                new ArrayList<>()
+            );
+
+            // ACT
+            caseAccessOperation.removeCaseUserRoles(caseUserRoles);
+
+            // ASSERT
+            verify(roleAssignmentService).deleteRoleAssignments(deleteRequestsCaptor.capture());
+
+            List<RoleAssignmentsDeleteRequest> deleteRequests = deleteRequestsCaptor.getValue();
+            assertAll(
+                () -> assertEquals(1, deleteRequests.size()),
+                () -> assertCorrectlyPopulatedRoleAssignmentsDeleteRequest(
+                    CASE_REFERENCE.toString(), USER_ID, List.of(CASE_ROLE),
+                    deleteRequests.get(0)
+                )
+            );
+
+            verifyNoInteractions(caseUserRepository);
         }
 
         @Test
         @DisplayName("should remove single [CREATOR] case user role")
         void shouldRemoveSingleCreatorCaseUserRole() {
+
             // ARRANGE
+            when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(false);
+
             List<CaseAssignedUserRoleWithOrganisation> caseUserRoles = Lists.newArrayList(
                 new CaseAssignedUserRoleWithOrganisation(CASE_REFERENCE.toString(), USER_ID, CASE_ROLE_CREATOR)
             );
 
             // for an existing relation and then after removal
-            when(caseUserRepository.findCaseUserRoles(
-                argThat(arg -> arg.contains(CASE_ID)),
-                argThat(arg -> arg.contains(USER_ID))
-            )).thenReturn(List.of(
-                createCaseUserEntity(CASE_ID, CASE_ROLE_CREATOR, USER_ID)
-            )).thenReturn(new ArrayList<>());
+            mockExistingCaseUserRoles(
+                // before
+                List.of(createCaseUserEntity(CASE_ID, CASE_ROLE_CREATOR, USER_ID)),
+                // after
+                new ArrayList<>()
+            );
 
             // ACT
             caseAccessOperation.removeCaseUserRoles(caseUserRoles);
 
             // ASSERT
             verify(caseUserRepository, times(1)).revokeAccess(CASE_ID, USER_ID, CASE_ROLE_CREATOR);
+
+            verifyNoInteractions(roleAssignmentService);
+        }
+
+        @Test
+        @DisplayName("RA set to true, should remove single [CREATOR] case user role")
+        void shouldRemoveSingleCreatorCaseUserRoleForRA() {
+
+            // ARRANGE
+            when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(true);
+
+            List<CaseAssignedUserRoleWithOrganisation> caseUserRoles = Lists.newArrayList(
+                new CaseAssignedUserRoleWithOrganisation(CASE_REFERENCE.toString(), USER_ID, CASE_ROLE_CREATOR)
+            );
+
+            // for an existing relation and then after removal
+            mockExistingCaseUserRolesForRA(
+                // before
+                List.of(new CaseAssignedUserRole(CASE_REFERENCE.toString(), USER_ID, CASE_ROLE_CREATOR)),
+                // after
+                new ArrayList<>()
+            );
+
+            // ACT
+            caseAccessOperation.removeCaseUserRoles(caseUserRoles);
+
+            // ASSERT
+            verify(roleAssignmentService).deleteRoleAssignments(deleteRequestsCaptor.capture());
+
+            List<RoleAssignmentsDeleteRequest> deleteRequests = deleteRequestsCaptor.getValue();
+            assertAll(
+                () -> assertEquals(1, deleteRequests.size()),
+                () -> assertCorrectlyPopulatedRoleAssignmentsDeleteRequest(
+                    CASE_REFERENCE.toString(), USER_ID, List.of(CASE_ROLE_CREATOR),
+                    deleteRequests.get(0)
+                )
+            );
+
+            verifyNoInteractions(caseUserRepository);
         }
 
         @Test
         @DisplayName("should remove multiple case user roles")
         void shouldRemoveMultipleCaseUserRoles() {
+
             // ARRANGE
+            when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(false);
+
             final CaseDetails caseDetailsOther = new CaseDetails();
             caseDetailsOther.setId(String.valueOf(CASE_ID_OTHER));
             caseDetailsOther.setReference(CASE_REFERENCE_OTHER);
@@ -1359,11 +1495,15 @@ class CaseAccessOperationTest {
             );
 
             // for an existing relation and then after removal
-            when(caseUserRepository.findCaseUserRoles(
-                argThat(arg -> arg.contains(CASE_ID) && arg.contains(CASE_ID_OTHER)),
-                argThat(arg -> arg.contains(USER_ID))
-            )).thenReturn(List.of(createCaseUserEntity(CASE_ID, CASE_ROLE, USER_ID),
-                createCaseUserEntity(CASE_ID_OTHER, CASE_ROLE, USER_ID)));
+            mockExistingCaseUserRoles(
+                // before
+                List.of(
+                    createCaseUserEntity(CASE_ID, CASE_ROLE, USER_ID),
+                    createCaseUserEntity(CASE_ID_OTHER, CASE_ROLE, USER_ID)
+                ),
+                // after
+                new ArrayList<>()
+            );
 
             // ACT
             caseAccessOperation.removeCaseUserRoles(caseUserRoles);
@@ -1372,11 +1512,70 @@ class CaseAccessOperationTest {
             verify(caseUserRepository, times(1)).revokeAccess(CASE_ID, USER_ID, CASE_ROLE);
             verify(caseUserRepository, times(1))
                 .revokeAccess(CASE_ID_OTHER, USER_ID, CASE_ROLE);
+
+            verifyNoInteractions(roleAssignmentService);
+        }
+
+        @Test
+        @DisplayName("RA set to true, should remove multiple case user roles")
+        void shouldRemoveMultipleCaseUserRolesForRA() {
+
+            // ARRANGE
+            when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(true);
+
+            final CaseDetails caseDetailsOther = new CaseDetails();
+            caseDetailsOther.setId(String.valueOf(CASE_ID_OTHER));
+            caseDetailsOther.setReference(CASE_REFERENCE_OTHER);
+            doReturn(Optional.of(caseDetailsOther)).when(caseDetailsRepository).findByReference(null,
+                CASE_REFERENCE_OTHER);
+
+            List<CaseAssignedUserRoleWithOrganisation> caseUserRoles = Lists.newArrayList(
+                new CaseAssignedUserRoleWithOrganisation(CASE_REFERENCE.toString(), USER_ID, CASE_ROLE),
+                new CaseAssignedUserRoleWithOrganisation(CASE_REFERENCE_OTHER.toString(), USER_ID, CASE_ROLE)
+            );
+
+            // for an existing relation and then after removal
+            mockExistingCaseUserRolesForRA(
+                // before
+                List.of(
+                    new CaseAssignedUserRole(CASE_REFERENCE.toString(), USER_ID, CASE_ROLE),
+                    new CaseAssignedUserRole(CASE_REFERENCE_OTHER.toString(), USER_ID, CASE_ROLE)
+                ),
+                // after
+                new ArrayList<>()
+            );
+
+            // ACT
+            caseAccessOperation.removeCaseUserRoles(caseUserRoles);
+
+            // ASSERT
+            verify(roleAssignmentService).deleteRoleAssignments(deleteRequestsCaptor.capture());
+
+            Map<String, RoleAssignmentsDeleteRequest> deleteRequestsMapByCaseId =
+                deleteRequestsCaptor.getValue().stream()
+                    .collect(Collectors.toMap(
+                        RoleAssignmentsDeleteRequest::getCaseId, deleteRequests -> deleteRequests)
+                    );
+
+            assertAll(
+                () -> assertEquals(2, deleteRequestsMapByCaseId.size()),
+                () -> assertCorrectlyPopulatedRoleAssignmentsDeleteRequest(
+                    CASE_REFERENCE.toString(), USER_ID, List.of(CASE_ROLE),
+                    deleteRequestsMapByCaseId.get(CASE_REFERENCE.toString())
+                ),
+                () -> assertCorrectlyPopulatedRoleAssignmentsDeleteRequest(
+                    CASE_REFERENCE_OTHER.toString(), USER_ID, List.of(CASE_ROLE),
+                    deleteRequestsMapByCaseId.get(CASE_REFERENCE_OTHER.toString())
+                )
+            );
+
+            verifyNoInteractions(caseUserRepository);
         }
 
         @Test
         @DisplayName("should throw not found exception when case not found")
         void shouldThrowNotFound() {
+
             // ARRANGE
             List<CaseAssignedUserRoleWithOrganisation> caseUserRoles = Lists.newArrayList(
                 new CaseAssignedUserRoleWithOrganisation(CASE_NOT_FOUND.toString(), USER_ID, CASE_ROLE)
@@ -1384,21 +1583,29 @@ class CaseAccessOperationTest {
 
             // ACT / ASSERT
             assertThrows(CaseNotFoundException.class, () -> caseAccessOperation.removeCaseUserRoles(caseUserRoles));
+
+            verifyNoInteractions(caseUserRepository);
+            verifyNoInteractions(roleAssignmentService);
         }
 
         @Test
         @DisplayName("should decrement organisation user count for single new case-user relationship")
         void shouldDecrementOrganisationUserCountForSingleNewRelationship() {
+
             // ARRANGE
+            when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(false);
+
             List<CaseAssignedUserRoleWithOrganisation> caseUserRoles = Lists.newArrayList(
                 new CaseAssignedUserRoleWithOrganisation(CASE_REFERENCE.toString(), USER_ID, CASE_ROLE, ORGANISATION)
             );
+
             // for an existing relation and then after removal
-            when(caseUserRepository.findCaseUserRoles(
-                argThat(arg -> arg.contains(CASE_ID)),
-                argThat(arg -> arg.contains(USER_ID))
-            )).thenReturn(List.of(createCaseUserEntity(CASE_ID, CASE_ROLE, USER_ID)))
-            .thenReturn(new ArrayList<>());
+            mockExistingCaseUserRoles(
+                // before
+                List.of(createCaseUserEntity(CASE_ID, CASE_ROLE, USER_ID)),
+                // after
+                new ArrayList<>()
+            );
 
             // ACT
             caseAccessOperation.removeCaseUserRoles(caseUserRoles);
@@ -1406,67 +1613,166 @@ class CaseAccessOperationTest {
             // ASSERT
             verify(supplementaryDataRepository, times(1))
                 .incrementSupplementaryData(CASE_REFERENCE.toString(), getOrgUserCountSupDataKey(ORGANISATION), -1L);
+
+            verifyNoInteractions(roleAssignmentService);
+        }
+
+        @Test
+        @DisplayName("RA set to true, should decrement organisation user count for single new case-user relationship")
+        void shouldDecrementOrganisationUserCountForSingleNewRelationshipForRA() {
+
+            // ARRANGE
+            when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(true);
+
+            List<CaseAssignedUserRoleWithOrganisation> caseUserRoles = Lists.newArrayList(
+                new CaseAssignedUserRoleWithOrganisation(CASE_REFERENCE.toString(), USER_ID, CASE_ROLE, ORGANISATION)
+            );
+
+            // for an existing relation and then after removal
+            mockExistingCaseUserRolesForRA(
+                // before
+                List.of(new CaseAssignedUserRole(CASE_REFERENCE.toString(), USER_ID, CASE_ROLE)),
+                // after
+                new ArrayList<>()
+            );
+
+            // ACT
+            caseAccessOperation.removeCaseUserRoles(caseUserRoles);
+
+            // ASSERT
+            verify(supplementaryDataRepository, times(1))
+                .incrementSupplementaryData(CASE_REFERENCE.toString(), getOrgUserCountSupDataKey(ORGANISATION), -1L);
+
+            verifyNoInteractions(caseUserRepository);
         }
 
         @Test
         @DisplayName("should not decrement organisation user count for non-existing case-user relationship")
         void shouldNotDecrementOrganisationUserCountForExistingRelationship() {
+
             // ARRANGE
+            when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(false);
+
             List<CaseAssignedUserRoleWithOrganisation> caseUserRoles = Lists.newArrayList(
                 new CaseAssignedUserRoleWithOrganisation(CASE_REFERENCE.toString(), USER_ID, CASE_ROLE, ORGANISATION)
             );
+
             // no existing relationship
-            when(caseUserRepository.findCaseUserRoles(
-                argThat(arg -> arg.contains(CASE_ID)),
-                argThat(arg -> arg.contains(USER_ID))
-            )).thenReturn(new ArrayList<>());
+            mockExistingCaseUserRoles(new ArrayList<>());
 
             // ACT
             caseAccessOperation.removeCaseUserRoles(caseUserRoles);
 
             // ASSERT
             verify(supplementaryDataRepository, never()).incrementSupplementaryData(anyString(), anyString(), any());
+
+            verifyNoInteractions(roleAssignmentService);
+        }
+
+        @Test
+        @DisplayName(
+            "RA set to true, should not decrement organisation user count for non-existing case-user relationship"
+        )
+        void shouldNotDecrementOrganisationUserCountForExistingRelationshipForRA() {
+
+            // ARRANGE
+            when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(true);
+
+            List<CaseAssignedUserRoleWithOrganisation> caseUserRoles = Lists.newArrayList(
+                new CaseAssignedUserRoleWithOrganisation(CASE_REFERENCE.toString(), USER_ID, CASE_ROLE, ORGANISATION)
+            );
+
+            // no existing relationship
+            mockExistingCaseUserRolesForRA(new ArrayList<>());
+
+            // ACT
+            caseAccessOperation.removeCaseUserRoles(caseUserRoles);
+
+            // ASSERT
+            verify(supplementaryDataRepository, never()).incrementSupplementaryData(anyString(), anyString(), any());
+
+            verifyNoInteractions(caseUserRepository);
         }
 
         @Test
         @DisplayName("should not decrement organisation user count for single new case-user with [CREATOR] role")
         void shouldNotIncrementOrganisationUserCountWithCreatorRole() {
+
             // ARRANGE
+            when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(false);
+
             List<CaseAssignedUserRoleWithOrganisation> caseUserRoles = Lists.newArrayList(
                 new CaseAssignedUserRoleWithOrganisation(
                     CASE_REFERENCE.toString(), USER_ID, CASE_ROLE_CREATOR, ORGANISATION)
             );
 
             // for an existing relation and then after removal
-            when(caseUserRepository.findCaseUserRoles(
-                argThat(arg -> arg.contains(CASE_ID)),
-                argThat(arg -> arg.contains(USER_ID))
-            )).thenReturn(
-                List.of(createCaseUserEntity(CASE_ID, CASE_ROLE_CREATOR, USER_ID)
-            )).thenReturn(new ArrayList<>());
+            mockExistingCaseUserRoles(
+                // before
+                List.of(createCaseUserEntity(CASE_ID, CASE_ROLE_CREATOR, USER_ID)),
+                // after
+                new ArrayList<>()
+            );
 
             // ACT
             caseAccessOperation.removeCaseUserRoles(caseUserRoles);
 
             // ASSERT
             verify(supplementaryDataRepository, never()).incrementSupplementaryData(anyString(), anyString(), any());
+
+            verifyNoInteractions(roleAssignmentService);
+        }
+
+        @Test
+        @DisplayName(
+            "RA set to true, should not decrement organisation user count for single new case-user with [CREATOR] role"
+        )
+        void shouldNotIncrementOrganisationUserCountWithCreatorRoleForRA() {
+
+            // ARRANGE
+            when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(true);
+
+            List<CaseAssignedUserRoleWithOrganisation> caseUserRoles = Lists.newArrayList(
+                new CaseAssignedUserRoleWithOrganisation(
+                    CASE_REFERENCE.toString(), USER_ID, CASE_ROLE_CREATOR, ORGANISATION)
+            );
+
+            // for an existing relation and then after removal
+            mockExistingCaseUserRolesForRA(
+                // before
+                List.of(new CaseAssignedUserRole(CASE_REFERENCE.toString(), USER_ID, CASE_ROLE_CREATOR)),
+                // after
+                new ArrayList<>()
+            );
+
+            // ACT
+            caseAccessOperation.removeCaseUserRoles(caseUserRoles);
+
+            // ASSERT
+            verify(supplementaryDataRepository, never()).incrementSupplementaryData(anyString(), anyString(), any());
+
+            verifyNoInteractions(caseUserRepository);
         }
 
         @Test
         @DisplayName("should decrement organisation user count only once for repeat remove case-user relationship")
         void shouldDecrementOrganisationUserCountOnlyOnceForRepeatRelationship() {
+
             // ARRANGE
+            when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(false);
+
             List<CaseAssignedUserRoleWithOrganisation> caseUserRoles = Lists.newArrayList(
                 new CaseAssignedUserRoleWithOrganisation(CASE_REFERENCE.toString(), USER_ID, CASE_ROLE, ORGANISATION),
                 new CaseAssignedUserRoleWithOrganisation(CASE_REFERENCE.toString(), USER_ID, CASE_ROLE, ORGANISATION)
             );
 
             // for an existing relation and then after removal
-            when(caseUserRepository.findCaseUserRoles(
-                argThat(arg -> arg.contains(CASE_ID)),
-                argThat(arg -> arg.contains(USER_ID))
-            )).thenReturn(List.of(createCaseUserEntity(CASE_ID, CASE_ROLE, USER_ID)))
-                .thenReturn(new ArrayList<>());
+            mockExistingCaseUserRoles(
+                // before
+                List.of(createCaseUserEntity(CASE_ID, CASE_ROLE, USER_ID)),
+                // after
+                new ArrayList<>()
+            );
 
             // ACT
             caseAccessOperation.removeCaseUserRoles(caseUserRoles);
@@ -1474,12 +1780,50 @@ class CaseAccessOperationTest {
             // ASSERT
             verify(supplementaryDataRepository, times(1))
                 .incrementSupplementaryData(CASE_REFERENCE.toString(), getOrgUserCountSupDataKey(ORGANISATION), -1L);
+
+            verifyNoInteractions(roleAssignmentService);
+        }
+
+        @Test
+        @DisplayName(
+            "RA set to true, "
+                + "should decrement organisation user count only once for repeat remove case-user relationship"
+        )
+        void shouldDecrementOrganisationUserCountOnlyOnceForRepeatRelationshipForRA() {
+
+            // ARRANGE
+            when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(true);
+
+            List<CaseAssignedUserRoleWithOrganisation> caseUserRoles = Lists.newArrayList(
+                new CaseAssignedUserRoleWithOrganisation(CASE_REFERENCE.toString(), USER_ID, CASE_ROLE, ORGANISATION),
+                new CaseAssignedUserRoleWithOrganisation(CASE_REFERENCE.toString(), USER_ID, CASE_ROLE, ORGANISATION)
+            );
+
+            // for an existing relation and then after removal
+            mockExistingCaseUserRolesForRA(
+                // before
+                List.of(new CaseAssignedUserRole(CASE_REFERENCE.toString(), USER_ID, CASE_ROLE)),
+                // after
+                new ArrayList<>()
+            );
+
+            // ACT
+            caseAccessOperation.removeCaseUserRoles(caseUserRoles);
+
+            // ASSERT
+            verify(supplementaryDataRepository, times(1))
+                .incrementSupplementaryData(CASE_REFERENCE.toString(), getOrgUserCountSupDataKey(ORGANISATION), -1L);
+
+            verifyNoInteractions(caseUserRepository);
         }
 
         @Test
         @DisplayName("should decrement organisation user count only once and ignore creator role")
         void shouldDecrementOrganisationUserCountOnlyOnceForRepeatRelationshipIgnoreCreatorRole() {
+
             // ARRANGE
+            when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(false);
+
             List<CaseAssignedUserRoleWithOrganisation> caseUserRoles = Lists.newArrayList(
                 new CaseAssignedUserRoleWithOrganisation(
                     CASE_REFERENCE.toString(), USER_ID, CASE_ROLE, ORGANISATION),
@@ -1488,13 +1832,15 @@ class CaseAccessOperationTest {
             );
 
             // for an existing relation and then after removal
-            when(caseUserRepository.findCaseUserRoles(
-                argThat(arg -> arg.contains(CASE_ID)),
-                argThat(arg -> arg.contains(USER_ID))
-            )).thenReturn(List.of(
-                createCaseUserEntity(CASE_ID, CASE_ROLE, USER_ID),
-                createCaseUserEntity(CASE_ID, CASE_ROLE_CREATOR, USER_ID)
-            )).thenReturn(new ArrayList<>());
+            mockExistingCaseUserRoles(
+                // before
+                List.of(
+                    createCaseUserEntity(CASE_ID, CASE_ROLE, USER_ID),
+                    createCaseUserEntity(CASE_ID, CASE_ROLE_CREATOR, USER_ID)
+                ),
+                // after
+                new ArrayList<>()
+            );
 
             // ACT
             caseAccessOperation.removeCaseUserRoles(caseUserRoles);
@@ -1502,26 +1848,68 @@ class CaseAccessOperationTest {
             // ASSERT
             verify(supplementaryDataRepository, times(1))
                 .incrementSupplementaryData(CASE_REFERENCE.toString(), getOrgUserCountSupDataKey(ORGANISATION), -1L);
+
+            verifyNoInteractions(roleAssignmentService);
+        }
+
+        @Test
+        @DisplayName("RA set to true, should decrement organisation user count only once and ignore creator role")
+        void shouldDecrementOrganisationUserCountOnlyOnceForRepeatRelationshipIgnoreCreatorRoleForRA() {
+
+            // ARRANGE
+            when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(true);
+
+            List<CaseAssignedUserRoleWithOrganisation> caseUserRoles = Lists.newArrayList(
+                new CaseAssignedUserRoleWithOrganisation(
+                    CASE_REFERENCE.toString(), USER_ID, CASE_ROLE, ORGANISATION),
+                new CaseAssignedUserRoleWithOrganisation(
+                    CASE_REFERENCE.toString(), USER_ID, CASE_ROLE_CREATOR, ORGANISATION)
+            );
+
+            // for an existing relation and then after removal
+            mockExistingCaseUserRolesForRA(
+                // before
+                List.of(
+                    new CaseAssignedUserRole(CASE_REFERENCE.toString(), USER_ID, CASE_ROLE),
+                    new CaseAssignedUserRole(CASE_REFERENCE.toString(), USER_ID, CASE_ROLE_CREATOR)
+                ),
+                // after
+                new ArrayList<>()
+            );
+
+            // ACT
+            caseAccessOperation.removeCaseUserRoles(caseUserRoles);
+
+            // ASSERT
+            verify(supplementaryDataRepository, times(1))
+                .incrementSupplementaryData(CASE_REFERENCE.toString(), getOrgUserCountSupDataKey(ORGANISATION), -1L);
+
+            verifyNoInteractions(caseUserRepository);
         }
 
         @Test
         @DisplayName("should decrement organisation user count for single creator role after removing other roles")
         void shouldDecrementOrganisationUserCountForSingleCreatorRoleAfterRemovingOtherRoles() {
+
             // ARRANGE
+            when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(false);
+
             List<CaseAssignedUserRoleWithOrganisation> caseUserRoles = Lists.newArrayList(
                 new CaseAssignedUserRoleWithOrganisation(CASE_REFERENCE.toString(), USER_ID, CASE_ROLE, ORGANISATION)
             );
 
             // for an existing relation and then after removal
-            when(caseUserRepository.findCaseUserRoles(
-                argThat(arg -> arg.contains(CASE_ID)),
-                argThat(arg -> arg.contains(USER_ID))
-            )).thenReturn(List.of(
-                createCaseUserEntity(CASE_ID, CASE_ROLE, USER_ID),
-                createCaseUserEntity(CASE_ID, CASE_ROLE_CREATOR, USER_ID)
-            )).thenReturn(List.of(
-                createCaseUserEntity(CASE_ID, CASE_ROLE_CREATOR, USER_ID)
-            ));
+            mockExistingCaseUserRoles(
+                // before
+                List.of(
+                    createCaseUserEntity(CASE_ID, CASE_ROLE, USER_ID),
+                    createCaseUserEntity(CASE_ID, CASE_ROLE_CREATOR, USER_ID)
+                ),
+                // after
+                List.of(
+                    createCaseUserEntity(CASE_ID, CASE_ROLE_CREATOR, USER_ID)
+                )
+            );
 
             // ACT
             caseAccessOperation.removeCaseUserRoles(caseUserRoles);
@@ -1529,63 +1917,191 @@ class CaseAccessOperationTest {
             // ASSERT
             verify(supplementaryDataRepository, times(1))
                 .incrementSupplementaryData(CASE_REFERENCE.toString(), getOrgUserCountSupDataKey(ORGANISATION), -1L);
+
+            verifyNoInteractions(roleAssignmentService);
+        }
+
+        @Test
+        @DisplayName(
+            "RA set to true, "
+                + "should decrement organisation user count for single creator role after removing other roles"
+        )
+        void shouldDecrementOrganisationUserCountForSingleCreatorRoleAfterRemovingOtherRolesForRA() {
+
+            // ARRANGE
+            when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(true);
+
+            List<CaseAssignedUserRoleWithOrganisation> caseUserRoles = Lists.newArrayList(
+                new CaseAssignedUserRoleWithOrganisation(CASE_REFERENCE.toString(), USER_ID, CASE_ROLE, ORGANISATION)
+            );
+
+            // for an existing relation and then after removal
+            mockExistingCaseUserRolesForRA(
+                // before
+                List.of(
+                    new CaseAssignedUserRole(CASE_REFERENCE.toString(), USER_ID, CASE_ROLE),
+                    new CaseAssignedUserRole(CASE_REFERENCE.toString(), USER_ID, CASE_ROLE_CREATOR)
+                ),
+                // after
+                List.of(
+                    new CaseAssignedUserRole(CASE_REFERENCE.toString(), USER_ID, CASE_ROLE_CREATOR)
+                )
+            );
+
+            // ACT
+            caseAccessOperation.removeCaseUserRoles(caseUserRoles);
+
+            // ASSERT
+            verify(supplementaryDataRepository, times(1))
+                .incrementSupplementaryData(CASE_REFERENCE.toString(), getOrgUserCountSupDataKey(ORGANISATION), -1L);
+
+            verifyNoInteractions(caseUserRepository);
         }
 
         @Test
         @DisplayName("should not decrement organisation user count after removing creator role")
         void shouldNotDecrementOrganisationUserCountAfterRemovingCreatorRole() {
+
             // ARRANGE
+            when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(false);
+
             List<CaseAssignedUserRoleWithOrganisation> caseUserRoles = Lists.newArrayList(
                 new CaseAssignedUserRoleWithOrganisation(
                     CASE_REFERENCE.toString(), USER_ID, CASE_ROLE_CREATOR, ORGANISATION)
             );
 
             // for an existing relation and then after removal
-            when(caseUserRepository.findCaseUserRoles(
-                argThat(arg -> arg.contains(CASE_ID)),
-                argThat(arg -> arg.contains(USER_ID))
-            )).thenReturn(List.of(
-                createCaseUserEntity(CASE_ID, CASE_ROLE, USER_ID),
-                createCaseUserEntity(CASE_ID, CASE_ROLE_CREATOR, USER_ID)
-            )).thenReturn(List.of(
-                createCaseUserEntity(CASE_ID, CASE_ROLE, USER_ID)
-            ));
+            mockExistingCaseUserRoles(
+                // before
+                List.of(
+                    createCaseUserEntity(CASE_ID, CASE_ROLE, USER_ID),
+                    createCaseUserEntity(CASE_ID, CASE_ROLE_CREATOR, USER_ID)
+                ),
+                // after
+                List.of(
+                    createCaseUserEntity(CASE_ID, CASE_ROLE, USER_ID)
+                )
+            );
 
             // ACT
             caseAccessOperation.removeCaseUserRoles(caseUserRoles);
 
             // ASSERT
             verify(supplementaryDataRepository, never()).incrementSupplementaryData(anyString(), anyString(), any());
+
+            verifyNoInteractions(roleAssignmentService);
+        }
+
+        @Test
+        @DisplayName("RA set to true, should not decrement organisation user count after removing creator role")
+        void shouldNotDecrementOrganisationUserCountAfterRemovingCreatorRoleForRA() {
+
+            // ARRANGE
+            when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(true);
+
+            List<CaseAssignedUserRoleWithOrganisation> caseUserRoles = Lists.newArrayList(
+                new CaseAssignedUserRoleWithOrganisation(
+                    CASE_REFERENCE.toString(), USER_ID, CASE_ROLE_CREATOR, ORGANISATION)
+            );
+
+            // for an existing relation and then after removal
+            mockExistingCaseUserRolesForRA(
+                // before
+                List.of(
+                    new CaseAssignedUserRole(CASE_REFERENCE.toString(), USER_ID, CASE_ROLE),
+                    new CaseAssignedUserRole(CASE_REFERENCE.toString(), USER_ID, CASE_ROLE_CREATOR)
+                ),
+                // after
+                List.of(
+                    new CaseAssignedUserRole(CASE_REFERENCE.toString(), USER_ID, CASE_ROLE)
+                )
+            );
+
+            // ACT
+            caseAccessOperation.removeCaseUserRoles(caseUserRoles);
+
+            // ASSERT
+            verify(supplementaryDataRepository, never()).incrementSupplementaryData(anyString(), anyString(), any());
+
+            verifyNoInteractions(caseUserRepository);
         }
 
         @Test
         @DisplayName("should not decrement organisation user count for an existing relationship with another role")
         void shouldNotDecrementOrganisationUserCountForAnExistingRelationshipWithOtherRole() {
+
             // ARRANGE
+            when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(false);
+
             List<CaseAssignedUserRoleWithOrganisation> caseUserRoles = Lists.newArrayList(
                 new CaseAssignedUserRoleWithOrganisation(CASE_REFERENCE.toString(), USER_ID, CASE_ROLE, ORGANISATION)
             );
 
             // for an existing relation and then after removal
-            when(caseUserRepository.findCaseUserRoles(
-                argThat(arg -> arg.contains(CASE_ID)),
-                argThat(arg -> arg.contains(USER_ID))
-            )).thenReturn(List.of(
-                createCaseUserEntity(CASE_ID, CASE_ROLE, USER_ID),
-                createCaseUserEntity(CASE_ID, CASE_ROLE_OTHER, USER_ID)
-            )).thenReturn(List.of(createCaseUserEntity(CASE_ID, CASE_ROLE_OTHER, USER_ID)));
+            mockExistingCaseUserRoles(
+                // before
+                List.of(
+                    createCaseUserEntity(CASE_ID, CASE_ROLE, USER_ID),
+                    createCaseUserEntity(CASE_ID, CASE_ROLE_OTHER, USER_ID)
+                ),
+                // after
+                List.of(
+                    createCaseUserEntity(CASE_ID, CASE_ROLE_OTHER, USER_ID)
+                )
+            );
 
             // ACT
             caseAccessOperation.removeCaseUserRoles(caseUserRoles);
 
             // ASSERT
             verify(supplementaryDataRepository, never()).incrementSupplementaryData(anyString(), anyString(), any());
+
+            verifyNoInteractions(roleAssignmentService);
+        }
+
+        @Test
+        @DisplayName(
+            "RA set to true, "
+                + "should not decrement organisation user count for an existing relationship with another role"
+        )
+        void shouldNotDecrementOrganisationUserCountForAnExistingRelationshipWithOtherRoleForRA() {
+
+            // ARRANGE
+            when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(true);
+
+            List<CaseAssignedUserRoleWithOrganisation> caseUserRoles = Lists.newArrayList(
+                new CaseAssignedUserRoleWithOrganisation(CASE_REFERENCE.toString(), USER_ID, CASE_ROLE, ORGANISATION)
+            );
+
+            // for an existing relation and then after removal
+            mockExistingCaseUserRolesForRA(
+                // before
+                List.of(
+                    new CaseAssignedUserRole(CASE_REFERENCE.toString(), USER_ID, CASE_ROLE),
+                    new CaseAssignedUserRole(CASE_REFERENCE.toString(), USER_ID, CASE_ROLE_OTHER)
+                ),
+                // after
+                List.of(
+                    new CaseAssignedUserRole(CASE_REFERENCE.toString(), USER_ID, CASE_ROLE_OTHER)
+                )
+            );
+
+            // ACT
+            caseAccessOperation.removeCaseUserRoles(caseUserRoles);
+
+            // ASSERT
+            verify(supplementaryDataRepository, never()).incrementSupplementaryData(anyString(), anyString(), any());
+
+            verifyNoInteractions(caseUserRepository);
         }
 
         @Test
         @DisplayName("should decrement organisation user count for multiple case-user relationship")
         void shouldDecrementOrganisationUserCountForMultipleRelationships() {
+
             // ARRANGE
+            when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(false);
+
             List<CaseAssignedUserRoleWithOrganisation> caseUserRoles = Lists.newArrayList(
                 // CASE_REFERENCE/CASE_ID
                 // (2 orgs with 2 users with 2 roles >> 2 org counts decremented by 1)
@@ -1594,19 +2110,22 @@ class CaseAccessOperationTest {
                     ORGANISATION),
                 new CaseAssignedUserRoleWithOrganisation(CASE_REFERENCE.toString(), USER_ID, CASE_ROLE_OTHER,
                     ORGANISATION_OTHER)
-
             );
+
             // for an existing relation and then after removal
-            when(caseUserRepository.findCaseUserRoles(
-                argThat(arg -> arg.contains(CASE_ID)),
-                argThat(arg -> arg.contains(USER_ID) && arg.contains(USER_ID_OTHER))
-            )).thenReturn(List.of(
-                createCaseUserEntity(CASE_ID, CASE_ROLE, USER_ID), createCaseUserEntity(CASE_ID, CASE_ROLE,
-                    USER_ID_OTHER),
-                createCaseUserEntity(CASE_ID, CASE_ROLE_OTHER, USER_ID), createCaseUserEntity(CASE_ID, CASE_ROLE_OTHER,
-                    USER_ID_OTHER)
-            ))
-                .thenReturn(List.of(createCaseUserEntity(CASE_ID, CASE_ROLE_OTHER, USER_ID_OTHER)));
+            mockExistingCaseUserRoles(
+                // before
+                List.of(
+                    createCaseUserEntity(CASE_ID, CASE_ROLE, USER_ID),
+                    createCaseUserEntity(CASE_ID, CASE_ROLE, USER_ID_OTHER),
+                    createCaseUserEntity(CASE_ID, CASE_ROLE_OTHER, USER_ID),
+                    createCaseUserEntity(CASE_ID, CASE_ROLE_OTHER, USER_ID_OTHER)
+                ),
+                // after
+                List.of(
+                    createCaseUserEntity(CASE_ID, CASE_ROLE_OTHER, USER_ID_OTHER)
+                )
+            );
 
             // ACT
             caseAccessOperation.removeCaseUserRoles(caseUserRoles);
@@ -1618,7 +2137,56 @@ class CaseAccessOperationTest {
             verify(supplementaryDataRepository, times(1))
                 .incrementSupplementaryData(CASE_REFERENCE.toString(), getOrgUserCountSupDataKey(ORGANISATION_OTHER),
                     -1L);
+
+            verifyNoInteractions(roleAssignmentService);
         }
+
+        @Test
+        @DisplayName("RA set to true, should decrement organisation user count for multiple case-user relationship")
+        void shouldDecrementOrganisationUserCountForMultipleRelationshipsForRA() {
+
+            // ARRANGE
+            when(applicationParams.getEnableAttributeBasedAccessControl()).thenReturn(true);
+
+            List<CaseAssignedUserRoleWithOrganisation> caseUserRoles = Lists.newArrayList(
+                // CASE_REFERENCE/CASE_ID
+                // (2 orgs with 2 users with 2 roles >> 2 org counts decremented by 1)
+                new CaseAssignedUserRoleWithOrganisation(CASE_REFERENCE.toString(), USER_ID, CASE_ROLE, ORGANISATION),
+                new CaseAssignedUserRoleWithOrganisation(CASE_REFERENCE.toString(), USER_ID_OTHER, CASE_ROLE,
+                    ORGANISATION),
+                new CaseAssignedUserRoleWithOrganisation(CASE_REFERENCE.toString(), USER_ID, CASE_ROLE_OTHER,
+                    ORGANISATION_OTHER)
+            );
+
+            // for an existing relation and then after removal
+            mockExistingCaseUserRolesForRA(
+                // before
+                List.of(
+                    new CaseAssignedUserRole(CASE_REFERENCE.toString(), USER_ID, CASE_ROLE),
+                    new CaseAssignedUserRole(CASE_REFERENCE.toString(), USER_ID, CASE_ROLE_OTHER),
+                    new CaseAssignedUserRole(CASE_REFERENCE.toString(), USER_ID_OTHER, CASE_ROLE),
+                    new CaseAssignedUserRole(CASE_REFERENCE.toString(), USER_ID_OTHER, CASE_ROLE_OTHER)
+                ),
+                // after
+                List.of(
+                    new CaseAssignedUserRole(CASE_REFERENCE.toString(), USER_ID_OTHER, CASE_ROLE_OTHER)
+                )
+            );
+
+            // ACT
+            caseAccessOperation.removeCaseUserRoles(caseUserRoles);
+
+            // ASSERT
+            // verify CASE_REFERENCE/CASE_ID
+            verify(supplementaryDataRepository, times(1))
+                .incrementSupplementaryData(CASE_REFERENCE.toString(), getOrgUserCountSupDataKey(ORGANISATION), -1L);
+            verify(supplementaryDataRepository, times(1))
+                .incrementSupplementaryData(CASE_REFERENCE.toString(), getOrgUserCountSupDataKey(ORGANISATION_OTHER),
+                    -1L);
+
+            verifyNoInteractions(caseUserRepository);
+        }
+
     }
 
 
@@ -1764,19 +2332,54 @@ class CaseAccessOperationTest {
         return "orgs_assigned_users." + organisationId;
     }
 
-    private void mockExistingCaseUserRoles(List<CaseUserEntity> existingCaseUserRoles) {
-        when(caseUserRepository.findCaseUserRoles(
+    @SuppressWarnings("SameParameterValue")
+    private void assertCorrectlyPopulatedRoleAssignmentsDeleteRequest(
+        final String expectedCaseId,
+        final String expectedUserId,
+        final List<String> expectedRoleNames,
+        final RoleAssignmentsDeleteRequest actualRoleAssignmentsDeleteRequest
+    ) {
+        assertNotNull(actualRoleAssignmentsDeleteRequest);
+        assertAll(
+            () -> assertEquals(expectedCaseId, actualRoleAssignmentsDeleteRequest.getCaseId()),
+            () -> assertEquals(expectedUserId, actualRoleAssignmentsDeleteRequest.getUserId()),
+            () -> assertEquals(expectedRoleNames.size(), actualRoleAssignmentsDeleteRequest.getRoleNames().size()),
+            () -> assertThat(
+                actualRoleAssignmentsDeleteRequest.getRoleNames(),
+                containsInAnyOrder(expectedRoleNames.toArray())
+            )
+        );
+    }
+
+    private OngoingStubbing<List<CaseUserEntity>> mockExistingCaseUserRoles(
+        List<CaseUserEntity> existingCaseUserRoles
+    ) {
+        return when(caseUserRepository.findCaseUserRoles(
             argThat(arg -> arg.contains(CASE_ID) || arg.contains(CASE_ID_OTHER)),
             argThat(arg -> arg.contains(USER_ID) || arg.isEmpty()))
         ).thenReturn(existingCaseUserRoles);
     }
 
-    private void mockExistingCaseUserRolesForRA(List<CaseAssignedUserRole> existingCaseUserRoles) {
-        when(roleAssignmentService.findRoleAssignmentsByCasesAndUsers(
+    private void mockExistingCaseUserRoles(List<CaseUserEntity> existingCaseUserRoles,
+                                           List<CaseUserEntity> secondCallCaseUserRoles) {
+        mockExistingCaseUserRoles(existingCaseUserRoles)
+            .thenReturn(secondCallCaseUserRoles);
+    }
+
+    private OngoingStubbing<List<CaseAssignedUserRole>> mockExistingCaseUserRolesForRA(
+        List<CaseAssignedUserRole> existingCaseUserRoles
+    ) {
+        return when(roleAssignmentService.findRoleAssignmentsByCasesAndUsers(
             argThat(arg -> arg.contains(CASE_REFERENCE.toString())
-                        || arg.contains(CASE_REFERENCE_OTHER.toString())),
+                || arg.contains(CASE_REFERENCE_OTHER.toString())),
             argThat(arg -> arg.contains(USER_ID) || arg.isEmpty()))
         ).thenReturn(existingCaseUserRoles);
+    }
+
+    private void mockExistingCaseUserRolesForRA(List<CaseAssignedUserRole> existingCaseUserRoles,
+                                                List<CaseAssignedUserRole> secondCallCaseUserRoles) {
+        mockExistingCaseUserRolesForRA(existingCaseUserRoles)
+            .thenReturn(secondCallCaseUserRoles);
     }
 
 }

--- a/src/test/resources/mappings/roleassignmentservice/delete_role_assignments_by_query.json
+++ b/src/test/resources/mappings/roleassignmentservice/delete_role_assignments_by_query.json
@@ -1,0 +1,13 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPathPattern": "/am/role-assignments/query/delete"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {}
+  }
+}


### PR DESCRIPTION
 ### JIRA link (if applicable) ###

[RDM-10918](https://tools.hmcts.net/jira/browse/RDM-10918) _"Migrate Revoke Access APIs to new Access Control."_

### Change description ###

Migrate the following revoke case-role APIs across to to new Access Control (Role Assignment Service)

*  Revoke Access V1, see [F-046](https://github.com/hmcts/ccd-data-store-api/blob/master/src/aat/resources/features/F-046%20-%20Revoke%20Access%20V1/F-046.feature)
* Remove Case-Assigned Users and Roles, see [F-111](https://github.com/hmcts/ccd-data-store-api/blob/master/src/aat/resources/features/F-111%20-%20Remove%20Case-Assigned%20Users%20and%20Roles/F-111.feature)

> NB: This PR is currently based of PR #1555 as there are a number of shared changes between the _"Remove Case-Assigned Users and Roles"_ processing and the _"Add Case-Assigned Users and Roles"_ migrated in [RDM-10924](https://tools.hmcts.net/jira/browse/RDM-10924).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
