### PR TITLE
RDM-12724: Resolve differences in behaviour with migrated case role functions

### DIFF
--- a/src/aat/resources/features/F-045 - Grant Access V1/Befta_Jurisdiction2/F-045_Befta_Jurisdiction2_Full_Case_Creation_Data.td.json
+++ b/src/aat/resources/features/F-045 - Grant Access V1/Befta_Jurisdiction2/F-045_Befta_Jurisdiction2_Full_Case_Creation_Data.td.json
@@ -1,0 +1,20 @@
+{
+	"_guid_": "F-045_Befta_Jurisdiction2_Full_Case_Creation_Data",
+	"_extends_": "Befta_Jurisdiction2_Default_Full_Case_Creation_Data_solicitor_1",
+
+	"specs": [
+		"to create a full case"
+	],
+
+	"users": {
+		"invokingUser": {
+			"_extends_": "BeftaCaseworker2Solicitor2"
+		}
+	},
+
+	"request": {
+		"body" : {
+			"event_token" : "${[scenarioContext][siblingContexts][F-045_Befta_Jurisdiction2_Full_Case_Creation_Data_Token_Creation][testData][actualResponse][body][token]}"
+		}
+	}
+}

--- a/src/aat/resources/features/F-045 - Grant Access V1/Befta_Jurisdiction2/F-045_Befta_Jurisdiction2_Full_Case_Creation_Data_Token_Creation.td.json
+++ b/src/aat/resources/features/F-045 - Grant Access V1/Befta_Jurisdiction2/F-045_Befta_Jurisdiction2_Full_Case_Creation_Data_Token_Creation.td.json
@@ -1,0 +1,14 @@
+{
+	"_guid_": "F-045_Befta_Jurisdiction2_Full_Case_Creation_Data_Token_Creation",
+	"_extends_": "Befta_Jurisdiction2_Default_Token_Creation_Data_For_Case_Creation_Solicitor_1",
+
+	"specs": [
+		"to create a token for case creation"
+	],
+
+	"users": {
+		"invokingUser": {
+			"_extends_": "BeftaCaseworker2Solicitor2"
+		}
+	}
+}

--- a/src/aat/resources/features/F-045 - Grant Access V1/Befta_Jurisdiction2/F-045_Grant_Case_Role.td.json
+++ b/src/aat/resources/features/F-045 - Grant Access V1/Befta_Jurisdiction2/F-045_Grant_Case_Role.td.json
@@ -1,0 +1,39 @@
+{
+	"_guid_": "F-045_Grant_Case_Role",
+
+	"productName": "CCD Data Store",
+	"operationName": "Grant access to a case",
+
+	"method": "PUT",
+	"uri": "/cases/{cid}/users/{uid}",
+
+	"specs": [
+		"to grant an extra case-role to the case"
+	],
+
+	"users": {
+		"invokingUser": {
+			"_extends_": "BeftaCaseworker2Solicitor2"
+		}
+	},
+
+	"request": {
+		"_extends_": "Common_Request",
+		"pathVariables": {
+			"cid": "${[scenarioContext][siblingContexts][F-045_Befta_Jurisdiction2_Full_Case_Creation_Data][testData][actualResponse][body][id]}",
+			"uid": "${[scenarioContext][parentContext][testData][users][testUser][id]}"
+		},
+		"body": {
+			"case_roles": [
+				"[DEFENDANT]"
+			]
+		}
+	},
+
+	"expectedResponse": {
+		"_extends_": "Common_204_Response",
+		"headers": {
+			"Content-Type": "[[ANY_STRING_NULLABLE]]"
+		}
+	}
+}

--- a/src/aat/resources/features/F-045 - Grant Access V1/Befta_Jurisdiction2/F-045_Verify_Granted_Extra_Case_Role_for_Case.td.json
+++ b/src/aat/resources/features/F-045 - Grant Access V1/Befta_Jurisdiction2/F-045_Verify_Granted_Extra_Case_Role_for_Case.td.json
@@ -1,0 +1,30 @@
+{
+	"_guid_": "F-045_Verify_Granted_Extra_Case_Role_for_Case",
+	"_extends_": "F-045_Get_Case_Roles_for_Case__Base",
+
+	"specs": [
+	  "to verify testUser has been granted the extra case role for the case"
+	],
+
+	"request": {
+		"queryParams": {
+			"case_ids": "${[scenarioContext][siblingContexts][F-045_Befta_Jurisdiction2_Full_Case_Creation_Data][testData][actualResponse][body][id]}"
+		}
+	},
+
+	"expectedResponse": {
+		"body": {
+			"case_users": [
+				{
+					"__ordering__": "UNORDERED",
+					"__elementId__": "case_id,user_id,case_role"
+				},
+				{
+					"case_id": "${}${[scenarioContext][siblingContexts][F-045_Befta_Jurisdiction2_Full_Case_Creation_Data][testData][actualResponse][body][id]}",
+					"user_id": "${[scenarioContext][parentContext][testData][users][testUser][id]}",
+					"case_role": "[DEFENDANT]"
+				}
+			]
+		}
+	}
+}

--- a/src/aat/resources/features/F-045 - Grant Access V1/Befta_Jurisdiction2/F-045_Verify_Granted_Multiple_Case_Roles_for_Case.td.json
+++ b/src/aat/resources/features/F-045 - Grant Access V1/Befta_Jurisdiction2/F-045_Verify_Granted_Multiple_Case_Roles_for_Case.td.json
@@ -1,0 +1,35 @@
+{
+	"_guid_": "F-045_Verify_Granted_Multiple_Case_Roles_for_Case",
+	"_extends_": "F-045_Get_Case_Roles_for_Case__Base",
+
+	"specs": [
+	  "to verify testUser has been granted multiple case roles for the case"
+	],
+
+	"request": {
+		"queryParams": {
+			"case_ids": "${[scenarioContext][siblingContexts][F-045_Befta_Jurisdiction2_Full_Case_Creation_Data][testData][actualResponse][body][id]}"
+		}
+	},
+
+	"expectedResponse": {
+		"body": {
+			"case_users": [
+				{
+					"__ordering__": "UNORDERED",
+					"__elementId__": "case_id,user_id,case_role"
+				},
+				{
+					"case_id": "${}${[scenarioContext][siblingContexts][F-045_Befta_Jurisdiction2_Full_Case_Creation_Data][testData][actualResponse][body][id]}",
+					"user_id": "${[scenarioContext][parentContext][testData][users][testUser][id]}",
+					"case_role": "[DEFENDANT]"
+				},
+				{
+					"case_id": "${}${[scenarioContext][siblingContexts][F-045_Befta_Jurisdiction2_Full_Case_Creation_Data][testData][actualResponse][body][id]}",
+					"user_id": "${[scenarioContext][parentContext][testData][users][testUser][id]}",
+					"case_role": "[CREATOR]"
+				}
+			]
+		}
+	}
+}

--- a/src/aat/resources/features/F-045 - Grant Access V1/F-045.feature
+++ b/src/aat/resources/features/F-045 - Grant Access V1/F-045.feature
@@ -13,6 +13,7 @@ Scenario: must return 201 if the grant is successful for a user to a valid case 
     Given a user with [an active profile in CCD],
       And a user [testUser - with an active profile in CCD],
       And a case that has just been created as in [Standard_Full_Case_Creation_Data],
+      And a call [to verify testUser has been granted no case roles for the case] will get the expected response as in [F-045_Verify_Granted_No_Case_Roles_for_Case],
 
      When a request is prepared with appropriate values,
       And the request [uses the id of the case just created],
@@ -20,7 +21,8 @@ Scenario: must return 201 if the grant is successful for a user to a valid case 
 
      Then a positive response is received,
       And the response [has the 201 return code],
-      And the response has all other details as expected.
+      And the response has all other details as expected,
+      And a call [to verify testUser has been granted a case role for the case] will get the expected response as in [F-045_Verify_Granted_Case_Role_for_Case].
 
 #-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 @S-152
@@ -96,5 +98,24 @@ Scenario: must return negative response when case id contains some non-numeric c
      Then a negative response is received,
       And the response [has the 400 return code],
       And the response has all other details as expected.
+
+#-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+@S-045.07
+Scenario: must grant without removing other case roles
+
+    Given a user with [an active profile in CCD],
+      And a user [testUser - with an active profile in CCD],
+      And a case that has just been created as in [F-045_Befta_Jurisdiction2_Full_Case_Creation_Data],
+      And a call [to grant an extra case-role to the case] will get the expected response as in [F-045_Grant_Case_Role],
+      And a call [to verify testUser has been granted the extra case role for the case] will get the expected response as in [F-045_Verify_Granted_Extra_Case_Role_for_Case],
+
+     When a request is prepared with appropriate values,
+      And the request [uses the id of the case just created],
+      And it is submitted to call the [Grant access to case] operation of [CCD Data Store],
+
+     Then a positive response is received,
+      And the response [has the 201 return code],
+      And the response has all other details as expected,
+      And a call [to verify testUser has been granted multiple case roles for the case] will get the expected response as in [F-045_Verify_Granted_Multiple_Case_Roles_for_Case].
 
 #-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/src/aat/resources/features/F-045 - Grant Access V1/F-045_Get_Case_Roles_for_Case__Base.td.json
+++ b/src/aat/resources/features/F-045 - Grant Access V1/F-045_Get_Case_Roles_for_Case__Base.td.json
@@ -1,0 +1,34 @@
+{
+	"_guid_": "F-045_Get_Case_Roles_for_Case__Base",
+
+	"productName": "CCD Data Store",
+	"operationName": "Get Case-Assigned Users and Roles",
+
+	"method": "GET",
+	"uri": "/case-users",
+
+
+	"users": {
+		"invokingUser": {
+			"_extends_": "BeftaCaseworkerCaa"
+		}
+	},
+
+	"request": {
+		"_extends_": "Common_Request",
+		"queryParams": {
+			"case_ids": "${[scenarioContext][siblingContexts][Standard_Full_Case_Creation_Data][testData][actualResponse][body][id]}",
+			"user_ids": "${[scenarioContext][parentContext][testData][users][testUser][id]}"
+		}
+	},
+
+	"expectedResponse": {
+		"_extends_": "Common_200_Response",
+		"headers": {
+			"_extends_": "Common_Response_Headers",
+			"Content-Length": "[[ANYTHING_PRESENT]]",
+			"Content-Type": "[[ANYTHING_PRESENT]]",
+			"Content-Encoding": "[[ANYTHING_PRESENT]]"
+		}
+	}
+}

--- a/src/aat/resources/features/F-045 - Grant Access V1/F-045_Verify_Granted_Case_Role_for_Case.td.json
+++ b/src/aat/resources/features/F-045 - Grant Access V1/F-045_Verify_Granted_Case_Role_for_Case.td.json
@@ -1,0 +1,24 @@
+{
+	"_guid_": "F-045_Verify_Granted_Case_Role_for_Case",
+	"_extends_": "F-045_Get_Case_Roles_for_Case__Base",
+
+	"specs": [
+	  "to verify testUser has been granted a case role for the case"
+	],
+
+	"expectedResponse": {
+		"body": {
+			"case_users": [
+				{
+					"__ordering__": "UNORDERED",
+					"__elementId__": "case_id,user_id,case_role"
+				},
+				{
+					"case_id": "${}${[scenarioContext][siblingContexts][Standard_Full_Case_Creation_Data][testData][actualResponse][body][id]}",
+					"user_id": "${[scenarioContext][parentContext][testData][users][testUser][id]}",
+					"case_role": "[CREATOR]"
+				}
+			]
+		}
+	}
+}

--- a/src/aat/resources/features/F-045 - Grant Access V1/F-045_Verify_Granted_No_Case_Roles_for_Case.td.json
+++ b/src/aat/resources/features/F-045 - Grant Access V1/F-045_Verify_Granted_No_Case_Roles_for_Case.td.json
@@ -1,0 +1,14 @@
+{
+	"_guid_": "F-045_Verify_Granted_No_Case_Roles_for_Case",
+	"_extends_": "F-045_Get_Case_Roles_for_Case__Base",
+
+	"specs": [
+	  "to verify testUser has been granted no case roles for the case"
+	],
+
+	"expectedResponse": {
+		"body": {
+			"case_users": []
+		}
+	}
+}

--- a/src/aat/resources/features/F-045 - Grant Access V1/S-045.07.td.json
+++ b/src/aat/resources/features/F-045 - Grant Access V1/S-045.07.td.json
@@ -1,0 +1,39 @@
+{
+	"_guid_": "S-045.07",
+	"_extends_": "F-045_Test_Data_Base",
+	"title": "must grant without removing other case roles",
+
+	"specs": [
+		"an active profile in CCD",
+		"testUser - with an active profile in CCD",
+		"uses the id of the case just created",
+		"has the 201 return code"
+	],
+
+	"users": {
+		"invokingUser": {
+			"_extends_": "BeftaCaseworker2Solicitor2"
+		},
+		"testUser": {
+			"_extends_": "BeftaCaseworker2Solicitor3"
+		}
+
+	},
+
+	"request": {
+		"pathVariables": {
+			"jid": "${[scenarioContext][childContexts][F-045_Befta_Jurisdiction2_Full_Case_Creation_Data][testData][actualResponse][body][jurisdiction]}",
+			"ctid": "${[scenarioContext][childContexts][F-045_Befta_Jurisdiction2_Full_Case_Creation_Data][testData][actualResponse][body][case_type_id]}",
+			"cid": "${[scenarioContext][childContexts][F-045_Befta_Jurisdiction2_Full_Case_Creation_Data][testData][actualResponse][body][id]}"
+		}
+	},
+
+	"expectedResponse": {
+		"_extends_": "Common_201_Response",
+		"headers": {
+			"Content-Length": "[[ANYTHING_PRESENT]]",
+			"Content-Type": "[[ANY_STRING_NULLABLE]]",
+			"Vary": "Accept-Encoding"
+		}
+	}
+}

--- a/src/aat/resources/features/F-046 - Revoke Access V1/F-046.feature
+++ b/src/aat/resources/features/F-046 - Revoke Access V1/F-046.feature
@@ -12,6 +12,9 @@ Scenario: must return 204 if access is successfully revoked for a user on a case
 
     Given a case that has just been created as in [Standard_Full_Case_Creation_Data],
       And a user with [an active profile in CCD],
+      And a user [testUser - with an active profile in CCD],
+      And a call [to grant testUser access to the case] will get the expected response as in [F-046_Grant_Access],
+      And a call [to verify testUser has been granted a case role for the case] will get the expected response as in [F-046_Verify_Granted_Case_Role_for_Case],
 
      When a request is prepared with appropriate values,
       And the request [contains a valid case id],
@@ -19,7 +22,8 @@ Scenario: must return 204 if access is successfully revoked for a user on a case
 
      Then a positive response is received,
       And the response [has a 204 no content code],
-      And the response has all other details as expected.
+      And the response has all other details as expected,
+      And a call [to verify testUser has been granted no case roles for the case] will get the expected response as in [F-046_Verify_Granted_No_Case_Roles_for_Case].
 
 #-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 @S-223 # ACTUALLY returns a 404
@@ -27,6 +31,7 @@ Scenario: must return 400 if case id is invalid
 
     Given a case that has just been created as in [Standard_Full_Case_Creation_Data],
       And a user with [an active profile in CCD],
+      And a user [testUser - with an active profile in CCD],
 
      When a request is prepared with appropriate values,
       And the request [contains an invalid case id],

--- a/src/aat/resources/features/F-046 - Revoke Access V1/F-046_Base_Request_Data.td.json
+++ b/src/aat/resources/features/F-046 - Revoke Access V1/F-046_Base_Request_Data.td.json
@@ -10,6 +10,9 @@
 	"users": {
 		"invokingUser": {
 			"_extends_": "Common_User_For_Request"
+		},
+		"testUser": {
+			"_extends_": "PrivateCaseworker"
 		}
 	},
 
@@ -20,7 +23,7 @@
 			"jid": "AUTOTEST1",
 			"ctid": "AAT",
 			"cid": "[[DEFAULT_AUTO_VALUE]]",
-			"idToDelete": "${[scenarioContext][theInvokingUser][id]}"
+			"idToDelete": "${[scenarioContext][testData][users][testUser][id]}"
 		}
 	}
 }

--- a/src/aat/resources/features/F-046 - Revoke Access V1/F-046_Get_Case_Roles_for_Case__Base.td.json
+++ b/src/aat/resources/features/F-046 - Revoke Access V1/F-046_Get_Case_Roles_for_Case__Base.td.json
@@ -1,0 +1,34 @@
+{
+	"_guid_": "F-046_Get_Case_Roles_for_Case__Base",
+
+	"productName": "CCD Data Store",
+	"operationName": "Get Case-Assigned Users and Roles",
+
+	"method": "GET",
+	"uri": "/case-users",
+
+
+	"users": {
+		"invokingUser": {
+			"_extends_": "BeftaCaseworkerCaa"
+		}
+	},
+
+	"request": {
+		"_extends_": "Common_Request",
+		"queryParams": {
+			"case_ids": "${[scenarioContext][siblingContexts][Standard_Full_Case_Creation_Data][testData][actualResponse][body][id]}",
+			"user_ids": "${[scenarioContext][parentContext][testData][users][testUser][id]}"
+		}
+	},
+
+	"expectedResponse": {
+		"_extends_": "Common_200_Response",
+		"headers": {
+			"_extends_": "Common_Response_Headers",
+			"Content-Length": "[[ANYTHING_PRESENT]]",
+			"Content-Type": "[[ANYTHING_PRESENT]]",
+			"Content-Encoding": "[[ANYTHING_PRESENT]]"
+		}
+	}
+}

--- a/src/aat/resources/features/F-046 - Revoke Access V1/F-046_Grant_Access.td.json
+++ b/src/aat/resources/features/F-046 - Revoke Access V1/F-046_Grant_Access.td.json
@@ -1,0 +1,45 @@
+{
+	"_guid_": "F-046_Grant_Access",
+
+	"productName": "CCD Data Store",
+	"operationName": "Grant access to case",
+
+	"method": "POST",
+	"uri": "/caseworkers/{uid}/jurisdictions/{jid}/case-types/{ctid}/cases/{cid}/users",
+
+	"specs": [
+	  "to grant testUser access to the case"
+	],
+
+	"users": {
+		"invokingUser": {
+			"_extends_": "Common_User_For_Request"
+		},
+		"testUser": {
+			"_extends_": "PrivateCaseworker"
+		}
+
+	},
+
+	"request": {
+		"_extends_": "Common_Request",
+		"pathVariables": {
+			"uid": "[[DEFAULT_AUTO_VALUE]]",
+			"jid": "AUTOTEST1",
+			"cid": "${[scenarioContext][siblingContexts][Standard_Full_Case_Creation_Data][testData][actualResponse][body][id]}",
+			"ctid": "AAT"
+		},
+		"body": {
+			"id": "${[scenarioContext][testData][users][testUser][id]}"
+		}
+	},
+
+	"expectedResponse": {
+		"_extends_": "Common_201_Response",
+		"headers": {
+			"Content-Length": "[[ANYTHING_PRESENT]]",
+			"Content-Type": "[[ANY_STRING_NULLABLE]]",
+			"Vary": "Accept-Encoding"
+		}
+	}
+}

--- a/src/aat/resources/features/F-046 - Revoke Access V1/F-046_Verify_Granted_Case_Role_for_Case.td.json
+++ b/src/aat/resources/features/F-046 - Revoke Access V1/F-046_Verify_Granted_Case_Role_for_Case.td.json
@@ -1,0 +1,24 @@
+{
+	"_guid_": "F-046_Verify_Granted_Case_Role_for_Case",
+	"_extends_": "F-046_Get_Case_Roles_for_Case__Base",
+
+	"specs": [
+	  "to verify testUser has been granted a case role for the case"
+	],
+
+	"expectedResponse": {
+		"body": {
+			"case_users": [
+				{
+					"__ordering__": "UNORDERED",
+					"__elementId__": "case_id,user_id,case_role"
+				},
+				{
+					"case_id": "${}${[scenarioContext][siblingContexts][Standard_Full_Case_Creation_Data][testData][actualResponse][body][id]}",
+					"user_id": "${[scenarioContext][parentContext][testData][users][testUser][id]}",
+					"case_role": "[CREATOR]"
+				}
+			]
+		}
+	}
+}

--- a/src/aat/resources/features/F-046 - Revoke Access V1/F-046_Verify_Granted_No_Case_Roles_for_Case.td.json
+++ b/src/aat/resources/features/F-046 - Revoke Access V1/F-046_Verify_Granted_No_Case_Roles_for_Case.td.json
@@ -1,0 +1,14 @@
+{
+	"_guid_": "F-046_Verify_Granted_No_Case_Roles_for_Case",
+	"_extends_": "F-046_Get_Case_Roles_for_Case__Base",
+
+	"specs": [
+	  "to verify testUser has been granted no case roles for the case"
+	],
+
+	"expectedResponse": {
+		"body": {
+			"case_users": []
+		}
+	}
+}

--- a/src/aat/resources/features/F-046 - Revoke Access V1/S-222.td.json
+++ b/src/aat/resources/features/F-046 - Revoke Access V1/S-222.td.json
@@ -5,6 +5,7 @@
 
 	"specs": [
 		"an active profile in CCD",
+		"testUser - with an active profile in CCD",
 		"contains a valid case id",
 		"has a 204 no content code"
 	],

--- a/src/aat/resources/features/F-046 - Revoke Access V1/S-223.td.json
+++ b/src/aat/resources/features/F-046 - Revoke Access V1/S-223.td.json
@@ -5,6 +5,7 @@
 
 	"specs": [
 		"an active profile in CCD",
+		"testUser - with an active profile in CCD",
 		"contains an invalid case id",
 		"has a 404 not found code"
 	],

--- a/src/aat/resources/features/F-047 - Get Case IDs/F-047.feature
+++ b/src/aat/resources/features/F-047 - Get Case IDs/F-047.feature
@@ -11,6 +11,7 @@ Background: Load test data for the scenario
 Scenario: must return 200 and a list of case ids a user has access to
 
     Given a user with [an active profile in CCD],
+      And a user [testUser - with an active profile in CCD],
       And a case that has just been created as in [Standard_Full_Case_Creation_Data],
       And a successful call [to grant access on the case just created] as in [F-047_Grant_Access],
 
@@ -26,6 +27,7 @@ Scenario: must return 200 and a list of case ids a user has access to
 Scenario: must return 200 and an empty list if no case is found
 
     Given a user with [an active profile in CCD],
+      And a user [testUser - with an active profile in CCD],
 
      When a request is prepared with appropriate values,
       And the request [contains an userId which doesn't have access to the case],
@@ -40,6 +42,7 @@ Scenario: must return 200 and an empty list if no case is found
 Scenario: must return 401 when request does not provide valid authentication credentials
 
     Given a user with [an active profile in CCD],
+      And a user [testUser - with an active profile in CCD],
 
      When a request is prepared with appropriate values,
       And the request [does not provide valid authentication credentials],
@@ -54,6 +57,7 @@ Scenario: must return 401 when request does not provide valid authentication cre
 Scenario: must return 403 when request provides authentic credentials without authorised access to the operation
 
     Given a user with [an active profile in CCD],
+      And a user [testUser - with an active profile in CCD],
 
      When a request is prepared with appropriate values,
       And the request [does not provide authorised access to the operation],
@@ -68,6 +72,7 @@ Scenario: must return 403 when request provides authentic credentials without au
 Scenario: must return negative response HTTP-400 when request contains a malformed user ID
 
     Given a user with [an inactive profile in CCD],
+      And a user [testUser - with an active profile in CCD],
 
      When a request is prepared with appropriate values,
       And the request [contains a malformed user ID],
@@ -82,6 +87,7 @@ Scenario: must return negative response HTTP-400 when request contains a malform
 Scenario: must return negative response HTTP-400 when request contains a malformed case type ID
 
     Given a user with [an active profile in CCD],
+      And a user [testUser - with an active profile in CCD],
 
      When a request is prepared with appropriate values,
       And the request [contains a malformed case type ID],
@@ -96,6 +102,7 @@ Scenario: must return negative response HTTP-400 when request contains a malform
 Scenario: must return negative response HTTP-400 when request contains a malformed jurisdiction ID
 
     Given a user with [an active profile in CCD],
+      And a user [testUser - with an active profile in CCD],
 
      When a request is prepared with appropriate values,
       And the request [contains a malformed jurisdiction ID],
@@ -110,6 +117,7 @@ Scenario: must return negative response HTTP-400 when request contains a malfor
 Scenario: must return negative response HTTP-400 when request contains a non-existing jurisdiction ID
 
     Given a user with [an active profile in CCD],
+      And a user [testUser - with an active profile in CCD],
 
      When a request is prepared with appropriate values,
       And the request [contains a non-existing jurisdiction ID],
@@ -124,6 +132,7 @@ Scenario: must return negative response HTTP-400 when request contains a non-ex
 Scenario: must return negative response HTTP-404 when request contains a non-existing case type ID
 
     Given a user with [an active profile in CCD],
+      And a user [testUser - with an active profile in CCD],
 
      When a request is prepared with appropriate values,
       And the request [contains a non-existing case type ID],
@@ -138,6 +147,7 @@ Scenario: must return negative response HTTP-404 when request contains a non-exi
 Scenario: must return negative response HTTP-403 when request contains a non-existing user ID
 
     Given a user with [an inactive profile in CCD],
+      And a user [testUser - with an active profile in CCD],
 
      When a request is prepared with appropriate values,
       And the request [contains a non-existing user ID],

--- a/src/aat/resources/features/F-047 - Get Case IDs/F-047_Grant_Access.td.json
+++ b/src/aat/resources/features/F-047 - Get Case IDs/F-047_Grant_Access.td.json
@@ -24,7 +24,7 @@
 			"cid": "${[scenarioContext][parentContext][childContexts][Standard_Full_Case_Creation_Data][testData][actualResponse][body][id]}"
 		},
 		"body": {
-			"id": "F047UserIdTest"
+			"id": "${[scenarioContext][parentContext][testData][users][testUser][id]}"
 		}
 	},
 

--- a/src/aat/resources/features/F-047 - Get Case IDs/F-047_Test_Data_Base.td.json
+++ b/src/aat/resources/features/F-047 - Get Case IDs/F-047_Test_Data_Base.td.json
@@ -7,8 +7,14 @@
 	"method": "GET",
 	"uri": "/caseworkers/{uid}/jurisdictions/{jid}/case-types/{ctid}/cases/ids",
 
-	"user": {
-		"_extends_": "Common_User_For_Request"
+	"users": {
+		"invokingUser": {
+			"_extends_": "Common_User_For_Request"
+		},
+		"testUser": {
+			"_extends_": "PrivateCaseworker"
+		}
+
 	},
 
 	"request": {
@@ -19,7 +25,7 @@
 			"ctid": "AAT"
 		},
 		"queryParams": {
-			"userId": "F047UserIdTest"
+			"userId": "${[scenarioContext][testData][users][testUser][id]}"
 		}
 	},
 

--- a/src/aat/resources/features/F-047 - Get Case IDs/S-097.td.json
+++ b/src/aat/resources/features/F-047 - Get Case IDs/S-097.td.json
@@ -5,6 +5,7 @@
 
 	"specs": [
 		"an active profile in CCD",
+		"testUser - with an active profile in CCD",
 		"contains a list of case ids, along with an HTTP-200 OK"
 	],
 

--- a/src/aat/resources/features/F-047 - Get Case IDs/S-098.td.json
+++ b/src/aat/resources/features/F-047 - Get Case IDs/S-098.td.json
@@ -5,6 +5,7 @@
 
 	"specs": [
 		"an active profile in CCD",
+		"testUser - with an active profile in CCD",
 		"contains an userId which doesn't have access to the case",
 		"contains an empty list of case ids, along with an HTTP-200 OK"
 	],

--- a/src/aat/resources/features/F-047 - Get Case IDs/S-099.td.json
+++ b/src/aat/resources/features/F-047 - Get Case IDs/S-099.td.json
@@ -5,6 +5,7 @@
 
 	"specs": [
 		"an active profile in CCD",
+		"testUser - with an active profile in CCD",
 		"does not provide valid authentication credentials",
 		"contains an HTTP-401 Unauthorized"
 	],

--- a/src/aat/resources/features/F-047 - Get Case IDs/S-100.td.json
+++ b/src/aat/resources/features/F-047 - Get Case IDs/S-100.td.json
@@ -5,6 +5,7 @@
 
 	"specs": [
 		"an active profile in CCD",
+		"testUser - with an active profile in CCD",
 		"does not provide authorised access to the operation",
 		"contains an HTTP-403 Forbidden"
 	],

--- a/src/aat/resources/features/F-047 - Get Case IDs/S-570.td.json
+++ b/src/aat/resources/features/F-047 - Get Case IDs/S-570.td.json
@@ -5,6 +5,7 @@
 
 	"specs": [
 		"an inactive profile in CCD",
+		"testUser - with an active profile in CCD",
 		"contains a malformed user ID",
 		"code is HTTP-400"
 	],

--- a/src/aat/resources/features/F-047 - Get Case IDs/S-571.td.json
+++ b/src/aat/resources/features/F-047 - Get Case IDs/S-571.td.json
@@ -5,6 +5,7 @@
 
 	"specs": [
 		"an active profile in CCD",
+		"testUser - with an active profile in CCD",
 		"contains a malformed case type ID",
 		"code is HTTP-400"
 	],

--- a/src/aat/resources/features/F-047 - Get Case IDs/S-572.td.json
+++ b/src/aat/resources/features/F-047 - Get Case IDs/S-572.td.json
@@ -5,6 +5,7 @@
 
 	"specs": [
 		"an active profile in CCD",
+		"testUser - with an active profile in CCD",
 		"contains a malformed jurisdiction ID",
 		"code is HTTP-400"
 	],

--- a/src/aat/resources/features/F-047 - Get Case IDs/S-573.td.json
+++ b/src/aat/resources/features/F-047 - Get Case IDs/S-573.td.json
@@ -5,6 +5,7 @@
 
 	"specs": [
 		"an active profile in CCD",
+		"testUser - with an active profile in CCD",
 		"contains a non-existing jurisdiction ID",
 		"code is HTTP-400"
 	],

--- a/src/aat/resources/features/F-047 - Get Case IDs/S-574.td.json
+++ b/src/aat/resources/features/F-047 - Get Case IDs/S-574.td.json
@@ -5,6 +5,7 @@
 
 	"specs": [
 		"an active profile in CCD",
+		"testUser - with an active profile in CCD",
 		"contains a non-existing case type ID",
 		"code is HTTP-404"
 	],

--- a/src/aat/resources/features/F-047 - Get Case IDs/S-575.td.json
+++ b/src/aat/resources/features/F-047 - Get Case IDs/S-575.td.json
@@ -5,6 +5,7 @@
 
 	"specs": [
 		"an inactive profile in CCD",
+		"testUser - with an active profile in CCD",
 		"contains a non-existing user ID",
 		"code is HTTP-403"
 	],

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/caseaccess/CaseAccessOperation.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/caseaccess/CaseAccessOperation.java
@@ -73,7 +73,13 @@ public class CaseAccessOperation {
         final var caseDetails = maybeCase.orElseThrow(() -> new CaseNotFoundException(caseReference));
 
         if (applicationParams.getEnableAttributeBasedAccessControl()) {
-            roleAssignmentService.createCaseRoleAssignments(caseDetails, userId, Set.of(CREATOR.getRole()), true);
+            var currentRoles
+                = roleAssignmentService.findRoleAssignmentsByCasesAndUsers(List.of(caseReference), List.of(userId));
+
+            // if user does not have CREATOR role for case
+            if (currentRoles.stream().noneMatch(cauRole -> cauRole.getCaseRole().equals(CREATOR.getRole()))) {
+                roleAssignmentService.createCaseRoleAssignments(caseDetails, userId, Set.of(CREATOR.getRole()), false);
+            }
         } else {
             caseUserRepository.grantAccess(Long.valueOf(caseDetails.getId()), userId, CREATOR.getRole());
         }

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/casedataaccesscontrol/RoleAssignmentService.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/casedataaccesscontrol/RoleAssignmentService.java
@@ -139,6 +139,7 @@ public class RoleAssignmentService implements AccessControl {
             .map(roleAssignment -> roleAssignment.getAttributes().getCaseId())
             .filter(Objects::nonNull)
             .flatMap(Optional::stream)
+            .distinct()
             .collect(Collectors.toList());
     }
 

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/casedataaccesscontrol/RoleAssignmentServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/casedataaccesscontrol/RoleAssignmentServiceTest.java
@@ -59,12 +59,13 @@ class RoleAssignmentServiceTest {
     private static final String USER_ID = "user1";
     private static final String USER_ID_2 = "user2";
     private static final String CASE_ID = "111111";
+    private static final String CASE_ID_2 = "222222";
 
     private static final RoleCategory ROLE_CATEGORY_4_USER_1 = RoleCategory.PROFESSIONAL;
     private static final RoleCategory ROLE_CATEGORY_4_USER_2 = RoleCategory.JUDICIAL;
 
-    private final List<String> caseIds = Arrays.asList("111", "222");
-    private final List<String> userIds = Arrays.asList("111", "222");
+    private final List<String> caseIds = Arrays.asList(CASE_ID, CASE_ID_2);
+    private final List<String> userIds = Arrays.asList(USER_ID, USER_ID_2);
 
     @Mock
     private RoleAssignmentRepository roleAssignmentRepository;
@@ -422,27 +423,6 @@ class RoleAssignmentServiceTest {
     }
 
 
-    private RoleAssignments getRoleAssignments() {
-
-        final Instant currentTIme = Instant.now();
-        final long oneHour = 3600000;
-
-        final RoleAssignmentAttributes roleAssignmentAttributes =
-            RoleAssignmentAttributes.builder().caseId(Optional.of(CASE_ID)).build();
-
-        final List<RoleAssignment> roleAssignments = Arrays.asList(
-
-            RoleAssignment.builder().actorId("actorId").roleType(RoleType.CASE.name())
-                .attributes(roleAssignmentAttributes)
-                .beginTime(currentTIme.minusMillis(oneHour)).endTime(currentTIme.plusMillis(oneHour)).build(),
-
-            RoleAssignment.builder().actorId("actorId1").roleType(RoleType.CASE.name())
-                .attributes(roleAssignmentAttributes)
-                .beginTime(currentTIme.minusMillis(oneHour)).endTime(currentTIme.plusMillis(oneHour)).build()
-        );
-        return RoleAssignments.builder().roleAssignments(roleAssignments).build();
-    }
-
     @Nested
     @DisplayName("getRoleAssignments()")
     class GetRoleAssignments {
@@ -462,6 +442,7 @@ class RoleAssignmentServiceTest {
             // THEN
             assertThat(roleAssignments, is(mockedRoleAssignments));
         }
+
     }
 
     @Nested
@@ -490,57 +471,88 @@ class RoleAssignmentServiceTest {
 
     @Nested
     @DisplayName("findRoleAssignmentsByCasesAndUsers()")
-    class GetRoleAssignmentsByCasesAndUsers {
+    class FindRoleAssignmentsByCasesAndUsers {
 
         @Test
-        void shouldGetRoleAssignments() {
+        void shouldFindRoleAssignments() {
 
+            // GIVEN
             given(roleAssignmentRepository.findRoleAssignmentsByCasesAndUsers(caseIds, userIds))
                 .willReturn(mockedRoleAssignmentResponse);
 
             given(roleAssignmentsMapper.toRoleAssignments(mockedRoleAssignmentResponse))
-                .willReturn(getRoleAssignments());
+                .willReturn(createTestRoleAssignments(CASE_ID));
 
+            // WHEN
             final List<CaseAssignedUserRole> caseAssignedUserRole =
                 roleAssignmentService.findRoleAssignmentsByCasesAndUsers(caseIds, userIds);
 
+            // THEN
             assertEquals(2, caseAssignedUserRole.size());
             assertThat(caseAssignedUserRole.get(0).getCaseDataId(), is(CASE_ID));
         }
 
     }
 
+
     @Nested
     @DisplayName("getCaseReferencesForAGivenUser(String userId)")
-    class GetCaseIdsForAGivenUser {
+    class GetCaseReferencesForAGivenUser {
 
         @Test
-        void shouldGetRoleAssignments() {
+        void shouldGetReferencesWithoutDuplicatesSingleCase() {
 
+            // GIVEN
             given(roleAssignmentRepository.getRoleAssignments(USER_ID))
                 .willReturn(mockedRoleAssignmentResponse);
 
             given(roleAssignmentsMapper.toRoleAssignments(mockedRoleAssignmentResponse))
-                .willReturn(getRoleAssignments());
+                .willReturn(createTestRoleAssignments(CASE_ID));
 
+            // WHEN
             List<String> resultCases =
                 roleAssignmentService.getCaseReferencesForAGivenUser(USER_ID);
 
-            assertEquals(2, resultCases.size());
+            // THEN
+            assertEquals(1, resultCases.size());
+            assertEquals(CASE_ID, resultCases.get(0));
         }
-    }
-
-    @Nested
-    @DisplayName("getCaseReferencesForAGivenUser(String userId, CaseTypeDefinition caseTypeDefinition)")
-    class GetCaseIdsForAGivenUserAndCaseTypeDefinition {
 
         @Test
-        void shouldGetRoleAssignments() {
+        void shouldGetReferencesWithoutDuplicatesMultipleCases() {
 
+            // GIVEN
             given(roleAssignmentRepository.getRoleAssignments(USER_ID))
                 .willReturn(mockedRoleAssignmentResponse);
 
-            RoleAssignments roleAssignments = getRoleAssignments();
+            given(roleAssignmentsMapper.toRoleAssignments(mockedRoleAssignmentResponse))
+                .willReturn(createTestRoleAssignmentsMultipleCases());
+
+            // WHEN
+            List<String> resultCases =
+                roleAssignmentService.getCaseReferencesForAGivenUser(USER_ID);
+
+            // THEN
+            assertEquals(2, resultCases.size());
+            assertTrue(resultCases.containsAll(caseIds));
+        }
+
+    }
+
+
+    @Nested
+    @DisplayName("getCaseReferencesForAGivenUser(String userId, CaseTypeDefinition caseTypeDefinition)")
+    class GetCaseReferencesForAGivenUserAndCaseType {
+
+        @Test
+        void shouldGetCaseReferencesWithoutDuplicatesSingleCase() {
+
+            // GIVEN
+            given(roleAssignmentRepository.getRoleAssignments(USER_ID))
+                .willReturn(mockedRoleAssignmentResponse);
+
+            // test role assignments: single case with two case-roles
+            RoleAssignments roleAssignments = createTestRoleAssignments(CASE_ID);
             given(roleAssignmentsMapper.toRoleAssignments(mockedRoleAssignmentResponse))
                 .willReturn(roleAssignments);
 
@@ -549,11 +561,76 @@ class RoleAssignmentServiceTest {
             given(roleAssignmentFilteringService.filter(roleAssignments, caseTypeDefinition))
                 .willReturn(filteredRoleAssignments);
 
+            // WHEN
             List<String> resultCases =
                 roleAssignmentService.getCaseReferencesForAGivenUser(USER_ID, caseTypeDefinition);
 
-            assertEquals(2, resultCases.size());
-            roleAssignmentFilteringService.filter(roleAssignments, caseTypeDefinition);
+            // THEN
+            assertEquals(1, resultCases.size()); // single case
+            verify(roleAssignmentFilteringService).filter(roleAssignments, caseTypeDefinition);
         }
+
+        @Test
+        void shouldGetCaseReferencesWithoutDuplicatesMultipleCases() {
+
+            // GIVEN
+            given(roleAssignmentRepository.getRoleAssignments(USER_ID))
+                .willReturn(mockedRoleAssignmentResponse);
+
+            // test role assignments: two cases each with two case-roles
+            RoleAssignments roleAssignments = createTestRoleAssignmentsMultipleCases();
+            given(roleAssignmentsMapper.toRoleAssignments(mockedRoleAssignmentResponse))
+                .willReturn(roleAssignments);
+
+            given(filteredRoleAssignments.getFilteredMatchingRoleAssignments())
+                .willReturn(roleAssignments.getRoleAssignments());
+            given(roleAssignmentFilteringService.filter(roleAssignments, caseTypeDefinition))
+                .willReturn(filteredRoleAssignments);
+
+            // WHEN
+            List<String> resultCases =
+                roleAssignmentService.getCaseReferencesForAGivenUser(USER_ID, caseTypeDefinition);
+
+            // THEN
+            assertEquals(2, resultCases.size()); // multiple cases
+            verify(roleAssignmentFilteringService).filter(roleAssignments, caseTypeDefinition);
+        }
+
     }
+
+    /**
+     *  Create test role assignments: single case with two case-roles.
+     */
+    private RoleAssignments createTestRoleAssignments(String caseId) {
+        final Instant currentTIme = Instant.now();
+        final long oneHour = 3600000;
+
+        final RoleAssignmentAttributes roleAssignmentAttributes =
+            RoleAssignmentAttributes.builder().caseId(Optional.of(caseId)).build();
+
+        final List<RoleAssignment> roleAssignments = Arrays.asList(
+
+            RoleAssignment.builder().actorId(USER_ID).roleType(RoleType.CASE.name())
+                .attributes(roleAssignmentAttributes)
+                .beginTime(currentTIme.minusMillis(oneHour)).endTime(currentTIme.plusMillis(oneHour)).build(),
+
+            RoleAssignment.builder().actorId(USER_ID).roleType(RoleType.CASE.name())
+                .attributes(roleAssignmentAttributes)
+                .beginTime(currentTIme.minusMillis(oneHour)).endTime(currentTIme.plusMillis(oneHour)).build()
+        );
+        return RoleAssignments.builder().roleAssignments(roleAssignments).build();
+    }
+
+    /**
+     *  Create multiple test role assignments: two cases each with two case-roles.
+     */
+    private RoleAssignments createTestRoleAssignmentsMultipleCases() {
+        List<RoleAssignment> roleAssignments = new ArrayList<>();
+
+        roleAssignments.addAll(createTestRoleAssignments(CASE_ID).getRoleAssignments());
+        roleAssignments.addAll(createTestRoleAssignments(CASE_ID_2).getRoleAssignments());
+
+        return RoleAssignments.builder().roleAssignments(roleAssignments).build();
+    }
+
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

[RDM-12724](https://tools.hmcts.net/jira/browse/RDM-12724) _"Resolve differences in behaviour with migrated case role functions"_

see also:
* [RDM-10923](https://tools.hmcts.net/jira/browse/RDM-10923) _"Migrate get case access APIs to new Access Control"_
* [RDM-10924](https://tools.hmcts.net/jira/browse/RDM-10924) _"Migrate Grant Access to a Case APIs to new Access Control"_

### Change description ###

Restore previous behaviour when using the recently migrated case role functions and the user has multiple case-roles for a case:

* Get case ids (v1), see [RDM-10923](https://tools.hmcts.net/jira/browse/RDM-10923) and [F-047](https://github.com/hmcts/ccd-data-store-api/blob/master/src/aat/resources/features/F-047%20-%20Get%20Case%20IDs/F-047.feature).
  * must return a distinct list of case IDs even when the user has multiple case roles for the same case

* Grant access to case (v1), see [RDM-10924](https://tools.hmcts.net/jira/browse/RDM-10924) and [F-045](https://github.com/hmcts/ccd-data-store-api/blob/master/src/aat/resources/features/F-045%20-%20Grant%20Access%20V1/F-045.feature). 
  * must grant without removing other case roles

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
