### PR TITLE
Rdm 12768 - Implement pre security filters for Global Search endpoint

### DIFF
--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/search/elasticsearch/CrossCaseTypeSearchRequest.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/search/elasticsearch/CrossCaseTypeSearchRequest.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.ccd.domain.service.search.elasticsearch;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.extern.slf4j.Slf4j;
 import uk.gov.hmcts.ccd.domain.model.definition.SearchAliasField;
 import uk.gov.hmcts.ccd.domain.model.search.elasticsearch.ElasticsearchRequest;
 import uk.gov.hmcts.ccd.endpoint.exceptions.BadSearchRequest;
@@ -30,6 +31,7 @@ import static uk.gov.hmcts.ccd.domain.model.search.elasticsearch.ElasticsearchRe
  *   }
  * }
  */
+@Slf4j
 public class CrossCaseTypeSearchRequest {
 
     private static final String SEARCH_ALIAS_FIELD_PREFIX = "alias.";
@@ -78,6 +80,12 @@ public class CrossCaseTypeSearchRequest {
 
     public boolean hasAliasField(SearchAliasField searchAliasField) {
         return aliasFields.stream().anyMatch(aliasField -> aliasField.equalsIgnoreCase(searchAliasField.getId()));
+    }
+
+    public String toJsonString() {
+        String jsonString = elasticsearchRequest.toFinalRequest();
+        log.debug("json search request: {}", jsonString);
+        return jsonString;
     }
 
     public static class Builder {

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/search/elasticsearch/security/CaseSearchRequestSecurity.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/search/elasticsearch/security/CaseSearchRequestSecurity.java
@@ -1,9 +1,12 @@
 package uk.gov.hmcts.ccd.domain.service.search.elasticsearch.security;
 
 import uk.gov.hmcts.ccd.domain.service.search.elasticsearch.CaseSearchRequest;
+import uk.gov.hmcts.ccd.domain.service.search.elasticsearch.CrossCaseTypeSearchRequest;
 
 public interface CaseSearchRequestSecurity {
 
     CaseSearchRequest createSecuredSearchRequest(CaseSearchRequest caseSearchRequest);
+
+    CrossCaseTypeSearchRequest createSecuredSearchRequest(CrossCaseTypeSearchRequest request);
 
 }

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/search/elasticsearch/security/ElasticsearchCaseSearchRequestSecurity.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/search/elasticsearch/security/ElasticsearchCaseSearchRequestSecurity.java
@@ -10,8 +10,10 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.ccd.domain.model.search.elasticsearch.ElasticsearchRequest;
 import uk.gov.hmcts.ccd.domain.service.common.ObjectMapperService;
 import uk.gov.hmcts.ccd.domain.service.search.elasticsearch.CaseSearchRequest;
+import uk.gov.hmcts.ccd.domain.service.search.elasticsearch.CrossCaseTypeSearchRequest;
 
 import java.util.List;
+import java.util.Optional;
 
 import static uk.gov.hmcts.ccd.domain.model.search.elasticsearch.ElasticsearchRequest.QUERY;
 
@@ -34,6 +36,27 @@ public class ElasticsearchCaseSearchRequestSecurity implements CaseSearchRequest
         return createNewCaseSearchRequest(caseSearchRequest, queryClauseWithSecurityFilters);
     }
 
+    @Override
+    public CrossCaseTypeSearchRequest createSecuredSearchRequest(CrossCaseTypeSearchRequest request) {
+        String queryClauseWithSecurityFilters = addFiltersToQuery(request);
+        return createNewCrossCaseTypeSearchRequest(request, queryClauseWithSecurityFilters);
+    }
+
+    private String addFiltersToQuery(CrossCaseTypeSearchRequest crossCaseTypeSearchRequest) {
+        String query = crossCaseTypeSearchRequest.getElasticSearchRequest().getQuery().toString();
+
+        BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery();
+        boolQueryBuilder.must(QueryBuilders.wrapperQuery(query));
+
+        // At least one of these clauses must match. The equivalent of OR
+        crossCaseTypeSearchRequest.getCaseTypeIds()
+            .forEach(caseTypeId -> createCaseType(caseTypeId).ifPresent(boolQueryBuilder::should));
+
+        boolQueryBuilder.minimumShouldMatch(1);
+
+        return createQueryString(boolQueryBuilder);
+    }
+
     private String addFiltersToQuery(CaseSearchRequest caseSearchRequest) {
         BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery();
         boolQueryBuilder.must(QueryBuilders.wrapperQuery(caseSearchRequest.getQueryValue()));
@@ -42,6 +65,23 @@ public class ElasticsearchCaseSearchRequestSecurity implements CaseSearchRequest
             filter.getFilter(caseSearchRequest.getCaseTypeId()).ifPresent(boolQueryBuilder::filter));
 
         return createQueryString(boolQueryBuilder);
+    }
+
+
+    // return must object
+    public Optional<QueryBuilder> createCaseType(String caseTypeId) {
+        BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery();
+
+        caseSearchFilters.forEach(filter ->
+            filter.getFilter(caseTypeId).ifPresent(boolQueryBuilder::must));
+
+        if (boolQueryBuilder.must().isEmpty()) {
+            return Optional.empty();
+        }
+
+        boolQueryBuilder.must(QueryBuilders.termQuery("case_type_id", caseTypeId.toLowerCase()));
+
+        return Optional.of(boolQueryBuilder);
     }
 
     private String createQueryString(QueryBuilder queryBuilder) {
@@ -61,5 +101,17 @@ public class ElasticsearchCaseSearchRequestSecurity implements CaseSearchRequest
 
         return new CaseSearchRequest(caseSearchRequest.getCaseTypeId(),
             new ElasticsearchRequest(searchRequestJsonNode));
+    }
+
+    private CrossCaseTypeSearchRequest createNewCrossCaseTypeSearchRequest(CrossCaseTypeSearchRequest request,
+                                                                           String queryWithFilters) {
+        ObjectNode queryNode = objectMapperService.convertStringToObject(queryWithFilters, ObjectNode.class);
+
+        return new CrossCaseTypeSearchRequest.Builder()
+            .withCaseTypes(request.getCaseTypeIds())
+            .withSearchRequest(new ElasticsearchRequest(queryNode))
+            .withMultiCaseTypeSearch(request.isMultiCaseTypeSearch())
+            .withSourceFilterAliasFields(request.getAliasFields())
+            .build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/search/elasticsearch/security/ElasticsearchCaseSearchRequestSecurity.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/search/elasticsearch/security/ElasticsearchCaseSearchRequestSecurity.java
@@ -50,7 +50,7 @@ public class ElasticsearchCaseSearchRequestSecurity implements CaseSearchRequest
 
         // At least one of these clauses must match. The equivalent of OR
         crossCaseTypeSearchRequest.getCaseTypeIds()
-            .forEach(caseTypeId -> createCaseType(caseTypeId).ifPresent(boolQueryBuilder::should));
+            .forEach(caseTypeId -> createFilterQueryForCaseType(caseTypeId).ifPresent(boolQueryBuilder::should));
 
         boolQueryBuilder.minimumShouldMatch(1);
 
@@ -68,8 +68,7 @@ public class ElasticsearchCaseSearchRequestSecurity implements CaseSearchRequest
     }
 
 
-    // return must object
-    public Optional<QueryBuilder> createCaseType(String caseTypeId) {
+    private Optional<QueryBuilder> createFilterQueryForCaseType(String caseTypeId) {
         BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery();
 
         caseSearchFilters.forEach(filter ->
@@ -110,8 +109,6 @@ public class ElasticsearchCaseSearchRequestSecurity implements CaseSearchRequest
         return new CrossCaseTypeSearchRequest.Builder()
             .withCaseTypes(request.getCaseTypeIds())
             .withSearchRequest(new ElasticsearchRequest(queryNode))
-            .withMultiCaseTypeSearch(request.isMultiCaseTypeSearch())
-            .withSourceFilterAliasFields(request.getAliasFields())
             .build();
     }
 }

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/search/elasticsearch/security/ElasticsearchCaseSearchRequestSecurityTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/search/elasticsearch/security/ElasticsearchCaseSearchRequestSecurityTest.java
@@ -1,25 +1,10 @@
 package uk.gov.hmcts.ccd.domain.service.search.elasticsearch.security;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.ccd.domain.model.search.elasticsearch.ElasticsearchRequest.NATIVE_ES_QUERY;
-import static uk.gov.hmcts.ccd.domain.model.search.elasticsearch.ElasticsearchRequest.QUERY;
-
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -28,20 +13,43 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.ccd.domain.model.search.elasticsearch.ElasticsearchRequest;
+import uk.gov.hmcts.ccd.domain.service.common.CaseAccessService;
+import uk.gov.hmcts.ccd.domain.service.common.DefaultObjectMapperService;
 import uk.gov.hmcts.ccd.domain.service.common.ObjectMapperService;
 import uk.gov.hmcts.ccd.domain.service.search.elasticsearch.CaseSearchRequest;
 import uk.gov.hmcts.ccd.domain.service.search.elasticsearch.CrossCaseTypeSearchRequest;
 
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
 @ExtendWith(MockitoExtension.class)
 class ElasticsearchCaseSearchRequestSecurityTest {
+
+    private final String SEARCH_REQUEST = "{\"query\" : {\"match\" : {\"reference\" : 1630596267899527}}}";
 
     private static final String CASE_TYPE_ID = "caseType";
     private static final String CASE_TYPE_ID_2 = "caseType2";
 
+    private static final String FILTER_VALUE_1 = "filterType1";
+    private static final String FILTER_VALUE_2 = "filterType2";
+
+    private List<CaseSearchFilter> filterList = new ArrayList<>();
+
     @Mock
     private CaseSearchFilter caseSearchFilter;
+
     @Mock
+    private CaseAccessService caseAccessService;
+
     private ObjectMapperService objectMapperService;
+
     @Mock
     private ObjectNode searchRequestJsonNode;
 
@@ -49,59 +57,130 @@ class ElasticsearchCaseSearchRequestSecurityTest {
 
     @BeforeEach
     void setUp() {
+        objectMapperService = new DefaultObjectMapperService(new ObjectMapper());
         MockitoAnnotations.initMocks(this);
-        querySecurity = new ElasticsearchCaseSearchRequestSecurity(Collections.singletonList(caseSearchFilter),
-                objectMapperService);
-        when(searchRequestJsonNode.has(QUERY)).thenReturn(true);
-        when(searchRequestJsonNode.has(NATIVE_ES_QUERY)).thenReturn(false);
     }
 
     @Test
     @DisplayName("should parse and secure request with filters and single case type")
     void shouldSecureRequest() {
-        CaseSearchRequest caseSearchRequest = mock(CaseSearchRequest.class);
-        doReturn(CASE_TYPE_ID).when(caseSearchRequest).getCaseTypeId();
-        doReturn("{}").when(caseSearchRequest).getQueryValue();
-        doReturn("").when(caseSearchRequest).toJsonString();
-        doReturn(Optional.of(mock(QueryBuilder.class))).when(caseSearchFilter).getFilter(CASE_TYPE_ID);
-        doReturn(searchRequestJsonNode).when(objectMapperService).convertStringToObject(anyString(),
-                eq(ObjectNode.class));
-        doReturn(searchRequestJsonNode).when(searchRequestJsonNode).get(anyString());
+        createTestEnvironment();
 
-        querySecurity.createSecuredSearchRequest(caseSearchRequest);
+        JsonNode searchRequestNode = objectMapperService.convertStringToObject(SEARCH_REQUEST, JsonNode.class);
 
-        assertAll(
-            () -> verify(caseSearchRequest).getQueryValue(),
-            () -> verify(caseSearchFilter).getFilter(CASE_TYPE_ID),
-            () -> verify(caseSearchRequest).toJsonString(),
-            () -> verify(searchRequestJsonNode).set(anyString(), any(JsonNode.class)),
-            () -> verify(objectMapperService, times(2)).convertStringToObject(anyString(), eq(ObjectNode.class))
-        );
+        CaseSearchRequest request = new CaseSearchRequest(CASE_TYPE_ID, new ElasticsearchRequest(searchRequestNode));
+
+        CaseSearchRequest securedSearchRequest = querySecurity.createSecuredSearchRequest(request);
+
+        JsonNode jsonNode = objectMapperService.convertStringToObject(
+            securedSearchRequest.toJsonString(),
+            JsonNode.class);
+        String decodedQuery = getDecodedQuery(jsonNode);
+
+        assertEquals(request.getCaseTypeId(), securedSearchRequest.getCaseTypeId());
+        assertEquals(request.getQueryValue(), decodedQuery);
+        assertEquals(FILTER_VALUE_1, jsonNode.at("/query/bool/filter").get(0).at("/term/filterTermValue/value")
+            .asText());
     }
 
     @Test
-    @DisplayName("should parse and secure request with filters and multiple case types")
+    @DisplayName("should parse and secure request with NO filters and only base query and multiple case types")
     void shouldSecureCrossCaseTypeRequest() {
+        createTestEnvironment();
+
         List<String> caseTypeIds = new ArrayList<>();
         caseTypeIds.add(CASE_TYPE_ID);
         caseTypeIds.add(CASE_TYPE_ID_2);
 
-        CrossCaseTypeSearchRequest request = mock(CrossCaseTypeSearchRequest.class);
-        doReturn(caseTypeIds).when(request).getCaseTypeIds();
-        doReturn(new ElasticsearchRequest(searchRequestJsonNode)).when(request).getElasticSearchRequest();
-        doReturn(true).when(request).isMultiCaseTypeSearch();
-        doReturn(Optional.of(mock(QueryBuilder.class))).when(caseSearchFilter).getFilter(CASE_TYPE_ID);
-        doReturn(searchRequestJsonNode).when(objectMapperService).convertStringToObject(anyString(),
-            eq(ObjectNode.class));
-        doReturn(searchRequestJsonNode).when(searchRequestJsonNode).get(anyString());
+        JsonNode searchRequestNode = objectMapperService.convertStringToObject(SEARCH_REQUEST, JsonNode.class);
 
-        querySecurity.createSecuredSearchRequest(request);
+        CrossCaseTypeSearchRequest request = new CrossCaseTypeSearchRequest.Builder()
+            .withSearchRequest(new ElasticsearchRequest(searchRequestNode))
+            .withCaseTypes(caseTypeIds)
+            .build();
 
-        assertAll(
-            () -> verify(caseSearchFilter).getFilter(CASE_TYPE_ID),
-            () -> verify(request).isMultiCaseTypeSearch(),
-            () -> verify(objectMapperService, times(1)).convertStringToObject(anyString(), eq(ObjectNode.class))
+        CrossCaseTypeSearchRequest securedSearchRequest = querySecurity.createSecuredSearchRequest(request);
 
-        );
+        String decodedQuery = getDecodedQuery(securedSearchRequest.getSearchRequestJsonNode());
+
+        assertEquals(request.getCaseTypeIds(), securedSearchRequest.getCaseTypeIds());
+        assertEquals(request.getElasticSearchRequest().getQuery().toString(), decodedQuery);
     }
+
+    @Test
+    @DisplayName("should parse and secure request with filters and multiple case types")
+    void shouldSecureCrossCaseTypeRequestWithFilters() {
+        List<String> caseTypeIds = new ArrayList<>();
+        caseTypeIds.add(CASE_TYPE_ID);
+        caseTypeIds.add(CASE_TYPE_ID_2);
+
+        when(caseSearchFilter.getFilter(CASE_TYPE_ID_2)).thenReturn(Optional.of(newQueryBuilder(FILTER_VALUE_2)));
+        createTestEnvironment();
+
+        JsonNode searchRequestNode = objectMapperService.convertStringToObject(SEARCH_REQUEST, JsonNode.class);
+
+        CrossCaseTypeSearchRequest request = new CrossCaseTypeSearchRequest.Builder()
+            .withSearchRequest(new ElasticsearchRequest(searchRequestNode))
+            .withCaseTypes(caseTypeIds)
+            .build();
+
+        CrossCaseTypeSearchRequest securedSearchRequest = querySecurity.createSecuredSearchRequest(request);
+        String decodedQuery = getDecodedQuery(securedSearchRequest.getSearchRequestJsonNode());
+
+        Map<String, JsonNode> mapOfFilterValues = createMapOfFilterValues(securedSearchRequest.getSearchRequestJsonNode());
+
+        assertEquals(request.getCaseTypeIds(), securedSearchRequest.getCaseTypeIds());
+        assertEquals(request.getElasticSearchRequest().getQuery().toString(), decodedQuery);
+        assertEquals(FILTER_VALUE_1, mapOfFilterValues.get(CASE_TYPE_ID.toLowerCase()).at("/bool/must").get(0)
+            .at("/term/filterTermValue/value").asText());
+        assertEquals(FILTER_VALUE_2, mapOfFilterValues.get(CASE_TYPE_ID_2.toLowerCase()).at("/bool/must").get(0)
+            .at("/term/filterTermValue/value").asText());
+        assertEquals(CASE_TYPE_ID.toLowerCase(), mapOfFilterValues.get(CASE_TYPE_ID.toLowerCase()).at("/bool/must")
+            .get(1).at("/term/case_type_id/value").asText());
+        assertEquals(CASE_TYPE_ID_2.toLowerCase(), mapOfFilterValues.get(CASE_TYPE_ID_2.toLowerCase()).at("/bool/must")
+            .get(1).at("/term/case_type_id/value").asText());
+    }
+
+    private String getDecodedQuery(JsonNode node) {
+        // get wrapped query
+        JsonNode queryJsonNode = node
+            .at("/query/bool/must").get(0).at("/wrapper/query");
+        return decodedQuery(queryJsonNode);
+    }
+
+    // decode base 64
+    private String decodedQuery(JsonNode queryJsonNode) {
+        return new String(Base64.getDecoder().decode(queryJsonNode.asText()));
+    }
+
+    private QueryBuilder newQueryBuilder(String value) {
+        return QueryBuilders.termQuery("filterTermValue", value);
+    }
+
+    private Map<String, JsonNode> createMapOfFilterValues(JsonNode jsonNode) {
+        Map<String, JsonNode> values = new HashMap<>();
+        JsonNode filterJsonNodes = jsonNode.at("/query/bool/should");
+
+        for (JsonNode shouldNode : filterJsonNodes) {
+            for (JsonNode mustNode : shouldNode.at("/bool/must")) {
+                if(!mustNode.at("/term/case_type_id").isEmpty()) {
+                    values.put(
+                        mustNode.at("/term/case_type_id/value").asText(),
+                        shouldNode
+                    );
+                }
+            }
+        }
+
+        return values;
+    }
+
+    private void createTestEnvironment() {
+        when(caseSearchFilter.getFilter(CASE_TYPE_ID)).thenReturn(Optional.of(newQueryBuilder(FILTER_VALUE_1)));
+
+        filterList.add(caseSearchFilter);
+        querySecurity = new ElasticsearchCaseSearchRequestSecurity(filterList,
+            objectMapperService);
+    }
+
 }

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/search/elasticsearch/security/ElasticsearchCaseSearchRequestSecurityTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/search/elasticsearch/security/ElasticsearchCaseSearchRequestSecurityTest.java
@@ -36,6 +36,7 @@ import uk.gov.hmcts.ccd.domain.service.search.elasticsearch.CrossCaseTypeSearchR
 class ElasticsearchCaseSearchRequestSecurityTest {
 
     private static final String CASE_TYPE_ID = "caseType";
+    private static final String CASE_TYPE_ID_2 = "caseType2";
 
     @Mock
     private CaseSearchFilter caseSearchFilter;
@@ -56,7 +57,7 @@ class ElasticsearchCaseSearchRequestSecurityTest {
     }
 
     @Test
-    @DisplayName("should parse and secure request with filters")
+    @DisplayName("should parse and secure request with filters and single case type")
     void shouldSecureRequest() {
         CaseSearchRequest caseSearchRequest = mock(CaseSearchRequest.class);
         doReturn(CASE_TYPE_ID).when(caseSearchRequest).getCaseTypeId();
@@ -79,10 +80,11 @@ class ElasticsearchCaseSearchRequestSecurityTest {
     }
 
     @Test
-    @DisplayName("should parse and secure request with filters")
+    @DisplayName("should parse and secure request with filters and multiple case types")
     void shouldSecureCrossCaseTypeRequest() {
         List<String> caseTypeIds = new ArrayList<>();
         caseTypeIds.add(CASE_TYPE_ID);
+        caseTypeIds.add(CASE_TYPE_ID_2);
 
         CrossCaseTypeSearchRequest request = mock(CrossCaseTypeSearchRequest.class);
         doReturn(caseTypeIds).when(request).getCaseTypeIds();

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/search/elasticsearch/security/ElasticsearchCaseSearchRequestSecurityTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/search/elasticsearch/security/ElasticsearchCaseSearchRequestSecurityTest.java
@@ -40,8 +40,6 @@ class ElasticsearchCaseSearchRequestSecurityTest {
     private static final String FILTER_VALUE_1 = "filterType1";
     private static final String FILTER_VALUE_2 = "filterType2";
 
-    private List<CaseSearchFilter> filterList = new ArrayList<>();
-
     @Mock
     private CaseSearchFilter caseSearchFilter;
 
@@ -58,7 +56,6 @@ class ElasticsearchCaseSearchRequestSecurityTest {
     @BeforeEach
     void setUp() {
         objectMapperService = new DefaultObjectMapperService(new ObjectMapper());
-        MockitoAnnotations.initMocks(this);
     }
 
     @Test
@@ -177,6 +174,8 @@ class ElasticsearchCaseSearchRequestSecurityTest {
     }
 
     private void createTestEnvironment() {
+        List<CaseSearchFilter> filterList = new ArrayList<>();
+
         when(caseSearchFilter.getFilter(CASE_TYPE_ID)).thenReturn(Optional.of(newQueryBuilder(FILTER_VALUE_1)));
 
         filterList.add(caseSearchFilter);

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/search/elasticsearch/security/ElasticsearchCaseSearchRequestSecurityTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/search/elasticsearch/security/ElasticsearchCaseSearchRequestSecurityTest.java
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class ElasticsearchCaseSearchRequestSecurityTest {
 
-    private final String SEARCH_REQUEST = "{\"query\" : {\"match\" : {\"reference\" : 1630596267899527}}}";
+    private static final String SEARCH_REQUEST = "{\"query\" : {\"match\" : {\"reference\" : 1630596267899527}}}";
 
     private static final String CASE_TYPE_ID = "caseType";
     private static final String CASE_TYPE_ID_2 = "caseType2";
@@ -127,7 +127,8 @@ class ElasticsearchCaseSearchRequestSecurityTest {
         CrossCaseTypeSearchRequest securedSearchRequest = querySecurity.createSecuredSearchRequest(request);
         String decodedQuery = getDecodedQuery(securedSearchRequest.getSearchRequestJsonNode());
 
-        Map<String, JsonNode> mapOfFilterValues = createMapOfFilterValues(securedSearchRequest.getSearchRequestJsonNode());
+        Map<String, JsonNode> mapOfFilterValues =
+            createMapOfFilterValues(securedSearchRequest.getSearchRequestJsonNode());
 
         assertEquals(request.getCaseTypeIds(), securedSearchRequest.getCaseTypeIds());
         assertEquals(request.getElasticSearchRequest().getQuery().toString(), decodedQuery);
@@ -163,7 +164,7 @@ class ElasticsearchCaseSearchRequestSecurityTest {
 
         for (JsonNode shouldNode : filterJsonNodes) {
             for (JsonNode mustNode : shouldNode.at("/bool/must")) {
-                if(!mustNode.at("/term/case_type_id").isEmpty()) {
+                if (!mustNode.at("/term/case_type_id").isEmpty()) {
                     values.put(
                         mustNode.at("/term/case_type_id/value").asText(),
                         shouldNode


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-12768


### Change description ###
This will add in the pre security filters with a new elastic search query to allow multiple case types


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
