### PR TITLE
RDM-12862 - Handle `document_hash` field in the DocumentSanitiser

### DIFF
--- a/src/aat/resources/features/F-1003 - Case Creation With Documents/Default_Get_Case_Data_Base_02.td.json
+++ b/src/aat/resources/features/F-1003 - Case Creation With Documents/Default_Get_Case_Data_Base_02.td.json
@@ -1,0 +1,66 @@
+{
+  "_guid_": "Default_Get_Case_Data_Base_02",
+  "productName": "CCD Data Store",
+  "operationName": "Get case details",
+  "method": "GET",
+  "uri": "/cases/{cid}",
+  "specs": [
+    "to retrieve case details by case id"
+  ],
+  "users": {
+    "invokingUser": {
+      "username": "befta.caseworker.2.solicitor.2@gmail.com",
+      "password": "[[$CCD_BEFTA_CASEWORKER_2_SOLICITOR_2_PWD]]"
+    }
+  },
+  "request": {
+    "headers": {
+      "Authorization": "[[DEFAULT_AUTO_VALUE]]",
+      "ServiceAuthorization": "[[DEFAULT_AUTO_VALUE]]",
+      "experimental": true
+    },
+    "pathVariables": {
+      "cid": "${[scenarioContext][parentContext][testData][actualResponse][body][id]}"
+    }
+  },
+  "expectedResponse": {
+    "_extends_": "Common_200_Response",
+    "headers": {
+      "Content-Encoding" : "[[ANYTHING_PRESENT]]",
+      "Content-Length" : "[[ANYTHING_PRESENT]]",
+      "Content-Type" : "application/vnd.uk.gov.hmcts.ccd-data-store-api.case.v2+json;charset=UTF-8"
+    },
+    "body" : {
+      "_links" : {
+        "self" : {
+          "href" : "{{TEST_URL}}/cases/${[scenarioContext][parentContext][testData][actualResponse][body][id]}"
+        }
+      },
+      "id" : "${[scenarioContext][parentContext][testData][actualResponse][body][id]}",
+      "jurisdiction" : "BEFTA_JURISDICTION_2",
+      "case_type" : "BEFTA_CASETYPE_2_1",
+      "created_on" : "[[ANY_TIMESTAMP_NOT_NULLABLE]]",
+      "last_modified_on" : "[[ANY_TIMESTAMP_NOT_NULLABLE]]",
+      "last_state_modified_on" : "[[ANY_TIMESTAMP_NOT_NULLABLE]]",
+      "state" : "TODO",
+      "security_classification" : "PUBLIC",
+      "data" : {
+        "DocumentField1" : {
+          "document_url" : "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][parentContext][childContexts][Default_Document_Upload_Data][customValues][documentIdInTheResponse]}",
+          "document_filename" : "${[scenarioContext][parentContext][childContexts][Default_Document_Upload_Data][testData][actualResponse][body][documents][0][originalDocumentName]}",
+          "document_binary_url" : "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][parentContext][childContexts][Default_Document_Upload_Data][customValues][documentIdInTheResponse]}/binary"
+        }
+      },
+      "data_classification" : {
+        "DocumentField1" : "PUBLIC"
+      },
+      "after_submit_callback_response" : null,
+      "callback_response_status_code" : null,
+      "callback_response_status" : null,
+      "delete_draft_response_status_code" : null,
+      "delete_draft_response_status" : null
+    }
+  }
+}
+
+}

--- a/src/aat/resources/features/F-1003 - Case Creation With Documents/F-1003-SubmitCaseCreationNoFilenameResponse.td.json
+++ b/src/aat/resources/features/F-1003 - Case Creation With Documents/F-1003-SubmitCaseCreationNoFilenameResponse.td.json
@@ -1,0 +1,39 @@
+{
+  "_guid_": "F-1003-SubmitCaseCreationNoFilenameResponse",
+  "_extends_": "Common_201_Response",
+  "headers": {
+    "Content-Type" : "application/json;charset=UTF-8",
+    "Transfer-Encoding" : "chunked"
+  },
+  "body": {
+    "_links" : {
+      "self" : {
+        "href" : "{{TEST_URL}}/case-types/BEFTA_CASETYPE_2_1/cases{?ignore-warning}"
+      }
+    },
+    "id" : "[[ANYTHING_PRESENT]]",
+    "jurisdiction" : "BEFTA_JURISDICTION_2",
+    "case_type" : "BEFTA_CASETYPE_2_1",
+    "created_on" : "[[ANY_TIMESTAMP_NOT_NULLABLE]]",
+    "last_modified_on" : "[[ANY_TIMESTAMP_NOT_NULLABLE]]",
+    "last_state_modified_on" : "[[ANY_TIMESTAMP_NOT_NULLABLE]]",
+    "state" : "TODO",
+    "security_classification" : "PUBLIC",
+    "data" : {
+      "DocumentField1" : {
+        "document_url" : "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_Data][customValues][documentIdInTheResponse]}",
+        "document_binary_url" : "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_Data][customValues][documentIdInTheResponse]}/binary",
+        "document_filename" : "[[ANYTHING_PRESENT]]"
+      }
+    },
+    "data_classification" : {
+      "DocumentField1" : "PUBLIC"
+    },
+    "after_submit_callback_response" : null,
+    "callback_response_status_code" : null,
+    "callback_response_status" : null,
+    "delete_draft_response_status_code" : null,
+    "delete_draft_response_status" : null
+  }
+
+}

--- a/src/aat/resources/features/F-1003 - Case Creation With Documents/F-1003-SubmitCaseCreationWithNoFilename.td.json
+++ b/src/aat/resources/features/F-1003 - Case Creation With Documents/F-1003-SubmitCaseCreationWithNoFilename.td.json
@@ -1,0 +1,46 @@
+{
+  "_guid_": "F-1003-SubmitCaseCreationWithNoFilename",
+  "productName": "CCD Data Store",
+  "operationName": "Submit Case Creation With No Document Filename",
+  "specs": [
+    "an active caseworker profile in CCD with full permissions on a document field",
+    "is to attach the document uploaded above to a new case without specifying filename",
+    "contains necessary details about the document attached to the case"
+  ],
+  "users": {
+    "invokingUser": {
+      "username": "befta.caseworker.2.solicitor.2@gmail.com",
+      "password": "[[$CCD_BEFTA_CASEWORKER_2_SOLICITOR_2_PWD]]"
+    }
+  },
+  "method": "POST",
+  "uri": "case-types/{CaseTypeID}/cases",
+
+  "request": {
+    "headers": {
+      "Authorization": "[[DEFAULT_AUTO_VALUE]]",
+      "ServiceAuthorization": "[[DEFAULT_AUTO_VALUE]]",
+      "Content-Type": "application/json;charset=UTF-8",
+      "experimental": true
+    },
+    "pathVariables": {
+      "CaseTypeID": "BEFTA_CASETYPE_2_1"
+    },
+    "body": {
+      "data": {
+        "DocumentField1": {
+          "document_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_Data][customValues][documentIdInTheResponse]}",
+          "document_binary_url": "{{DM_STORE_BASE_URL}}/documents/${[scenarioContext][childContexts][Default_Document_Upload_Data][customValues][documentIdInTheResponse]}/binary",
+          "document_hash": "${[scenarioContext][childContexts][Default_Document_Upload_Data][testData][actualResponse][body][documents][0][hashToken]}"
+        }
+      },
+      "event": {
+        "id": "CREATE",
+        "summary": "",
+        "description": ""
+      },
+      "event_token": "${[scenarioContext][childContexts][Befta_Jurisdiction2_Default_Token_Creation_Data_For_Case_Creation][testData][actualResponse][body][token]}",
+      "ignore_warning": false
+    }
+  }
+}

--- a/src/aat/resources/features/F-1003 - Case Creation With Documents/F-1003.feature
+++ b/src/aat/resources/features/F-1003 - Case Creation With Documents/F-1003.feature
@@ -104,3 +104,17 @@ Feature: F-1003: Submit Case Creation
 
   @S-1040
   Scenario: generic scenario for Unsupported Media Type
+
+  @S-1041
+  Scenario: must successfully create a case with new document uploaded where filename is not specified
+    Given a user with [an active caseworker profile in CCD with full permissions on a document field],
+    And   a successful call [to upload a document with mandatory metadata] as in [Default_Document_Upload_Data],
+    And   a successful call [to create a token for case creation] as in [Befta_Jurisdiction2_Default_Token_Creation_Data_For_Case_Creation],
+    When  a request is prepared with appropriate values,
+    And   the request [is to attach the document uploaded above to a new case without specifying filename],
+    And   it is submitted to call the [Submit Case Creation With No Document Filename] operation of [CCD Data Store],
+    Then  a positive response is received,
+    And   the response [contains necessary details about the document attached to the case],
+    And   the response has all other details as expected,
+    And   a call [to retrieve case details by case id] will get the expected response as in [Default_Get_Case_Data_Base_02]
+    And   a call [to retrieve case document metadata by document id] will get the expected response as in [S-1041_Get_Document_Metadata].

--- a/src/aat/resources/features/F-1003 - Case Creation With Documents/Get_Document_Metadata.td.json
+++ b/src/aat/resources/features/F-1003 - Case Creation With Documents/Get_Document_Metadata.td.json
@@ -1,0 +1,52 @@
+{
+  "_guid_": "Get_Document_Metadata",
+  "productName": "CCD Data Store",
+  "operationName": "Get a case document",
+  "method": "GET",
+  "uri": "{{CASE_DOCUMENT_AM_URL}}/cases/documents/{docId}",
+  "users": {
+    "invokingUser": {
+      "username": "befta.caseworker.2.solicitor.2@gmail.com",
+      "password": "[[$CCD_BEFTA_CASEWORKER_2_SOLICITOR_2_PWD]]"
+    }
+  },
+  "request": {
+    "headers": {
+      "Authorization": "[[DEFAULT_AUTO_VALUE]]",
+      "ServiceAuthorization": "[[DEFAULT_AUTO_VALUE]]"
+    },
+    "pathVariables": {
+      "docId": "OVERRIDE"
+    }
+  },
+  "expectedResponse": {
+    "responseCode": 200,
+    "responseMessage": "OK",
+    "headers": {
+      "_extends_": "Common_Response_Header_Base"
+    },
+    "body": {
+      "classification": "PUBLIC",
+      "size": "[[ANYTHING_PRESENT]]",
+      "mimeType": "[[ANYTHING_PRESENT]]",
+      "originalDocumentName": "[[ANYTHING_PRESENT]]",
+      "createdOn": "[[ANYTHING_PRESENT]]",
+      "createdBy": "[[ANYTHING_PRESENT]]",
+      "lastModifiedBy": "[[ANYTHING_PRESENT]]",
+      "modifiedOn": "[[ANYTHING_PRESENT]]",
+      "metadata": {
+        "jurisdiction": "[[ANYTHING_PRESENT]]",
+        "case_id": "[[ANYTHING_PRESENT]]",
+        "case_type_id": "[[ANYTHING_PRESENT]]"
+      },
+      "_links": {
+        "self": {
+          "href": "[[ANYTHING_PRESENT]]"
+        },
+        "binary": {
+          "href": "[[ANYTHING_PRESENT]]"
+        }
+      }
+    }
+  }
+}

--- a/src/aat/resources/features/F-1003 - Case Creation With Documents/S-1041.td.json
+++ b/src/aat/resources/features/F-1003 - Case Creation With Documents/S-1041.td.json
@@ -1,0 +1,8 @@
+{
+  "_guid_": "S-1041",
+  "_extends_": "F-1003-SubmitCaseCreationWithNoFilename",
+  "title": "must successfully create a case with new document uploaded",
+  "expectedResponse": {
+    "_extends_": "F-1003-SubmitCaseCreationNoFilenameResponse"
+  }
+}

--- a/src/aat/resources/features/F-1003 - Case Creation With Documents/S-1041_Get_Document_Metadata.td.json
+++ b/src/aat/resources/features/F-1003 - Case Creation With Documents/S-1041_Get_Document_Metadata.td.json
@@ -1,0 +1,27 @@
+{
+  "_guid_": "S-1041_Get_Document_Metadata",
+  "_extends_": "Get_Document_Metadata",
+  "title": "Get document metadata from case document am service",
+  "specs": [
+    "to retrieve case document metadata by document id"
+  ],
+  "request": {
+    "pathVariables": {
+      "docId": "${[scenarioContext][siblingContexts][Default_Document_Upload_Data][customValues][documentIdInTheResponse]}"
+    }
+  },
+  "expectedResponse": {
+    "responseCode": 200,
+    "responseMessage": "OK",
+    "headers": {
+      "_extends_": "Common_Response_Header_Base"
+    },
+    "body": {
+      "metadata": {
+        "jurisdiction": "BEFTA_JURISDICTION_2",
+        "case_id": "${[scenarioContext][parentContext][testData][actualResponse][body][id]}",
+        "case_type_id": "BEFTA_CASETYPE_2_1"
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/ccd/domain/types/sanitiser/DocumentSanitiser.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/types/sanitiser/DocumentSanitiser.java
@@ -25,6 +25,7 @@ public class DocumentSanitiser implements Sanitiser {
     public static final String DOCUMENT_URL = "document_url";
     public static final String DOCUMENT_BINARY_URL = "document_binary_url";
     public static final String DOCUMENT_FILENAME = "document_filename";
+    public static final String DOCUMENT_HASH = "document_hash";
 
     public static final String TYPE = "Document";
     private static final JsonNodeFactory JSON_NODE_FACTORY = new JsonNodeFactory(false);
@@ -57,6 +58,12 @@ public class DocumentSanitiser implements Sanitiser {
             Binary binary = document.get_links().getBinary();
             validateBinaryLink(fieldTypeDefinition, binary);
             sanitisedData.put(DOCUMENT_BINARY_URL, binary.getHref());
+
+            final JsonNode documentHashNode = fieldData.get(DOCUMENT_HASH);
+            if (documentHashNode != null) {
+                sanitisedData.put(DOCUMENT_HASH, documentHashNode.textValue());
+            }
+
             validateDocumentFilename(fieldTypeDefinition, document);
             sanitisedData.put(DOCUMENT_FILENAME, document.getOriginalDocumentName());
             return sanitisedData;

--- a/src/test/java/uk/gov/hmcts/ccd/domain/types/sanitiser/DocumentSanitiserTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/types/sanitiser/DocumentSanitiserTest.java
@@ -51,6 +51,7 @@ class DocumentSanitiserTest {
     private static final String DOCUMENT_URL_VALUE = "/documents/05e7cd7e-7041-4d8a-826a-7bb49dfd83d0";
     private static final String BINARY_URL = "/documents/05e7cd7e-7041-4d8a-826a-7bb49dfd83d0/binary";
     private static final String FILENAME = "Seagulls_Sqaure.jpg";
+    private static final String DOCUMENT_HASH = "document_hash";
 
     static {
         DOCUMENT_FIELD_TYPE.setId(TYPE_DOCUMENT);
@@ -73,9 +74,11 @@ class DocumentSanitiserTest {
 
         documentSanitiser = new DocumentSanitiser(documentManagementRestClient);
         DOCUMENT_VALUE_INITIAL.put("document_url", DOCUMENT_URL_VALUE);
+        DOCUMENT_VALUE_INITIAL.put("document_hash", DOCUMENT_HASH);
         DOCUMENT_VALUE_SANITISED.put("document_url", DOCUMENT_URL_VALUE);
         DOCUMENT_VALUE_SANITISED.put("document_binary_url",BINARY_URL);
         DOCUMENT_VALUE_SANITISED.put("document_filename", FILENAME);
+        DOCUMENT_VALUE_SANITISED.put("document_hash", DOCUMENT_HASH);
     }
 
     @Test
@@ -97,6 +100,7 @@ class DocumentSanitiserTest {
         ((ObjectNode)documentValue).set(DOCUMENT_URL, JSON_FACTORY.textNode("testUrl"));
         ((ObjectNode)documentValue).set(DOCUMENT_BINARY_URL, JSON_FACTORY.textNode("testBinaryUrl"));
         ((ObjectNode)documentValue).set(DOCUMENT_FILENAME, JSON_FACTORY.textNode("testFilename"));
+        ((ObjectNode)documentValue).set(DOCUMENT_HASH, JSON_FACTORY.textNode("testHash"));
 
         JsonNode sanitisedDocument = documentSanitiser.sanitise(DOCUMENT_FIELD_TYPE, documentValue);
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDM-12862

### Change description ###

Handle `document_hash` field in the DocumentSanitiser

It has to survive even if document_binary_url or document_filename not present

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
