### PR TITLE
RDM-12903 update GlobalSearch query builder

### DIFF
--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/search/global/GlobalSearchFields.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/search/global/GlobalSearchFields.java
@@ -80,6 +80,7 @@ public final class GlobalSearchFields {
         public static final String ADDRESS_LINE_1 = "AddressLine1";
         public static final String POSTCODE = "PostCode";
         public static final String DATE_OF_BIRTH = "DateOfBirth";
+        public static final String DATE_OF_DEATH = "DateOfDeath";
 
         // Hide Utility Class Constructor : Utility class should not have a public or default constructor (squid:S1118)
         private SearchPartyFields() {
@@ -154,6 +155,7 @@ public final class GlobalSearchFields {
             = SEARCH_PARTIES_PREFIX + SearchPartyFields.ADDRESS_LINE_1;
         public static final String SEARCH_PARTY_POSTCODE = SEARCH_PARTIES_PREFIX + SearchPartyFields.POSTCODE;
         public static final String SEARCH_PARTY_DATE_OF_BIRTH = SEARCH_PARTIES_PREFIX + SearchPartyFields.DATE_OF_BIRTH;
+        public static final String SEARCH_PARTY_DATE_OF_DEATH = SEARCH_PARTIES_PREFIX + SearchPartyFields.DATE_OF_DEATH;
 
 
         // Hide Utility Class Constructor : Utility class should not have a public or default constructor (squid:S1118)

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/search/global/GlobalSearchQueryBuilder.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/search/global/GlobalSearchQueryBuilder.java
@@ -36,6 +36,7 @@ import static uk.gov.hmcts.ccd.domain.service.search.global.GlobalSearchFields.C
 import static uk.gov.hmcts.ccd.domain.service.search.global.GlobalSearchFields.CaseDataPaths.SEARCH_PARTIES;
 import static uk.gov.hmcts.ccd.domain.service.search.global.GlobalSearchFields.CaseDataPaths.SEARCH_PARTY_ADDRESS_LINE_1;
 import static uk.gov.hmcts.ccd.domain.service.search.global.GlobalSearchFields.CaseDataPaths.SEARCH_PARTY_DATE_OF_BIRTH;
+import static uk.gov.hmcts.ccd.domain.service.search.global.GlobalSearchFields.CaseDataPaths.SEARCH_PARTY_DATE_OF_DEATH;
 import static uk.gov.hmcts.ccd.domain.service.search.global.GlobalSearchFields.CaseDataPaths.SEARCH_PARTY_EMAIL_ADDRESS;
 import static uk.gov.hmcts.ccd.domain.service.search.global.GlobalSearchFields.CaseDataPaths.SEARCH_PARTY_NAME;
 import static uk.gov.hmcts.ccd.domain.service.search.global.GlobalSearchFields.CaseDataPaths.SEARCH_PARTY_POSTCODE;
@@ -162,6 +163,12 @@ public class GlobalSearchQueryBuilder {
                 boolQueryBuilder.must(QueryBuilders.rangeQuery(SEARCH_PARTY_DATE_OF_BIRTH)
                     .gte(party.getDateOfBirth())
                     .lte(party.getDateOfBirth())
+                );
+            }
+            if (StringUtils.isNotBlank(party.getDateOfDeath())) {
+                boolQueryBuilder.must(QueryBuilders.rangeQuery(SEARCH_PARTY_DATE_OF_DEATH)
+                    .gte(party.getDateOfDeath())
+                    .lte(party.getDateOfDeath())
                 );
             }
         }

--- a/src/test/java/uk/gov/hmcts/ccd/ElasticsearchIT.java
+++ b/src/test/java/uk/gov/hmcts/ccd/ElasticsearchIT.java
@@ -1585,6 +1585,7 @@ public class ElasticsearchIT extends ElasticsearchBaseTest {
             // NB: should only return test case 2 as case 1 has matching criteria but across different parties
             Party party = new Party();
             party.setDateOfBirth("2000-01-01");
+            party.setDateOfDeath("2000-02-02");
             party.setAddressLine1("AddressLine1");
             party.setPostCode("PostCode");
             party.setEmailAddress("test@example.com");

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/search/global/GlobalSearchQueryBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/search/global/GlobalSearchQueryBuilderTest.java
@@ -185,6 +185,7 @@ class GlobalSearchQueryBuilderTest {
             party1.setAddressLine1("addressLine1_1");
             party1.setPostCode("postCode_1");
             party1.setDateOfBirth("2021-02-01");
+            party1.setDateOfDeath("2021-05-06");
 
             Party party2 = new Party();
             party2.setPartyName("partyName_2");
@@ -192,6 +193,7 @@ class GlobalSearchQueryBuilderTest {
             party2.setAddressLine1("addressLine1_2");
             party2.setPostCode("postCode_2");
             party2.setDateOfBirth("2021-03-02");
+            party2.setDateOfDeath("2021-07-08");
 
             SearchCriteria searchCriteria = new SearchCriteria();
             searchCriteria.setParties(List.of(party1, party2));
@@ -275,6 +277,7 @@ class GlobalSearchQueryBuilderTest {
             partyEmptyProperties.setAddressLine1("");
             partyEmptyProperties.setPostCode("");
             partyEmptyProperties.setDateOfBirth("");
+            partyEmptyProperties.setDateOfDeath("");
 
             Party partyNullProperties = new Party();
             partyNullProperties.setPartyName(null);
@@ -282,6 +285,7 @@ class GlobalSearchQueryBuilderTest {
             partyNullProperties.setAddressLine1(null);
             partyNullProperties.setPostCode(null);
             partyNullProperties.setDateOfBirth(null);
+            partyNullProperties.setDateOfDeath(null);
 
             List<Party> partyList = new ArrayList<>();
             partyList.add(partyEmptyProperties);
@@ -356,6 +360,11 @@ class GlobalSearchQueryBuilderTest {
                     actualPartyQuery,
                     CaseDataPaths.SEARCH_PARTY_DATE_OF_BIRTH,
                     expectedParty.getDateOfBirth()
+                ),
+                () -> assertNestedRangeQueryForDate(
+                    actualPartyQuery,
+                    CaseDataPaths.SEARCH_PARTY_DATE_OF_DEATH,
+                    expectedParty.getDateOfDeath()
                 )
             );
         }
@@ -369,7 +378,6 @@ class GlobalSearchQueryBuilderTest {
             );
         }
 
-        @SuppressWarnings("SameParameterValue")
         private void assertNestedRangeQueryForDate(NestedQueryBuilder nestedQueryBuilder,
                                                    String path,
                                                    String expectedDate) {
@@ -435,7 +443,6 @@ class GlobalSearchQueryBuilderTest {
             return jsonNode != null ? jsonNode.at("/nested/path").asText() : null;
         }
 
-        @SuppressWarnings("SameParameterValue")
         private RangeQueryBuilder getRangeQueryBuilder(QueryBuilder queryBuilder, String fieldName) {
             BoolQueryBuilder boolQueryBuilder = toBoolQueryBuilder(queryBuilder);
 

--- a/src/test/resources/elasticsearch/data/global_search/global-search-01.json
+++ b/src/test/resources/elasticsearch/data/global_search/global-search-01.json
@@ -24,6 +24,7 @@
                     "id": "a12cf1f0-c4e6-4f6d-baf2-447e876fd9f7",
                     "value": {
                         "DateOfBirth": "2000-01-01",
+                        "DateOfDeath": "2000-02-02",
                         "AddressLine1": "AddressLine1",
                         "PostCode": "no-match",
                         "EmailAddress": "test@example.com",
@@ -34,6 +35,7 @@
                     "id": "18e62954-9b84-4840-9048-f88293d9c5c5",
                     "value": {
                         "DateOfBirth": "2000-01-01",
+                        "DateOfDeath": "2000-02-02",
                         "AddressLine1": "no-match",
                         "PostCode": "PostCode",
                         "EmailAddress": "test@example.com",
@@ -44,15 +46,7 @@
         }
     },
     "data_classification": {
-        "DateOfBirth": "PUBLIC",
         "caseManagementCategory": "PUBLIC",
-        "Email": "PUBLIC",
-        "Address": {
-            "classification": "PUBLIC",
-            "value": {
-                "AddressLine1": "PUBLIC"
-            }
-        },
         "caseManagementLocation": {
             "classification": "PUBLIC",
             "value": {
@@ -60,9 +54,6 @@
                 "region": "PUBLIC"
             }
         },
-        "FirstName": "PUBLIC",
-        "LastName": "PUBLIC",
-        "PostCode": "PUBLIC",
         "caseNameHmctsInternal": "PUBLIC",
         "SearchCriteria": {
             "classification": "PUBLIC",
@@ -83,6 +74,7 @@
                             "id": "a12cf1f0-c4e6-4f6d-baf2-447e876fd9f7",
                             "value": {
                                 "DateOfBirth": "PUBLIC",
+                                "DateOfDeath": "PUBLIC",
                                 "AddressLine1": "PUBLIC",
                                 "PostCode": "PUBLIC",
                                 "EmailAddress": "PUBLIC",
@@ -93,6 +85,7 @@
                             "id": "18e62954-9b84-4840-9048-f88293d9c5c5",
                             "value": {
                                 "DateOfBirth": "PUBLIC",
+                                "DateOfDeath": "PUBLIC",
                                 "AddressLine1": "PUBLIC",
                                 "PostCode": "PUBLIC",
                                 "EmailAddress": "PUBLIC",

--- a/src/test/resources/elasticsearch/data/global_search/global-search-02.json
+++ b/src/test/resources/elasticsearch/data/global_search/global-search-02.json
@@ -24,6 +24,7 @@
                     "id": "a12cf1f0-c4e6-4f6d-baf2-447e876fd9f7",
                     "value": {
                         "DateOfBirth": "2000-01-01",
+                        "DateOfDeath": "2000-02-02",
                         "AddressLine1": "AddressLine1",
                         "PostCode": "PostCode",
                         "EmailAddress": "test@example.com",
@@ -34,15 +35,7 @@
         }
     },
     "data_classification": {
-        "DateOfBirth": "PUBLIC",
         "caseManagementCategory": "PUBLIC",
-        "Email": "PUBLIC",
-        "Address": {
-            "classification": "PUBLIC",
-            "value": {
-                "AddressLine1": "PUBLIC"
-            }
-        },
         "caseManagementLocation": {
             "classification": "PUBLIC",
             "value": {
@@ -50,9 +43,6 @@
                 "region": "PUBLIC"
             }
         },
-        "FirstName": "PUBLIC",
-        "LastName": "PUBLIC",
-        "PostCode": "PUBLIC",
         "caseNameHmctsInternal": "PUBLIC",
         "SearchCriteria": {
             "classification": "PUBLIC",
@@ -73,6 +63,7 @@
                             "id": "a12cf1f0-c4e6-4f6d-baf2-447e876fd9f7",
                             "value": {
                                 "DateOfBirth": "PUBLIC",
+                                "DateOfDeath": "PUBLIC",
                                 "AddressLine1": "PUBLIC",
                                 "PostCode": "PUBLIC",
                                 "EmailAddress": "PUBLIC",

--- a/src/test/resources/elasticsearch/data/global_search/global-search-03.json
+++ b/src/test/resources/elasticsearch/data/global_search/global-search-03.json
@@ -22,15 +22,7 @@
         }
     },
     "data_classification": {
-        "DateOfBirth": "PUBLIC",
         "caseManagementCategory": "PUBLIC",
-        "Email": "PUBLIC",
-        "Address": {
-            "classification": "PUBLIC",
-            "value": {
-                "AddressLine1": "PUBLIC"
-            }
-        },
         "caseManagementLocation": {
             "classification": "PUBLIC",
             "value": {
@@ -38,9 +30,6 @@
                 "region": "PUBLIC"
             }
         },
-        "FirstName": "PUBLIC",
-        "LastName": "PUBLIC",
-        "PostCode": "PUBLIC",
         "caseNameHmctsInternal": "PUBLIC",
         "SearchCriteria": {
             "classification": "PUBLIC",
@@ -51,21 +40,6 @@
                         {
                             "id": "72b5ab79-004c-46a6-b935-f1c657bd693a",
                             "classification": "PUBLIC"
-                        }
-                    ]
-                },
-                "SearchParties": {
-                    "classification": "PUBLIC",
-                    "value": [
-                        {
-                            "id": "a12cf1f0-c4e6-4f6d-baf2-447e876fd9f7",
-                            "value": {
-                                "DateOfBirth": "PUBLIC",
-                                "AddressLine1": "PUBLIC",
-                                "PostCode": "PUBLIC",
-                                "EmailAddress": "PUBLIC",
-                                "Name": "PUBLIC"
-                            }
                         }
                     ]
                 }

--- a/src/test/resources/elasticsearch/data/global_search/global-search-04.json
+++ b/src/test/resources/elasticsearch/data/global_search/global-search-04.json
@@ -22,15 +22,7 @@
         }
     },
     "data_classification": {
-        "DateOfBirth": "PUBLIC",
         "caseManagementCategory": "PUBLIC",
-        "Email": "PUBLIC",
-        "Address": {
-            "classification": "PUBLIC",
-            "value": {
-                "AddressLine1": "PUBLIC"
-            }
-        },
         "caseManagementLocation": {
             "classification": "PUBLIC",
             "value": {
@@ -38,9 +30,6 @@
                 "region": "PUBLIC"
             }
         },
-        "FirstName": "PUBLIC",
-        "LastName": "PUBLIC",
-        "PostCode": "PUBLIC",
         "caseNameHmctsInternal": "PUBLIC",
         "SearchCriteria": {
             "classification": "PUBLIC",
@@ -51,21 +40,6 @@
                         {
                             "id": "72b5ab79-004c-46a6-b935-f1c657bd693a",
                             "classification": "PUBLIC"
-                        }
-                    ]
-                },
-                "SearchParties": {
-                    "classification": "PUBLIC",
-                    "value": [
-                        {
-                            "id": "a12cf1f0-c4e6-4f6d-baf2-447e876fd9f7",
-                            "value": {
-                                "DateOfBirth": "PUBLIC",
-                                "AddressLine1": "PUBLIC",
-                                "PostCode": "PUBLIC",
-                                "EmailAddress": "PUBLIC",
-                                "Name": "PUBLIC"
-                            }
                         }
                     ]
                 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

[RDM-12903](https://tools.hmcts.net/jira/browse/RDM-12903) _"Apply date of death field in the search query"_

### Change description ###

Update `GlobalSearchQueryBuilder` to use `parties.dateOfDeath` property.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
