### PR TITLE
Removed supression of CVE-2021-22147

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -47,16 +47,10 @@
 	</suppress>
 
 	<suppress until="2021-10-25">
-		<notes>A vulnerability in all versions of Nim-lang allows unauthenticated attackers to write files to 
-		arbitrary directories via a crafted zip file with dot-slash characters included in the name of the 
+		<notes>A vulnerability in all versions of Nim-lang allows unauthenticated attackers to write files to
+		arbitrary directories via a crafted zip file with dot-slash characters included in the name of the
 		crafted file
 		</notes>
 		<cve>CVE-2020-23171</cve>
 	</suppress>
-
-	<!-- Suppress temporarily -->
-	<suppress>
-		<cve>CVE-2021-22147</cve>
-	</suppress>
-
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-1994


### Change description ###

File: dependency-check-suppressions.xml
Removed suppression block of: CVE-2021-22147

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
