### PR TITLE
CCD-2112: Address CVE-2021-42340

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -287,8 +287,9 @@ dependencyManagement {
         // Versions prior to 30.0 vulnerable to CVE-2020-8908
         dependency 'com.google.guava:guava:30.1-jre'
 
-        // CVE-2019-0232 - Java and Command Line injections in Windows
-        dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.50') {
+        // CVE-2019-0232 - Java and Command Line injections in Windows (updated to version 9.0.19)
+        // CVE-2021-42340 - Memory leak (updated to version 9.0.54)
+        dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.54') {
             entry 'tomcat-embed-core'
             entry 'tomcat-embed-el'
             entry 'tomcat-embed-websocket'

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -45,11 +45,6 @@
 		crafted file
 		</notes>
 		<cve>CVE-2020-23171</cve>
-	</suppress> 
-
-	<suppress until="2021-11-25">
-		<notes>Suppress CVE affecting Tomcat temporarily until it can be addressed</notes>
-		<cve>CVE-2021-42340</cve>
 	</suppress>
 
 </suppressions>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -47,4 +47,9 @@
 		<cve>CVE-2020-23171</cve>
 	</suppress>
 
+	<suppress until="2021-11-25">
+		<notes>Suppress CVE affecting spring-core temporarily until it can be addressed</notes>
+		<cve>CVE-2021-22096</cve>
+	</suppress>
+
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2112 (https://tools.hmcts.net/jira/browse/CCD-2112)


### Change description ###
- Updated dependencyManagement section of build.gradle. Set version of org.apache.tomcat.embed group to 9.0.54 to resolve CVE-2021-42340.
- Removed suppression of CVE-2021-42340 from dependency-check-suppressions.xml


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
