### PR TITLE
CCD-2136: Address CVE-2021-22096

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ def versions = [
         pact_version: '4.1.7'
 ]
 ext['spring-security.version'] = '5.4.7'
-ext['spring-framework.version'] = '5.3.7'
+ext['spring-framework.version'] = '5.3.12'
 
 
 dependencyUpdates.resolutionStrategy = {

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -47,9 +47,4 @@
 		<cve>CVE-2020-23171</cve>
 	</suppress>
 
-	<suppress until="2021-11-25">
-		<notes>Suppress CVE affecting spring-core temporarily until it can be addressed</notes>
-		<cve>CVE-2021-22096</cve>
-	</suppress>
-
 </suppressions>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<suppressions
-	xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
 
 	<suppress until="2021-11-25">
 		<notes>We do not use: Spring Framework 5.0.5.RELEASE + Spring Security


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2136 (https://tools.hmcts.net/jira/browse/CCD-2136)


### Change description ###
- Updated build.gradle.  Set value of override of spring-framework.version property to 5.3.12 to address CVE-2021-22096.
- Removed temporary suppression of CVE-2021-22096 from dependency-check-suppressions.xml


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
