### PR TITLE
RDM-12965 - Cache RoleToAccessProfiles info for case types

### DIFF
--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/AuthorisationMapper.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/AuthorisationMapper.java
@@ -39,7 +39,7 @@ public class AuthorisationMapper {
 
     public Map<String, RoleToAccessProfileDefinition> toRoleNameAsKeyMap(String caseTypeId) {
         return caseTypeRoleToAccessProfileDefinition.computeIfAbsent(caseTypeId,
-            id -> toRoleNameAsKeyMap(caseTypeService.getCaseType(caseTypeId)));
+            id -> toRoleNameAsKeyMap(caseTypeService.getCaseType(caseTypeId).getRoleToAccessProfiles()));
     }
 
     public Map<String, RoleToAccessProfileDefinition> toRoleNameAsKeyMap(

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/AuthorisationMapper.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/AuthorisationMapper.java
@@ -38,7 +38,8 @@ public class AuthorisationMapper {
     }
 
     public Map<String, RoleToAccessProfileDefinition> toRoleNameAsKeyMap(String caseTypeId) {
-        return toRoleNameAsKeyMap(caseTypeService.getCaseType(caseTypeId));
+        return caseTypeRoleToAccessProfileDefinition.computeIfAbsent(caseTypeId,
+            id -> toRoleNameAsKeyMap(caseTypeService.getCaseType(caseTypeId)));
     }
 
     public Map<String, RoleToAccessProfileDefinition> toRoleNameAsKeyMap(

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/AuthorisationMapper.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/AuthorisationMapper.java
@@ -16,7 +16,7 @@ import uk.gov.hmcts.ccd.domain.model.definition.CaseTypeDefinition;
 import uk.gov.hmcts.ccd.domain.model.definition.RoleToAccessProfileDefinition;
 import uk.gov.hmcts.ccd.domain.service.common.CaseTypeService;
 
-import static com.google.common.collect.Maps.newHashMap;
+import static com.google.common.collect.Maps.newConcurrentMap;
 
 @Component
 @RequestScope
@@ -25,7 +25,7 @@ public class AuthorisationMapper {
     private final CaseTypeService caseTypeService;
 
     private final Map<String, Map<String, RoleToAccessProfileDefinition>> caseTypeRoleToAccessProfileDefinition
-        = newHashMap();
+        = newConcurrentMap();
 
     @Autowired
     public AuthorisationMapper(CaseTypeService caseTypeService) {

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/AuthorisationMapper.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/AuthorisationMapper.java
@@ -7,13 +7,39 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.BooleanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
 import uk.gov.hmcts.ccd.domain.model.casedataaccesscontrol.AccessProfile;
 import uk.gov.hmcts.ccd.domain.model.casedataaccesscontrol.RoleAssignment;
+import uk.gov.hmcts.ccd.domain.model.definition.CaseTypeDefinition;
 import uk.gov.hmcts.ccd.domain.model.definition.RoleToAccessProfileDefinition;
+import uk.gov.hmcts.ccd.domain.service.common.CaseTypeService;
+
+import static com.google.common.collect.Maps.newHashMap;
 
 @Component
+@RequestScope
 public class AuthorisationMapper {
+
+    private final CaseTypeService caseTypeService;
+
+    private final Map<String, Map<String, RoleToAccessProfileDefinition>> caseTypeRoleToAccessProfileDefinition
+        = newHashMap();
+
+    @Autowired
+    public AuthorisationMapper(CaseTypeService caseTypeService) {
+        this.caseTypeService = caseTypeService;
+    }
+
+    public Map<String, RoleToAccessProfileDefinition> toRoleNameAsKeyMap(CaseTypeDefinition caseTypeDefinition) {
+        return caseTypeRoleToAccessProfileDefinition.computeIfAbsent(caseTypeDefinition.getId(),
+            id -> toRoleNameAsKeyMap(caseTypeDefinition.getRoleToAccessProfiles()));
+    }
+
+    public Map<String, RoleToAccessProfileDefinition> toRoleNameAsKeyMap(String caseTypeId) {
+        return toRoleNameAsKeyMap(caseTypeService.getCaseType(caseTypeId));
+    }
 
     public Map<String, RoleToAccessProfileDefinition> toRoleNameAsKeyMap(
         List<RoleToAccessProfileDefinition> roleToAccessProfiles) {

--- a/src/test/java/uk/gov/hmcts/ccd/domain/model/casedataaccesscontrol/AccessProfileServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/model/casedataaccesscontrol/AccessProfileServiceImplTest.java
@@ -5,10 +5,13 @@ import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import uk.gov.hmcts.ccd.domain.model.casedataaccesscontrol.enums.GrantType;
 import uk.gov.hmcts.ccd.domain.model.definition.RoleToAccessProfileDefinition;
 import uk.gov.hmcts.ccd.domain.service.AuthorisationMapper;
 import uk.gov.hmcts.ccd.domain.service.casedataaccesscontrol.AccessProfileServiceImpl;
+import uk.gov.hmcts.ccd.domain.service.common.CaseTypeService;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -19,9 +22,13 @@ class AccessProfileServiceImplTest {
 
     private AccessProfileServiceImpl roleAssignmentMapper;
 
+    @Mock
+    private CaseTypeService caseTypeService;
+
     @BeforeEach
     void setUp() {
-        AuthorisationMapper authorisationMapper = new AuthorisationMapper();
+        MockitoAnnotations.openMocks(this);
+        AuthorisationMapper authorisationMapper = new AuthorisationMapper(caseTypeService);
         roleAssignmentMapper = new AccessProfileServiceImpl(authorisationMapper);
     }
 

--- a/src/test/java/uk/gov/hmcts/ccd/domain/model/casedataaccesscontrol/matcher/AuthorisationsMatcherTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/model/casedataaccesscontrol/matcher/AuthorisationsMatcherTest.java
@@ -35,7 +35,7 @@ class AuthorisationsMatcherTest extends BaseFilter {
     @BeforeEach
     void setUp() {
         caseTypeService = mock(CaseTypeService.class);
-        classUnderTest = new AuthorisationsMatcher(caseTypeService, new AuthorisationMapper());
+        classUnderTest = new AuthorisationsMatcher(new AuthorisationMapper(caseTypeService));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/casedataaccesscontrol/DefaultCaseDataAccessControlTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/casedataaccesscontrol/DefaultCaseDataAccessControlTest.java
@@ -27,6 +27,7 @@ import uk.gov.hmcts.ccd.domain.model.definition.CaseTypeDefinition;
 import uk.gov.hmcts.ccd.domain.model.definition.RoleToAccessProfileDefinition;
 import uk.gov.hmcts.ccd.domain.service.AccessControl;
 import uk.gov.hmcts.ccd.domain.service.AuthorisationMapper;
+import uk.gov.hmcts.ccd.domain.service.common.CaseTypeService;
 import uk.gov.hmcts.ccd.infrastructure.user.UserAuthorisation;
 
 import java.util.ArrayList;
@@ -93,8 +94,11 @@ class DefaultCaseDataAccessControlTest {
     @Mock
     private RoleAssignmentsFilteringService roleAssignmentsFilteringService;
 
+    @Mock
+    private CaseTypeService caseTypeService;
+
     private final AccessProfileService accessProfileService =
-        spy(new AccessProfileServiceImpl(new AuthorisationMapper()));
+        spy(new AccessProfileServiceImpl(new AuthorisationMapper(caseTypeService)));
 
     @Mock
     private PseudoRoleAssignmentsGenerator pseudoRoleAssignmentsGenerator;


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-12965


### Change description ###
Cache `RoleToAccessProfiles` info for case types in each request.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
