### PR TITLE
CCD-2107: Updated CVE suppression dates

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
 
-	<suppress until="2021-11-25">
+	<suppress until="2021-12-25">
 		<notes>We do not use: Spring Framework 5.0.5.RELEASE + Spring Security
 			(any version), see https://pivotal.io/security/cve-2018-1258
 			False positive confirmed.
@@ -10,7 +10,7 @@
 		<cve>CVE-2018-1258</cve>
 	</suppress>
 
-	<suppress until="2021-11-25">
+	<suppress until="2021-12-25">
 		<notes>These CVE's are coming from Dhowden tag library and it impacts only MP3/MP4/OGG/FLAC metadata parsing
 			library. Also it is declared as false positive in https://github.com/jeremylong/DependencyCheck/issues/3043
 			Last control version: 1.5
@@ -21,7 +21,7 @@
 		<cve>CVE-2020-29245</cve>
 	</suppress>
 
-	<suppress until="2021-11-25">
+	<suppress until="2021-12-25">
 		<notes>Declared as False Positive on com.nimbusds:oauth2-oidc-sdk #2866
 			https://github.com/jeremylong/DependencyCheck/issues/2866
 			Last control version: 9.10.1
@@ -38,7 +38,7 @@
 		<vulnerabilityName>CVE-2021-27568</vulnerabilityName>
 	</suppress>
 
-	<suppress until="2021-11-25">
+	<suppress until="2021-12-25">
 		<notes>A vulnerability in all versions of Nim-lang allows unauthenticated attackers to write files to
 		arbitrary directories via a crafted zip file with dot-slash characters included in the name of the
 		crafted file


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2107 (https://tools.hmcts.net/jira/browse/CCD-2107)


### Change description ###
Updated CVE suppression dates in dependency-check-suppressions.xml to 25/12/2021


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
