### PR TITLE
CCD-2177: Review CVE suppressions

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -1,6 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
 
+	<suppress>
+		<notes>
+			Declared as False positive on library com.nimbusds:lang-tag #3594
+			https://github.com/jeremylong/DependencyCheck/issues/3594
+			CVE-2020-23171 Reference https://tools.hmcts.net/jira/browse/CCD-1871
+		</notes>
+		<packageUrl regex="true">^pkg:maven/com\.nimbusds/lang\-tag@.*$</packageUrl>
+		<cpe>cpe:/a:nim-lang:nim-lang</cpe>
+		<cve>CVE-2020-23171</cve>
+	</suppress>
+
 	<suppress until="2021-12-25">
 		<notes>We do not use: Spring Framework 5.0.5.RELEASE + Spring Security
 			(any version), see https://pivotal.io/security/cve-2018-1258
@@ -28,22 +39,6 @@
 		</notes>
 		<cve>CVE-2007-1651</cve>
 		<cve>CVE-2007-1652</cve>
-	</suppress>
-
-	<suppress>
-		<notes><![CDATA[
-   file name: json-smart-2.3.jar
-   ]]></notes>
-		<packageUrl regex="true">^pkg:maven/net\.minidev/json\-smart@.*$</packageUrl>
-		<vulnerabilityName>CVE-2021-27568</vulnerabilityName>
-	</suppress>
-
-	<suppress until="2021-12-25">
-		<notes>A vulnerability in all versions of Nim-lang allows unauthenticated attackers to write files to
-		arbitrary directories via a crafted zip file with dot-slash characters included in the name of the
-		crafted file
-		</notes>
-		<cve>CVE-2020-23171</cve>
 	</suppress>
 
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2177 (https://tools.hmcts.net/jira/browse/CCD-2177)


### Change description ###
- Removed suppression of CVE-2021-27568 from dependency-check-suppressions.xml.  This was fixed in Pull Request 1564 (https://github.com/hmcts/ccd-data-store-api/pull/1564).  Suppression was added in Pull Request 1558 (https://github.com/hmcts/ccd-data-store-api/pull/1558) which was being worked on in parrallel.
- Documented CVE-2020-23171 as a false positive and moved it to the top of the dependency-check-suppressions.xml file so that position is consistent with suppression files in other components.  This change was originally made under CCD-1871 but the associated pull request - Pull Request 1641 (https://github.com/hmcts/ccd-data-store-api/pull/1641) - wasn't merged.  The changes in Pull Request 1641 itself have also been reverted as a result of merging changes from master into it.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
