### PR TITLE
CCD-2231-update-cve-suppression-dates-dec-2021

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -12,7 +12,7 @@
 		<cve>CVE-2020-23171</cve>
 	</suppress>
 
-	<suppress until="2021-12-25">
+	<suppress until="2022-01-25">
 		<notes>We do not use: Spring Framework 5.0.5.RELEASE + Spring Security
 			(any version), see https://pivotal.io/security/cve-2018-1258
 			False positive confirmed.
@@ -21,7 +21,7 @@
 		<cve>CVE-2018-1258</cve>
 	</suppress>
 
-	<suppress until="2021-12-25">
+	<suppress until="2022-01-25">
 		<notes>These CVE's are coming from Dhowden tag library and it impacts only MP3/MP4/OGG/FLAC metadata parsing
 			library. Also it is declared as false positive in https://github.com/jeremylong/DependencyCheck/issues/3043
 			Last control version: 1.5
@@ -32,7 +32,7 @@
 		<cve>CVE-2020-29245</cve>
 	</suppress>
 
-	<suppress until="2021-12-25">
+	<suppress until="2022-01-25">
 		<notes>Declared as False Positive on com.nimbusds:oauth2-oidc-sdk #2866
 			https://github.com/jeremylong/DependencyCheck/issues/2866
 			Last control version: 9.10.1


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-2231

### Change description ###

Changed suppression dates from 2021-12-25 to 2022-01-25

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
