### PR TITLE
CCD-2374: Update log4j version to 2.17.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -169,7 +169,7 @@ dependencies {
 
     compile group: 'javax.inject', name: 'javax.inject', version: '1'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.7'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.16.0'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.0'
     compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
     implementation group: 'io.springfox', name: 'springfox-boot-starter', version: swagger2Version
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CCD-2351

### Change description ###
Update log4j version to 2.17.0.
- Mitigations for CVE-2021-45105, CVE-2021-45046 and CVE-2021-44228

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```