### PR TITLE
RDM-13070 Remove caching of jurisdictions in Global Search

### DIFF
--- a/src/main/java/uk/gov/hmcts/ccd/data/definition/CachedCaseDefinitionRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/definition/CachedCaseDefinitionRepository.java
@@ -37,7 +37,6 @@ public class CachedCaseDefinitionRepository implements CaseDefinitionRepository 
     private final Map<String, CaseTypeDefinitionVersion> versions = newHashMap();
     private final Map<String, UserRole> userRoleClassifications = newHashMap();
     private final Map<String, List<FieldTypeDefinition>> baseTypes = newHashMap();
-    private final Map<String, JurisdictionDefinition> jurisdictions = newHashMap();
     private final Map<String, CaseTypeDefinition> caseTypes = newHashMap();
 
     @Autowired
@@ -110,7 +109,7 @@ public class CachedCaseDefinitionRepository implements CaseDefinitionRepository 
     @Override
     public JurisdictionDefinition getJurisdiction(String jurisdictionId) {
         LOGGER.debug("Will get jurisdiction '{}' from repository.", jurisdictionId);
-        return jurisdictions.computeIfAbsent(jurisdictionId, caseDefinitionRepository::getJurisdiction);
+        return caseDefinitionRepository.getJurisdiction(jurisdictionId);
     }
 
     @Override


### PR DESCRIPTION
### JIRA link (if applicable) ###

[RDM-13070](https://tools.hmcts.net/jira/browse/RDM-13070) _"Remove caching of jurisdictions in Global Search"_

### Change description ###

Remove caching of jurisdictions in Global Search until [CCD-913](https://tools.hmcts.net/jira/browse/CCD-913).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
