### PR TITLE
CCD-2400: Reschedule nightly build

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -2,7 +2,7 @@
 
 properties([
     // H allow predefined but random minute see https://en.wikipedia.org/wiki/Cron#Non-standard_characters
-    pipelineTriggers([cron('H 04 * * *')])
+    pipelineTriggers([cron('H 07 * * *')])
 ])
 
 @Library("Infrastructure")

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -2,7 +2,7 @@
 
 properties([
     // H allow predefined but random minute see https://en.wikipedia.org/wiki/Cron#Non-standard_characters
-    pipelineTriggers([cron('H 05 * * *')])
+    pipelineTriggers([cron('H 04 * * *')])
 ])
 
 @Library("Infrastructure")


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2400 (https://tools.hmcts.net/jira/browse/CCD-2400)


### Change description ###
Updated Jenkinsfile_nightly.  Changed pipeline trigger hour to 04 so as not to conflict with ccd-definition-store-api nightly build.  Believe that conflict with test data used by ccd-definition-store-api tests is causing ccd-data-store-api tests to fail.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
