### PR TITLE
RDM-13087 Remove GlobalSearch endpoint dependency on Jurisdiction Details call

### DIFF
--- a/src/aat/resources/features/F-1005 - GlobalSearch - Search cases/F-1005.feature
+++ b/src/aat/resources/features/F-1005 - GlobalSearch - Search cases/F-1005.feature
@@ -1,4 +1,4 @@
-@F-1005 @elasticsearch @Ignore # Exclude all tests until issues with them are resolved
+@F-1005 @elasticsearch
 Feature: F-1005: Global Search - Search cases
 
   Background: Load test data for the scenario

--- a/src/aat/resources/features/F-1005 - GlobalSearch - Search cases/F-1005.feature
+++ b/src/aat/resources/features/F-1005 - GlobalSearch - Search cases/F-1005.feature
@@ -1,4 +1,4 @@
-@F-1005 @elasticsearch
+@F-1005 @elasticsearch @Ignore # Exclude all tests until issues with them are resolved
 Feature: F-1005: Global Search - Search cases
 
   Background: Load test data for the scenario


### PR DESCRIPTION
### JIRA link (if applicable) ###

[RDM-13087](https://tools.hmcts.net/jira/browse/RDM-13087) _"Remove GlobalSearch endpoint dependency on Jurisdiction Details call"_

### Change description ###

Remove GlobalSearch endpoint dependency on Jurisdiction Details call.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
