### PR TITLE
CCD-2539: Cache system user token

### DIFF
--- a/src/contractTest/resources/application.properties
+++ b/src/contractTest/resources/application.properties
@@ -50,6 +50,9 @@ definition.cache.request-scope.case-types.till-hour=${REQUEST_SCOPE_CACHED_CASE_
 #time to live for user cache entries
 user.cache.ttl.secs=${USER_CACHE_ENTRIES_TTL_SEC:1800}
 
+# Time To Live (TTL) in seconds for system user token cache
+system.user.token.cache.ttl.secs=${SYSTEM_USER_TOKEN_CACHE_TTL_SEC:14400}
+
 # Jackson ObjectMapper configuration
 spring.jackson.serialization.WRITE_DATES_AS_TIMESTAMPS=false
 

--- a/src/main/java/uk/gov/hmcts/ccd/ApplicationParams.java
+++ b/src/main/java/uk/gov/hmcts/ccd/ApplicationParams.java
@@ -213,6 +213,9 @@ public class ApplicationParams {
     @Value("${reference.data.cache.ttl.in.days}")
     private String referenceDataCacheTtlInDays;
 
+    @Value("${system.user.token.cache.ttl.secs}")
+    private Integer systemUserTokenCacheTTLSecs;
+
     public static String encode(final String stringToEncode) {
         try {
             return URLEncoder.encode(stringToEncode, "UTF-8");
@@ -580,5 +583,9 @@ public class ApplicationParams {
 
     public Integer getRequestScopeCachedCaseTypesTillHour() {
         return requestScopeCachedCaseTypesTillHour;
+    }
+
+    public Integer getSystemUserTokenCacheTTLSecs() {
+        return systemUserTokenCacheTTLSecs;
     }
 }

--- a/src/main/java/uk/gov/hmcts/ccd/CachingConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/ccd/CachingConfiguration.java
@@ -51,6 +51,8 @@ public class CachingConfiguration {
         config.addMapConfig(newMapConfigWithMaxIdle("userInfoCache", applicationParams.getUserCacheTTLSecs()));
         config.addMapConfig(newMapConfigWithMaxIdle("idamUserRoleCache",
             applicationParams.getUserCacheTTLSecs()));
+        config.addMapConfig(newMapConfigWithMaxIdle("systemUserTokenCache",
+            applicationParams.getSystemUserTokenCacheTTLSecs()));
         config.addMapConfig(newMapConfigWithMaxIdle("bannersCache", latestVersionTTL));
         config.addMapConfig(newMapConfigWithMaxIdle("jurisdictionUiConfigsCache", latestVersionTTL));
         config.addMapConfig(newMapConfigWithTtl("caseTypeDefinitionLatestVersionCache", latestVersionTTL));

--- a/src/main/java/uk/gov/hmcts/ccd/security/idam/IdamRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/security/idam/IdamRepository.java
@@ -45,6 +45,7 @@ public class IdamRepository {
         return idamClient.getUserByUserId(bearerToken, userId);
     }
 
+    @Cacheable("systemUserTokenCache")
     public String getDataStoreSystemUserAccessToken() {
         return idamClient.getAccessToken(applicationParams.getDataStoreSystemUserId(),
             applicationParams.getDataStoreSystemUserPassword());

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -50,6 +50,9 @@ definition.cache.request-scope.case-types.till-hour=${REQUEST_SCOPE_CACHED_CASE_
 #time to live for user cache entries
 user.cache.ttl.secs=${USER_CACHE_ENTRIES_TTL_SEC:1800}
 
+# Time To Live (TTL) in seconds for system user token cache
+system.user.token.cache.ttl.secs=${SYSTEM_USER_TOKEN_CACHE_TTL_SEC:14400}
+
 # Jackson ObjectMapper configuration
 spring.jackson.serialization.WRITE_DATES_AS_TIMESTAMPS=false
 

--- a/src/test/java/uk/gov/hmcts/ccd/integrations/IdamRepositoryCachingIT.java
+++ b/src/test/java/uk/gov/hmcts/ccd/integrations/IdamRepositoryCachingIT.java
@@ -95,7 +95,7 @@ public class IdamRepositoryCachingIT {
 
         // Pause long enough so that cache time limit expires - see system.user.token.cache.ttl.secs in test.properties
         try {
-            TimeUnit.SECONDS.sleep(3);
+            TimeUnit.SECONDS.sleep(5);
         } catch (InterruptedException e) {
             fail("Exception occurred whilst pausing to expire cache time limit: " + e.getMessage());
         }

--- a/src/test/java/uk/gov/hmcts/ccd/integrations/IdamRepositoryCachingIT.java
+++ b/src/test/java/uk/gov/hmcts/ccd/integrations/IdamRepositoryCachingIT.java
@@ -1,0 +1,123 @@
+package uk.gov.hmcts.ccd.integrations;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockitoAnnotations;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.hmcts.ccd.ApplicationParams;
+import uk.gov.hmcts.ccd.security.idam.IdamRepository;
+import uk.gov.hmcts.reform.idam.client.IdamClient;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureWireMock(port = 0)
+@TestPropertySource(locations = "classpath:test.properties")
+public class IdamRepositoryCachingIT {
+
+    private static final Logger LOG = LoggerFactory.getLogger(IdamRepositoryCachingIT.class);
+
+    private static final String TEST_SYS_USERNAME = "testSysUsername";
+    private static final String TEST_SYS_PASSWORD = "testSysPassword";
+    private static final String TEST_SYS_ACCESS_TOKEN_ONE = "testSysAccessTokenOne";
+    private static final String TEST_SYS_ACCESS_TOKEN_TWO = "testSysAccessTokenTwo";
+
+    // Need to Spy ApplicationParams rather than Mock it as it is used during setup of other beans
+    @SpyBean
+    private ApplicationParams applicationParams;
+
+    @MockBean
+    private IdamClient idamClient;
+
+    // SpyBean and MockBean annotations mean that IdamRepository bean will automatically use
+    // mocked/spied ApplicationParams and IdamClient beans
+    @Autowired
+    private IdamRepository idamRepository;
+
+    private AutoCloseable autoCloseable;
+
+    @Before
+    public void openMocks() {
+        autoCloseable = MockitoAnnotations.openMocks(this);
+    }
+
+    /**
+     * <p>Test cached behaviour of getDataStoreUserAccessToken method.  Caching is implemented using Spring
+     * Cacheable annotation so test is performed on the actual IdamRepository bean with mocked dependencies.</p>
+     *
+     * <p>As the caching behaviour is controlled by Spring it is not reset between tests.  For this reason
+     * all tests have to be in a single method so that state can be controlled.</p>
+     */
+    @Test
+    public void shouldCacheGetDataStoreUserAccessTokenMethod() {
+
+        // Set up initial expected behaviour for mock and spy beans
+        when(applicationParams.getDataStoreSystemUserId()).thenReturn(TEST_SYS_USERNAME);
+        when(applicationParams.getDataStoreSystemUserPassword()).thenReturn(TEST_SYS_PASSWORD);
+        when(idamClient.getAccessToken(TEST_SYS_USERNAME, TEST_SYS_PASSWORD)).thenReturn(TEST_SYS_ACCESS_TOKEN_ONE);
+
+        // Before testing getDataStoreUserAccessToken method first
+        // confirm that none of the mocked methods have been called
+        verify(applicationParams, never()).getDataStoreSystemUserId();
+        verify(applicationParams, never()).getDataStoreSystemUserPassword();
+        verify(idamClient, never()).getAccessToken(TEST_SYS_USERNAME, TEST_SYS_PASSWORD);
+
+        // Call getDataStoreUserAccessToken method for the first time.  No cached
+        // value should be available so the mocked methods should be called once.
+        LOG.info("Test getDataStoreUserAccessToken - no cached value");
+        checkGetDataStoreUserAccessToken(1, TEST_SYS_ACCESS_TOKEN_ONE);
+
+        // Change value returned by mock IdamClient to prove that cached value is returned
+        when(idamClient.getAccessToken(TEST_SYS_USERNAME, TEST_SYS_PASSWORD)).thenReturn(TEST_SYS_ACCESS_TOKEN_TWO);
+
+        // Call getDataStoreUserAccessToken method for the second time.  Cached original value should be returned
+        // and the mocked methods should still only have been called once.
+        LOG.info("Test getDataStoreUserAccessToken - cached value");
+        checkGetDataStoreUserAccessToken(1, TEST_SYS_ACCESS_TOKEN_ONE);
+
+        // Pause long enough so that cache time limit expires - see system.user.token.cache.ttl.secs in test.properties
+        try {
+            TimeUnit.SECONDS.sleep(3);
+        } catch (InterruptedException e) {
+            fail("Exception occurred whilst pausing to expire cache time limit: " + e.getMessage());
+        }
+
+        // Call getDataStoreUserAccessToken method for the third time.  As cache time limit has now
+        // expired the mocked methods should have been called again making two times in total.
+        LOG.info("Test getDataStoreUserAccessToken - cache expired");
+        checkGetDataStoreUserAccessToken(2, TEST_SYS_ACCESS_TOKEN_TWO);
+    }
+
+    private void checkGetDataStoreUserAccessToken(final int expectedNumInvocations, final String expectedAccessToken) {
+        String actualAccessToken;
+        actualAccessToken = idamRepository.getDataStoreSystemUserAccessToken();
+
+        verify(applicationParams, times(expectedNumInvocations)).getDataStoreSystemUserId();
+        verify(applicationParams, times(expectedNumInvocations)).getDataStoreSystemUserPassword();
+        verify(idamClient, times(expectedNumInvocations)).getAccessToken(TEST_SYS_USERNAME, TEST_SYS_PASSWORD);
+        assertEquals("Unexpected Access Token value", expectedAccessToken, actualAccessToken);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        autoCloseable.close();
+    }
+}

--- a/src/test/resources/test.properties
+++ b/src/test/resources/test.properties
@@ -33,6 +33,7 @@ definition.cache.latest-version-ttl=3
 definition.cache.jurisdiction-ttl=3
 definition.cache.max-idle.secs=3
 user.cache.ttl.secs=3
+system.user.token.cache.ttl.secs=3
 
 case_document_am.url=http://localhost:${wiremock.server.port}
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2539 (https://tools.hmcts.net/jira/browse/CCD-2539)


### Change description ###
Added Cacheable annotation to IdamRepository getDataStoreSystemUserAccessToken().  This caches the system user access token and reduces the number of calls made to IDAM.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
