### PR TITLE
CCD-2539: Cache system user token

### DIFF
--- a/charts/ccd-data-store-api/values.preview.template.yaml
+++ b/charts/ccd-data-store-api/values.preview.template.yaml
@@ -29,6 +29,7 @@ java:
     ELASTIC_SEARCH_NODES_DISCOVERY_ENABLED: true
     ELASTIC_SEARCH_HOSTS: "{{ .Release.Name }}-es-master:9200"
     ELASTIC_SEARCH_DATA_NODES_HOSTS: "http://{{ .Release.Name }}-es-master:9200"
+    LOGGING_LEVEL_UK_GOV_HMCTS_CCD_SECURITY_IDAM: DEBUG
     LOG_CALLBACK_DETAILS:
   postgresql:
     enabled: true

--- a/src/main/java/uk/gov/hmcts/ccd/CachingConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/ccd/CachingConfiguration.java
@@ -51,7 +51,7 @@ public class CachingConfiguration {
         config.addMapConfig(newMapConfigWithMaxIdle("userInfoCache", applicationParams.getUserCacheTTLSecs()));
         config.addMapConfig(newMapConfigWithMaxIdle("idamUserRoleCache",
             applicationParams.getUserCacheTTLSecs()));
-        config.addMapConfig(newMapConfigWithMaxIdle("systemUserTokenCache",
+        config.addMapConfig(newMapConfigWithTtl("systemUserTokenCache",
             applicationParams.getSystemUserTokenCacheTTLSecs()));
         config.addMapConfig(newMapConfigWithMaxIdle("bannersCache", latestVersionTTL));
         config.addMapConfig(newMapConfigWithMaxIdle("jurisdictionUiConfigsCache", latestVersionTTL));

--- a/src/main/java/uk/gov/hmcts/ccd/security/idam/IdamRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/security/idam/IdamRepository.java
@@ -19,7 +19,7 @@ public class IdamRepository {
     private final IdamClient idamClient;
     private final ApplicationParams applicationParams;
 
-    @Resource(name="idamRepository")
+    @Resource(name = "idamRepository")
     private IdamRepository selfInstance;
 
     @Autowired

--- a/src/main/java/uk/gov/hmcts/ccd/security/idam/IdamRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/security/idam/IdamRepository.java
@@ -18,6 +18,9 @@ public class IdamRepository {
     private final IdamClient idamClient;
     private final ApplicationParams applicationParams;
 
+    @Resource
+    private IdamRepository selfInstance;
+    
     @Autowired
     public IdamRepository(IdamClient idamClient, ApplicationParams applicationParams) {
         this.idamClient = idamClient;
@@ -35,7 +38,7 @@ public class IdamRepository {
 
     @Cacheable("idamUserRoleCache")
     public List<String> getUserRoles(String userId) {
-        String dataStoreSystemUserToken = getDataStoreSystemUserAccessToken();
+        String dataStoreSystemUserToken = selfInstance.getDataStoreSystemUserAccessToken();
         List<String> roles = getUserByUserId(userId, dataStoreSystemUserToken).getRoles();
         log.debug("System user queried user info from IDAM API. User Id={}. Roles={}.", userId, roles);
         return roles;

--- a/src/main/java/uk/gov/hmcts/ccd/security/idam/IdamRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/security/idam/IdamRepository.java
@@ -19,7 +19,7 @@ public class IdamRepository {
     private final IdamClient idamClient;
     private final ApplicationParams applicationParams;
 
-    @Resource
+    @Resource(name="idamRepository")
     private IdamRepository selfInstance;
 
     @Autowired

--- a/src/main/java/uk/gov/hmcts/ccd/security/idam/IdamRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/security/idam/IdamRepository.java
@@ -9,6 +9,7 @@ import uk.gov.hmcts.reform.idam.client.IdamClient;
 import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 import uk.gov.hmcts.reform.idam.client.models.UserInfo;
 
+import javax.annotation.Resource;
 import java.util.List;
 
 @Component
@@ -20,7 +21,7 @@ public class IdamRepository {
 
     @Resource
     private IdamRepository selfInstance;
-    
+
     @Autowired
     public IdamRepository(IdamClient idamClient, ApplicationParams applicationParams) {
         this.idamClient = idamClient;

--- a/src/main/java/uk/gov/hmcts/ccd/security/idam/IdamRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/security/idam/IdamRepository.java
@@ -41,7 +41,7 @@ public class IdamRepository {
     public List<String> getUserRoles(String userId) {
         String dataStoreSystemUserToken = selfInstance.getDataStoreSystemUserAccessToken();
         List<String> roles = getUserByUserId(userId, dataStoreSystemUserToken).getRoles();
-        log.debug("System user queried user info from IDAM API. User Id={}. Roles={}.", userId, roles);
+        log.info("System user queried user info from IDAM API. User Id={}. Roles={}.", userId, roles);
         return roles;
     }
 

--- a/src/main/java/uk/gov/hmcts/ccd/security/idam/IdamRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/security/idam/IdamRepository.java
@@ -41,7 +41,7 @@ public class IdamRepository {
     public List<String> getUserRoles(String userId) {
         String dataStoreSystemUserToken = selfInstance.getDataStoreSystemUserAccessToken();
         List<String> roles = getUserByUserId(userId, dataStoreSystemUserToken).getRoles();
-        log.info("System user queried user info from IDAM API. User Id={}. Roles={}.", userId, roles);
+        log.debug("System user queried user info from IDAM API. User Id={}. Roles={}.", userId, roles);
         return roles;
     }
 

--- a/src/main/java/uk/gov/hmcts/ccd/security/idam/IdamRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/security/idam/IdamRepository.java
@@ -51,6 +51,7 @@ public class IdamRepository {
 
     @Cacheable("systemUserTokenCache")
     public String getDataStoreSystemUserAccessToken() {
+        log.info("Getting a fresh token for system account.");
         return idamClient.getAccessToken(applicationParams.getDataStoreSystemUserId(),
             applicationParams.getDataStoreSystemUserPassword());
     }

--- a/src/test/java/uk/gov/hmcts/ccd/security/idam/IdamRepositoryTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/security/idam/IdamRepositoryTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.mockito.internal.util.reflection.Whitebox;
 import uk.gov.hmcts.ccd.ApplicationParams;
 import uk.gov.hmcts.reform.idam.client.IdamClient;
 import uk.gov.hmcts.reform.idam.client.models.UserDetails;
@@ -34,6 +35,7 @@ class IdamRepositoryTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.initMocks(this);
+        Whitebox.setInternalState(idamRepository, "selfInstance", idamRepository);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/ccd/security/idam/IdamRepositoryTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/security/idam/IdamRepositoryTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.mockito.internal.util.reflection.Whitebox;
+import org.powermock.reflect.Whitebox;
 import uk.gov.hmcts.ccd.ApplicationParams;
 import uk.gov.hmcts.reform.idam.client.IdamClient;
 import uk.gov.hmcts.reform.idam.client.models.UserDetails;


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CCD-2539


### Change description ###
- Added self reference to IdamRepository class.  This is used on the call to getDataStoreSystemUserAccessToken() from within the class itself and forces it to utilise the Spring cache.  This ensures that all calls to getDataStoreSystemUserAccessToken() use the Spring cache.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
