### PR TITLE
RDM-13127 adjust CaseAccessCategory in GS search

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -19,7 +19,8 @@ def branchesToSync = ['demo', 'ithc', 'perftest']
 
 // Variables to switch pipeline logic and wiring per type of build
 
-def definitionStoreDevelopPr = "PR-575"  // This doesn't change frequently, but when it does, only change this value.
+// TODO: remove TEMPORARY OVERRIDE FOR RDM-13127, reinstate: def definitionStoreDevelopPr = "PR-575"
+def definitionStoreDevelopPr = "PR-1166"  // This doesn't change frequently, but when it does, only change this value.
 def dataStoreApiDevelopPr    = "PR-1260" // This doesn't change frequently, but when it does, only change this value.
 def prsToUseAat              = "PR-1793" // Set this value to a PR number, or add it as a comma-separated value, if it's to follow CI/CD.
 
@@ -92,7 +93,8 @@ env.DM_STORE_BASE_URL = "http://dm-store-aat.service.core-compute-aat.internal"
 env.CASE_DOCUMENT_AM_URL = "http://ccd-case-document-am-api-aat.service.core-compute-aat.internal"
 env.RD_PROFESSIONAL_API_BASE_URL = "http://rd-professional-api-aat.service.core-compute-aat.internal"
 env.BEFTA_RESPONSE_HEADER_CHECK_POLICY="JUST_WARN"
-env.ELASTIC_SEARCH_FTA_ENABLED = "false"
+// TODO: remove TEMPORARY OVERRIDE FOR RDM-13127, reinstate: env.ELASTIC_SEARCH_FTA_ENABLED = "false"
+env.ELASTIC_SEARCH_FTA_ENABLED = "true"
 env.PACT_BROKER_FULL_URL = 'https://pact-broker.platform.hmcts.net'
 env.DEFAULT_COLLECTION_ASSERTION_MODE="UNORDERED"
 env.MAX_NUM_PARALLEL_THREADS=6

--- a/charts/ccd-data-store-api/values.preview.template.yaml
+++ b/charts/ccd-data-store-api/values.preview.template.yaml
@@ -23,7 +23,8 @@ java:
     DATA_STORE_DB_PASSWORD: "{{ .Values.postgresql.postgresqlPassword}}"
     DATA_STORE_DB_OPTIONS: "?stringtype=unspecified"
     DATA_STORE_DB_MAX_POOL_SIZE: 10
-    DEFINITION_STORE_HOST: http://ccd-definition-store-api-pr-575.service.core-compute-preview.internal/
+    # TODO: remove TEMPORARY OVERRIDE FOR RDM-13127, reinstate: DEFINITION_STORE_HOST: http://ccd-definition-store-api-pr-575.service.core-compute-preview.internal/
+    DEFINITION_STORE_HOST: http://ccd-definition-store-api-pr-1166.service.core-compute-preview.internal/
     USER_PROFILE_HOST: http://ccd-user-profile-api-pr-399.service.core-compute-preview.internal/
     ELASTIC_SEARCH_ENABLED: true # enable whenever ES required on a particular PR
     ELASTIC_SEARCH_NODES_DISCOVERY_ENABLED: true

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/search/global/GlobalSearchFields.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/search/global/GlobalSearchFields.java
@@ -27,6 +27,7 @@ public final class GlobalSearchFields {
      */
     public static final class CaseDataFields {
 
+        public static final String CASE_ACCESS_CATEGORY = "CaseAccessCategory";
         public static final String CASE_MANAGEMENT_CATEGORY = "caseManagementCategory";
         public static final String CASE_MANAGEMENT_LOCATION = "caseManagementLocation";
         public static final String CASE_NAME_HMCTS_INTERNAL = "caseNameHmctsInternal";
@@ -109,6 +110,8 @@ public final class GlobalSearchFields {
     public static final class CaseDataPaths {
 
         // root fields
+        public static final String CASE_ACCESS_CATEGORY
+            = CASE_DATA_PREFIX + CaseDataFields.CASE_ACCESS_CATEGORY;
         public static final String CASE_MANAGEMENT_CATEGORY
             = CASE_DATA_PREFIX + CaseDataFields.CASE_MANAGEMENT_CATEGORY;
         public static final String CASE_MANAGEMENT_LOCATION

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/search/global/GlobalSearchQueryBuilder.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/search/global/GlobalSearchQueryBuilder.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 
 import static uk.gov.hmcts.ccd.domain.service.search.global.GlobalSearchFields.CASE_TYPE;
 import static uk.gov.hmcts.ccd.domain.service.search.global.GlobalSearchFields.CaseDataPaths.BASE_LOCATION;
+import static uk.gov.hmcts.ccd.domain.service.search.global.GlobalSearchFields.CaseDataPaths.CASE_ACCESS_CATEGORY;
 import static uk.gov.hmcts.ccd.domain.service.search.global.GlobalSearchFields.CaseDataPaths.CASE_MANAGEMENT_CATEGORY_ID;
 import static uk.gov.hmcts.ccd.domain.service.search.global.GlobalSearchFields.CaseDataPaths.CASE_MANAGEMENT_CATEGORY_NAME;
 import static uk.gov.hmcts.ccd.domain.service.search.global.GlobalSearchFields.CaseDataPaths.CASE_MANAGEMENT_LOCATION;
@@ -105,6 +106,7 @@ public class GlobalSearchQueryBuilder {
     public ArrayNode globalSearchSourceFields() {
         return JacksonUtils.MAPPER.createArrayNode()
             // root level case data fields
+            .add(CASE_ACCESS_CATEGORY)
             .add(CASE_MANAGEMENT_CATEGORY_ID)
             .add(CASE_MANAGEMENT_CATEGORY_NAME)
             .add(CASE_MANAGEMENT_LOCATION)

--- a/src/test/resources/elasticsearch/config/mappings-global_search.json
+++ b/src/test/resources/elasticsearch/config/mappings-global_search.json
@@ -64,6 +64,16 @@
       "data": {
         "type": "object",
         "properties": {
+          "CaseAccessCategory": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256,
+                "normalizer": "lowercase_normalizer"
+              }
+            }
+          },
           "SearchCriteria": {
             "type": "object",
             "properties": {


### PR DESCRIPTION
### JIRA link (if applicable) ###

   [RDM-13127](https://tools.hmcts.net/jira/browse/RDM-13127) _"Access Control - CaseAccessCategory not working for the Global Search endpoint"_

### Change description ###

Add `CaseAccessCategory` to list of elastic search query source fields used by GlobalSearch to allow enhanced ES filter to use it.

> NB: This branch is dependent on: hmcts/ccd-definition-store-api#1166

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
