### PR TITLE
Re-add ignoreExitValue property to fortifyScan task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -748,6 +748,8 @@ task fortifyScan(type: JavaExec)  {
     main = "uk.gov.hmcts.fortifyclient.FortifyClientMainApp"
     classpath += sourceSets.test.runtimeClasspath
     jvmArgs = ['--add-opens=java.base/java.lang.reflect=ALL-UNNAMED']
+    // The line below prevents the build from failing if the Fortify scan detects issues
+    ignoreExitValue = true
 }
 
 idea {


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Re-added ignoreExitValue property to fortifyScan task in build.gradle.  This was accidentally removed by a previous commit.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
