### PR TITLE
CCD-2893:CVE-2022-21724 - ccd-data-store-api

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -1,73 +1,68 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
 
-    <suppress until="2022-04-25">
-        <notes>
-            Declared as False positive on library com.nimbusds:lang-tag #3594
-            https://github.com/jeremylong/DependencyCheck/issues/3594
-            CVE-2020-23171 Reference https://tools.hmcts.net/jira/browse/CCD-1871
-        </notes>
-        <packageUrl regex="true">^pkg:maven/com\.nimbusds/lang\-tag@.*$</packageUrl>
-        <cpe>cpe:/a:nim-lang:nim-lang</cpe>
-        <cve>CVE-2020-23171</cve>
-    </suppress>
+	<suppress until="2022-04-25">
+		<notes>
+			Declared as False positive on library com.nimbusds:lang-tag #3594
+			https://github.com/jeremylong/DependencyCheck/issues/3594
+			CVE-2020-23171 Reference https://tools.hmcts.net/jira/browse/CCD-1871
+		</notes>
+		<packageUrl regex="true">^pkg:maven/com\.nimbusds/lang\-tag@.*$</packageUrl>
+		<cpe>cpe:/a:nim-lang:nim-lang</cpe>
+		<cve>CVE-2020-23171</cve>
+	</suppress>
 
-    <suppress until="2022-04-25">
-        <notes>We do not use: Spring Framework 5.0.5.RELEASE + Spring Security
-            (any version), see https://pivotal.io/security/cve-2018-1258
-            False positive confirmed.
-            Last control version: 5.5.1
-        </notes>
-        <cve>CVE-2018-1258</cve>
-    </suppress>
+	<suppress until="2022-04-25">
+		<notes>We do not use: Spring Framework 5.0.5.RELEASE + Spring Security
+			(any version), see https://pivotal.io/security/cve-2018-1258
+			False positive confirmed.
+			Last control version: 5.5.1
+		</notes>
+		<cve>CVE-2018-1258</cve>
+	</suppress>
 
-    <suppress until="2022-04-25">
-        <notes>These CVE's are coming from Dhowden tag library and it impacts only MP3/MP4/OGG/FLAC
-            metadata parsing
-            library. Also it is declared as false positive in
-            https://github.com/jeremylong/DependencyCheck/issues/3043
-            Last control version: 1.5
-        </notes>
-        <cve>CVE-2020-29242</cve>
-        <cve>CVE-2020-29243</cve>
-        <cve>CVE-2020-29244</cve>
-        <cve>CVE-2020-29245</cve>
-    </suppress>
+	<suppress until="2022-04-25">
+		<notes>These CVE's are coming from Dhowden tag library and it impacts only MP3/MP4/OGG/FLAC metadata parsing
+			library. Also it is declared as false positive in https://github.com/jeremylong/DependencyCheck/issues/3043
+			Last control version: 1.5
+		</notes>
+		<cve>CVE-2020-29242</cve>
+		<cve>CVE-2020-29243</cve>
+		<cve>CVE-2020-29244</cve>
+		<cve>CVE-2020-29245</cve>
+	</suppress>
 
-    <suppress until="2022-04-25">
-        <notes>Declared as False Positive on com.nimbusds:oauth2-oidc-sdk #2866
-            https://github.com/jeremylong/DependencyCheck/issues/2866
-            Last control version: 9.10.1
-        </notes>
-        <cve>CVE-2007-1651</cve>
-        <cve>CVE-2007-1652</cve>
-    </suppress>
+	<suppress until="2022-04-25">
+		<notes>Declared as False Positive on com.nimbusds:oauth2-oidc-sdk #2866
+			https://github.com/jeremylong/DependencyCheck/issues/2866
+			Last control version: 9.10.1
+		</notes>
+		<cve>CVE-2007-1651</cve>
+		<cve>CVE-2007-1652</cve>
+	</suppress>
 
-    <suppress until="2022-04-25">
-        <notes><![CDATA[
+	<suppress until="2022-04-25">
+    		<notes><![CDATA[
    			file name: spring-security-core-5.4.7.jar
    		]]></notes>
-        <packageUrl regex="true">
-            ^pkg:maven/org\.springframework\.security/spring\-security\-core@.*$
-        </packageUrl>
-        <vulnerabilityName>CWE-862: Missing Authorization</vulnerabilityName>
-    </suppress>
+    		<packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-core@.*$</packageUrl>
+    		<vulnerabilityName>CWE-862: Missing Authorization</vulnerabilityName>
+  	</suppress>
 
-    <suppress until="2022-04-25">
-        <notes>
-            CVE affecting hazelcast-spring-4.0.3.jar and hazelcast-4.0.3.jar
-        </notes>
-        <cve>CVE-2022-0265</cve>
-    </suppress>
+	<suppress until="2022-04-25">
+		<notes>
+			CVE affecting hazelcast-spring-4.0.3.jar and hazelcast-4.0.3.jar
+		</notes>
+		<cve>CVE-2022-0265</cve>
+	</suppress>
 
-    <suppress until="2022-04-25">
-        <notes><![CDATA[
+	<suppress until="2022-04-25">
+		<notes><![CDATA[
    file name: jackson-databind-2.11.4.jar
    ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$
-        </packageUrl>
-        <cve>CVE-2020-36518</cve>
-    </suppress>
+		<packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
+		<cve>CVE-2020-36518</cve>
+	</suppress>
 
     <suppress until="2022-04-25">
         <notes><![CDATA[
@@ -76,4 +71,5 @@
         <packageUrl regex="true">^pkg:maven/org\.postgresql/postgresql@.*$</packageUrl>
         <cve>CVE-2022-21724</cve>
     </suppress>
+
 </suppressions>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -1,67 +1,79 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
 
-	<suppress until="2022-04-25">
-		<notes>
-			Declared as False positive on library com.nimbusds:lang-tag #3594
-			https://github.com/jeremylong/DependencyCheck/issues/3594
-			CVE-2020-23171 Reference https://tools.hmcts.net/jira/browse/CCD-1871
-		</notes>
-		<packageUrl regex="true">^pkg:maven/com\.nimbusds/lang\-tag@.*$</packageUrl>
-		<cpe>cpe:/a:nim-lang:nim-lang</cpe>
-		<cve>CVE-2020-23171</cve>
-	</suppress>
+    <suppress until="2022-04-25">
+        <notes>
+            Declared as False positive on library com.nimbusds:lang-tag #3594
+            https://github.com/jeremylong/DependencyCheck/issues/3594
+            CVE-2020-23171 Reference https://tools.hmcts.net/jira/browse/CCD-1871
+        </notes>
+        <packageUrl regex="true">^pkg:maven/com\.nimbusds/lang\-tag@.*$</packageUrl>
+        <cpe>cpe:/a:nim-lang:nim-lang</cpe>
+        <cve>CVE-2020-23171</cve>
+    </suppress>
 
-	<suppress until="2022-04-25">
-		<notes>We do not use: Spring Framework 5.0.5.RELEASE + Spring Security
-			(any version), see https://pivotal.io/security/cve-2018-1258
-			False positive confirmed.
-			Last control version: 5.5.1
-		</notes>
-		<cve>CVE-2018-1258</cve>
-	</suppress>
+    <suppress until="2022-04-25">
+        <notes>We do not use: Spring Framework 5.0.5.RELEASE + Spring Security
+            (any version), see https://pivotal.io/security/cve-2018-1258
+            False positive confirmed.
+            Last control version: 5.5.1
+        </notes>
+        <cve>CVE-2018-1258</cve>
+    </suppress>
 
-	<suppress until="2022-04-25">
-		<notes>These CVE's are coming from Dhowden tag library and it impacts only MP3/MP4/OGG/FLAC metadata parsing
-			library. Also it is declared as false positive in https://github.com/jeremylong/DependencyCheck/issues/3043
-			Last control version: 1.5
-		</notes>
-		<cve>CVE-2020-29242</cve>
-		<cve>CVE-2020-29243</cve>
-		<cve>CVE-2020-29244</cve>
-		<cve>CVE-2020-29245</cve>
-	</suppress>
+    <suppress until="2022-04-25">
+        <notes>These CVE's are coming from Dhowden tag library and it impacts only MP3/MP4/OGG/FLAC
+            metadata parsing
+            library. Also it is declared as false positive in
+            https://github.com/jeremylong/DependencyCheck/issues/3043
+            Last control version: 1.5
+        </notes>
+        <cve>CVE-2020-29242</cve>
+        <cve>CVE-2020-29243</cve>
+        <cve>CVE-2020-29244</cve>
+        <cve>CVE-2020-29245</cve>
+    </suppress>
 
-	<suppress until="2022-04-25">
-		<notes>Declared as False Positive on com.nimbusds:oauth2-oidc-sdk #2866
-			https://github.com/jeremylong/DependencyCheck/issues/2866
-			Last control version: 9.10.1
-		</notes>
-		<cve>CVE-2007-1651</cve>
-		<cve>CVE-2007-1652</cve>
-	</suppress>
+    <suppress until="2022-04-25">
+        <notes>Declared as False Positive on com.nimbusds:oauth2-oidc-sdk #2866
+            https://github.com/jeremylong/DependencyCheck/issues/2866
+            Last control version: 9.10.1
+        </notes>
+        <cve>CVE-2007-1651</cve>
+        <cve>CVE-2007-1652</cve>
+    </suppress>
 
-	<suppress until="2022-04-25">
-    		<notes><![CDATA[
+    <suppress until="2022-04-25">
+        <notes><![CDATA[
    			file name: spring-security-core-5.4.7.jar
    		]]></notes>
-    		<packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-core@.*$</packageUrl>
-    		<vulnerabilityName>CWE-862: Missing Authorization</vulnerabilityName>
-  	</suppress>
+        <packageUrl regex="true">
+            ^pkg:maven/org\.springframework\.security/spring\-security\-core@.*$
+        </packageUrl>
+        <vulnerabilityName>CWE-862: Missing Authorization</vulnerabilityName>
+    </suppress>
 
-	<suppress until="2022-04-25">
-		<notes>
-			CVE affecting hazelcast-spring-4.0.3.jar and hazelcast-4.0.3.jar
-		</notes>
-		<cve>CVE-2022-0265</cve>
-	</suppress>
+    <suppress until="2022-04-25">
+        <notes>
+            CVE affecting hazelcast-spring-4.0.3.jar and hazelcast-4.0.3.jar
+        </notes>
+        <cve>CVE-2022-0265</cve>
+    </suppress>
 
-	<suppress until="2022-04-25">
-		<notes><![CDATA[
+    <suppress until="2022-04-25">
+        <notes><![CDATA[
    file name: jackson-databind-2.11.4.jar
    ]]></notes>
-		<packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
-		<cve>CVE-2020-36518</cve>
-	</suppress>
+        <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$
+        </packageUrl>
+        <cve>CVE-2020-36518</cve>
+    </suppress>
 
+    <suppress until="2022-04-25">
+        <notes><![CDATA[
+   file name: postgresql-42.2.16.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.postgresql/postgresql@.*$</packageUrl>
+        <cve>CVE-2022-21724</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-2893

### Change description ###

A security hole was found in the jdbc driver for postgresql database while doing security research

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
