### PR TITLE
suppression for CVE-2022-22968

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -54,4 +54,12 @@
 		<packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
 		<cve>CVE-2020-36518</cve>
 	</suppress>
+
+	<suppress until="2022-05-25">
+		<notes><![CDATA[
+   file name: spring-core-5.3.18.jar
+   ]]></notes>
+		<packageUrl regex="true">^pkg:maven/org\.springframework/spring\-core@.*$</packageUrl>
+		<cve>CVE-2022-22968</cve>
+	</suppress>
 </suppressions>


### PR DESCRIPTION
This is suppression for:
In Spring Framework versions 5.3.0 - 5.3.18, 5.2.0 - 5.2.20, and older unsupported versions, the patterns for disallowedFields on a DataBinder are case sensitive which means a field is not effectively protected unless it is listed with both upper and lower case for the first character of the field, including upper and lower case for the first character of all nested fields within the property path.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
