### PR TITLE
CCD-3098: CVE-2022-22968: ccd-data-store-api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ def versions = [
         pact_version: '4.1.7'
 ]
 ext['spring-security.version'] = '5.6.1'
-ext['spring-framework.version'] = '5.3.19'
+ext['spring-framework.version'] = '5.3.20'
 
 
 dependencyUpdates.resolutionStrategy = {

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ def versions = [
         pact_version: '4.1.7'
 ]
 ext['spring-security.version'] = '5.6.1'
-ext['spring-framework.version'] = '5.3.18'
+ext['spring-framework.version'] = '5.3.19'
 
 
 dependencyUpdates.resolutionStrategy = {

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -46,7 +46,4 @@
 		</notes>
 		<cve>CVE-2022-0265</cve>
 	</suppress>
-	<suppress until="2022-05-25">
-		<cve>CVE-2022-22968</cve>
-	</suppress>
 </suppressions>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-3098

### Change description ###

Upgrading framework to 5.3.20 due to this vulnerability:
In Spring Framework versions 5.3.0 - 5.3.18, 5.2.0 - 5.2.20, and older unsupported versions, the patterns for disallowedFields on a DataBinder are case sensitive which means a field is not effectively protected unless it is listed with both upper and lower case for the first character of the field, including upper and lower case for the first character of all nested fields within the property path.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
