### PR TITLE
CVE-2022-25647: suppression change

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -49,4 +49,11 @@
 	<suppress until="2022-05-25">
 		<cve>CVE-2022-22968</cve>
 	</suppress>
+	<suppress until="2022-05-25">
+		<notes><![CDATA[
+   file name: gson-2.8.6.jar
+   ]]></notes>
+		<packageUrl regex="true">^pkg:maven/com\.google\.code\.gson/gson@.*$</packageUrl>
+		<cve>CVE-2022-25647</cve>
+	</suppress>
 </suppressions>


### PR DESCRIPTION
The package com.google.code.gson:gson before 2.8.9 are vulnerable to Deserialization of Untrusted Data via the writeReplace() method in internal classes, which may lead to DoS attacks.
CWE-502 Deserialization of Untrusted Data.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
