### PR TITLE
CCD-3086 Add JDK 17 to BEFTA Framework - befta pre release dependency…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -269,7 +269,7 @@ dependencies {
     compile 'com.github.hmcts:ccd-case-document-am-client:1.7.1'
 
     testCompile group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.19.0'
-    testCompile group: 'com.github.hmcts', name: 'befta-fw', version: '8.7.2-Categories'
+    testCompile group: 'com.github.hmcts', name: 'befta-fw', version: '8.7.2-CCD-3086.8'
 
     contractTestCompile group: 'au.com.dius.pact.provider', name: 'junit5', version: versions.pact_version
     contractTestCompile group: 'au.com.dius.pact.provider', name: 'spring', version: versions.pact_version


### PR DESCRIPTION
CCD-3086 Add JDK 17 to BEFTA Framework - befta pre release dependency used in build.gradle

https://tools.hmcts.net/jira/browse/CCD-3086

### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
