### PR TITLE
Ccd 216 malformed case type id error response

### DIFF
--- a/src/aat/resources/features/F-1003 - Case Creation With Documents/F-1003.feature
+++ b/src/aat/resources/features/F-1003 - Case Creation With Documents/F-1003.feature
@@ -36,7 +36,7 @@ Feature: F-1003: Submit Case Creation
     And   the response has all other details as expected,
     And   a call [to retrieve case details by case id] will get the expected response as in [Default_Get_Case_Data_Base_01].
 
-  @S-1032 @Ignore # Defect AM-707 / RDM-8403
+  @S-1032.1
   Scenario: must get an error response for a malformed case type ID
     Given a user with [an active caseworker profile in CCD with full permissions on a document field],
     And   a successful call [to upload a document with mandatory metadata] as in [Default_Document_Upload_Data],
@@ -44,6 +44,18 @@ Feature: F-1003: Submit Case Creation
     When  a request is prepared with appropriate values,
     And   the request [is to attach the document uploaded above to a new case],
     And   the request [contains a malformed case type ID]
+    And   it is submitted to call the [Submit Case Creation] operation of [CCD Data Store]
+    Then  a negative response is received
+    And   the response has all the details as expected
+
+  @S-1032.2
+  Scenario: must get an error response for a case type ID containing potentially malicious characters
+    Given a user with [an active caseworker profile in CCD with full permissions on a document field],
+    And   a successful call [to upload a document with mandatory metadata] as in [Default_Document_Upload_Data],
+    And   a successful call [to create a token for case creation] as in [Befta_Jurisdiction2_Default_Token_Creation_Data_For_Case_Creation],
+    When  a request is prepared with appropriate values,
+    And   the request [is to attach the document uploaded above to a new case],
+    And   the request [contains a case type ID containing potentially malicious characters]
     And   it is submitted to call the [Submit Case Creation] operation of [CCD Data Store]
     Then  a negative response is received
     And   the response has all the details as expected

--- a/src/aat/resources/features/F-1003 - Case Creation With Documents/S-1032.1.td.json
+++ b/src/aat/resources/features/F-1003 - Case Creation With Documents/S-1032.1.td.json
@@ -1,5 +1,5 @@
 {
-  "_guid_": "S-1032",
+  "_guid_": "S-1032.1",
   "_extends_": "F-1003-Test_Base_data",
   "title": "must get an error response for a malformed case type ID",
   "specs": [
@@ -13,8 +13,9 @@
   "expectedResponse": {
     "_extends_": "Common_400_Response",
     "body": {
-      "exception": "uk.gov.hmcts.ccd.endpoint.exceptions.BadRequestException",
-      "message": "Case ID is not valid",
+      "exception": "javax.validation.ConstraintViolationException",
+      "message": "createCase.caseTypeId: Case Type Id is invalid",
+      "path" : "/case-types/BEFTA_%2526%255E%2524%25C2%25A3CASETYPE_2_1/cases",
       "details": null,
       "callbackErrors": null,
       "callbackWarnings": null

--- a/src/aat/resources/features/F-1003 - Case Creation With Documents/S-1032.2.td.json
+++ b/src/aat/resources/features/F-1003 - Case Creation With Documents/S-1032.2.td.json
@@ -1,0 +1,20 @@
+{
+  "_guid_": "S-1032.2",
+  "_extends_": "F-1003-Test_Base_data",
+  "title": "must get an error response for a case type ID containing potentially malicious characters",
+  "specs": [
+    "contains a case type ID containing potentially malicious characters"
+  ],
+  "request": {
+    "pathVariables": {
+      "CaseTypeID": "BEFTA_%CASETYPE_2_1"
+    }
+  },
+  "expectedResponse": {
+    "_extends_": "Common_403_Response",
+    "body": {
+      "message": "The request was rejected because the URL contained a potentially malicious String \"%25\"",
+      "path" : "/case-types/BEFTA_%25CASETYPE_2_1/cases"
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/ccd/FirewallConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/ccd/FirewallConfiguration.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.ccd;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.web.firewall.RequestRejectedHandler;
+import uk.gov.hmcts.ccd.appinsights.AppInsights;
+import uk.gov.hmcts.ccd.security.DataStoreHttpStatusRequestRejectedHandler;
+
+@Configuration
+public class FirewallConfiguration {
+
+    @Bean
+    public RequestRejectedHandler requestRejectedHandler(AppInsights appInsights) {
+        return new DataStoreHttpStatusRequestRejectedHandler(appInsights);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/ccd/domain/model/common/HttpError.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/model/common/HttpError.java
@@ -49,6 +49,10 @@ public class HttpError<T extends Serializable> implements Serializable {
         this.path = UriUtils.encodePath(path, StandardCharsets.UTF_8);
     }
 
+    public HttpError(Exception exception, HttpServletRequest request, HttpStatus status) {
+        this(exception, request.getRequestURI(), status);
+    }
+
     private Integer getStatusFromResponseStatus(ResponseStatus responseStatus, HttpStatus status) {
         if (status != null) {
             return status.value();

--- a/src/main/java/uk/gov/hmcts/ccd/security/DataStoreHttpStatusRequestRejectedHandler.java
+++ b/src/main/java/uk/gov/hmcts/ccd/security/DataStoreHttpStatusRequestRejectedHandler.java
@@ -1,0 +1,42 @@
+package uk.gov.hmcts.ccd.security;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.web.firewall.RequestRejectedException;
+import org.springframework.security.web.firewall.RequestRejectedHandler;
+import uk.gov.hmcts.ccd.appinsights.AppInsights;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * Class for handling RequestRejectedExceptions raised by Spring StrictHttpFirewall.
+ * Based on the Spring HttpStatusRequestRejectedHandler class.
+ */
+public class DataStoreHttpStatusRequestRejectedHandler implements RequestRejectedHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DataStoreHttpStatusRequestRejectedHandler.class);
+
+    private final AppInsights appInsights;
+
+    private final int httpError;
+
+    public DataStoreHttpStatusRequestRejectedHandler(AppInsights appInsights) {
+        this(appInsights, HttpServletResponse.SC_FORBIDDEN);
+    }
+
+    public DataStoreHttpStatusRequestRejectedHandler(AppInsights appInsights, int httpError) {
+        this.appInsights = appInsights;
+        this.httpError = httpError;
+    }
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       RequestRejectedException requestRejectedException) throws IOException {
+        final String errorMsg = requestRejectedException.getMessage();
+        LOG.warn(errorMsg);
+        appInsights.trackException(requestRejectedException);
+        response.sendError(httpError, errorMsg);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/ccd/v2/external/controller/CaseController.java
+++ b/src/main/java/uk/gov/hmcts/ccd/v2/external/controller/CaseController.java
@@ -7,11 +7,11 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.ExampleProperty;
-import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -40,6 +40,9 @@ import uk.gov.hmcts.ccd.v2.V2;
 import uk.gov.hmcts.ccd.v2.external.resource.CaseEventsResource;
 import uk.gov.hmcts.ccd.v2.external.resource.CaseResource;
 import uk.gov.hmcts.ccd.v2.external.resource.SupplementaryDataResource;
+import uk.gov.hmcts.ccd.validator.annotation.ValidCaseTypeId;
+
+import java.util.List;
 
 import static org.springframework.http.ResponseEntity.status;
 import static uk.gov.hmcts.ccd.auditlog.AuditOperationType.CASE_ACCESSED;
@@ -48,6 +51,7 @@ import static uk.gov.hmcts.ccd.auditlog.AuditOperationType.UPDATE_CASE;
 
 @RestController
 @RequestMapping(path = "/")
+@Validated
 public class CaseController {
     private final GetCaseOperation getCaseOperation;
     private final CreateEventOperation createEventOperation;
@@ -304,7 +308,7 @@ public class CaseController {
     })
     @LogAudit(operationType = CREATE_CASE, caseId = "#result.body.reference",
         jurisdiction = "#result.body.jurisdiction", caseType = "#caseTypeId", eventName = "#content.event.eventId")
-    public ResponseEntity<CaseResource> createCase(@PathVariable("caseTypeId") String caseTypeId,
+    public ResponseEntity<CaseResource> createCase(@PathVariable("caseTypeId") @ValidCaseTypeId String caseTypeId,
                                                    @RequestBody final CaseDataContent content,
                                                    @RequestParam(value = "ignore-warning", required = false)
                                                        final Boolean ignoreWarning) {

--- a/src/main/java/uk/gov/hmcts/ccd/validator/CaseTypeIdValidator.java
+++ b/src/main/java/uk/gov/hmcts/ccd/validator/CaseTypeIdValidator.java
@@ -1,0 +1,29 @@
+package uk.gov.hmcts.ccd.validator;
+
+import uk.gov.hmcts.ccd.validator.annotation.ValidCaseTypeId;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.util.regex.PatternSyntaxException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CaseTypeIdValidator implements ConstraintValidator<ValidCaseTypeId, String> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CaseTypeIdValidator.class);
+
+    private static final String REG_EXP_VALID_CASE_TYPE_ID = "^[a-zA-Z0-9_-]+$";
+
+    @Override
+    public boolean isValid(String caseTypeId, ConstraintValidatorContext context) {
+        if (caseTypeId != null) {
+            try {
+                return caseTypeId.matches(REG_EXP_VALID_CASE_TYPE_ID);
+            } catch (final PatternSyntaxException e) {
+                LOG.error(e.getMessage());
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/ccd/validator/annotation/ValidCaseTypeId.java
+++ b/src/main/java/uk/gov/hmcts/ccd/validator/annotation/ValidCaseTypeId.java
@@ -1,0 +1,23 @@
+package uk.gov.hmcts.ccd.validator.annotation;
+
+import uk.gov.hmcts.ccd.validator.CaseTypeIdValidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+
+@Target({FIELD, PARAMETER})
+@Retention(RUNTIME)
+@Constraint(validatedBy = CaseTypeIdValidator.class)
+public @interface ValidCaseTypeId {
+    String message() default "Case Type Id is invalid";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/test/java/uk/gov/hmcts/ccd/security/DataStoreHttpStatusRequestRejectedHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/security/DataStoreHttpStatusRequestRejectedHandlerTest.java
@@ -1,0 +1,114 @@
+package uk.gov.hmcts.ccd.security;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.slf4j.LoggerFactory;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.web.firewall.RequestRejectedException;
+import uk.gov.hmcts.ccd.appinsights.AppInsights;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class DataStoreHttpStatusRequestRejectedHandlerTest {
+
+    private static final String EXCEPTION_MESSAGE = "Request Rejected Exception Test Message";
+
+    @Mock
+    private AppInsights appInsights;
+
+    private MockHttpServletRequest mockHttpServletRequest;
+    private MockHttpServletResponse mockHttpServletResponse;
+    private RequestRejectedException requestRejectedException;
+
+    private AutoCloseable autoCloseable;
+
+    private Logger handlerLogger;
+    private ListAppender<ILoggingEvent> handlerLoggerListAppender;
+
+    @Before
+    public void setUp() {
+        autoCloseable = MockitoAnnotations.openMocks(this);
+
+        mockHttpServletRequest = new MockHttpServletRequest();
+        mockHttpServletResponse = new MockHttpServletResponse();
+
+        requestRejectedException = mock(RequestRejectedException.class);
+        when(requestRejectedException.getMessage()).thenReturn(EXCEPTION_MESSAGE);
+
+        // Get the logger for the DataStoreHttpStatusRequestRejectedHandler class
+        handlerLogger = (Logger) LoggerFactory.getLogger(DataStoreHttpStatusRequestRejectedHandler.class);
+
+        // Create and start a list appender then add it to the logger
+        handlerLoggerListAppender = new ListAppender<>();
+        handlerLoggerListAppender.start();
+        handlerLogger.addAppender(handlerLoggerListAppender);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        autoCloseable.close();
+        handlerLogger.detachAndStopAllAppenders();
+    }
+
+    private void checkDataStoreHttpStatusRequestRejectedHandler(DataStoreHttpStatusRequestRejectedHandler handler,
+                                                                int expectedHttpError) {
+        try {
+            handler.handle(mockHttpServletRequest, mockHttpServletResponse, requestRejectedException);
+        } catch (final IOException e) {
+            fail("Unexpected IOException raised: " + e.getMessage());
+        }
+
+        // Confirm that exception was passed to application insights
+        verify(appInsights).trackException(requestRejectedException);
+
+        // Confirm that response contains expected http error and exception message
+        assertThat(mockHttpServletResponse.getStatus(), is(equalTo(expectedHttpError)));
+        assertThat(mockHttpServletResponse.getErrorMessage(), is(equalTo(EXCEPTION_MESSAGE)));
+
+        // Confirm that exception message was written to log and at the expected logging level
+        List<ILoggingEvent> loggerList = handlerLoggerListAppender.list;
+        ILoggingEvent lastLogEntry = loggerList.get(loggerList.size() - 1);
+        assertThat(lastLogEntry.getLevel(), is(equalTo(Level.WARN)));
+        assertThat(lastLogEntry.getMessage(), containsString(EXCEPTION_MESSAGE));
+    }
+
+    /**
+     * Test behaviour of DataStoreHttpStatusRequestRejectedHandler when it is initialised with the
+     * default http error code.
+     */
+    @Test
+    public void handlerCreatedWithDefaultHttpError() {
+        DataStoreHttpStatusRequestRejectedHandler handler = new DataStoreHttpStatusRequestRejectedHandler(appInsights);
+        checkDataStoreHttpStatusRequestRejectedHandler(handler, HttpServletResponse.SC_FORBIDDEN);
+    }
+
+    /**
+     * Test behaviour of DataStoreHttpStatusRequestRejectedHandler when it is initialised with a
+     * specific http error code.
+     */
+    @Test
+    public void handlerCreatedWithSpecificHttpError() {
+        DataStoreHttpStatusRequestRejectedHandler handler =
+            new DataStoreHttpStatusRequestRejectedHandler(appInsights, HttpServletResponse.SC_BAD_REQUEST);
+        checkDataStoreHttpStatusRequestRejectedHandler(handler, HttpServletResponse.SC_BAD_REQUEST);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/ccd/validator/CaseTypeIdValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/validator/CaseTypeIdValidatorTest.java
@@ -1,0 +1,87 @@
+package uk.gov.hmcts.ccd.validator;
+
+import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import javax.validation.ConstraintValidatorContext;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class CaseTypeIdValidatorTest {
+
+    private static final String CASE_TYPE_ID_INVALID_CHARACTER = "TEST#_CASE_TYPE_ID";
+    private static final String CASE_TYPE_ID_VALID_UPPER_CASE = "TEST_CASE_TYPE_ID";
+    private static final String CASE_TYPE_ID_VALID_LOWER_CASE = "test_case_type_id";
+    private static final String CASE_TYPE_ID_VALID_NUMBERS = "TEST_CASE_TYPE_ID_1234567890";
+    private static final String CASE_TYPE_ID_VALID_HYPHENS = "TEST-CASE-TYPE-ID";
+    private static final String CASE_TYPE_ID_VALID_ALL = "TEST_case-TYPE_1_ID";
+
+    private final CaseTypeIdValidator caseTypeIdValidator = new CaseTypeIdValidator();
+
+    @Mock
+    private ConstraintValidatorContext constraintValidatorContext;
+
+    private AutoCloseable autoCloseable;
+
+    @BeforeEach
+    public void openMocks() {
+        autoCloseable = MockitoAnnotations.openMocks(this);
+    }
+
+    @AfterEach
+    public void releaseMocks() throws Exception {
+        autoCloseable.close();
+    }
+
+    @Test
+    public void failForNullCaseTypeId() {
+        final boolean result = caseTypeIdValidator.isValid(null, constraintValidatorContext);
+        assertFalse("Null Case Type Id should not be valid", result);
+    }
+
+    @Test
+    public void failForBlankCaseTypeId() {
+        final boolean result = caseTypeIdValidator.isValid("", constraintValidatorContext);
+        assertFalse("Blank Case Type Id should not be valid", result);
+    }
+
+    @Test
+    public void failForInvalidCharacter() {
+        final boolean result = caseTypeIdValidator.isValid(CASE_TYPE_ID_INVALID_CHARACTER, constraintValidatorContext);
+        assertFalse("Case Type Id " + CASE_TYPE_ID_INVALID_CHARACTER + " should not be valid", result);
+    }
+
+    @Test
+    public void passForValidCaseTypeIdUpperCase() {
+        final boolean result = caseTypeIdValidator.isValid(CASE_TYPE_ID_VALID_UPPER_CASE, constraintValidatorContext);
+        assertTrue("Case Type Id " + CASE_TYPE_ID_VALID_UPPER_CASE + " should be valid", result);
+    }
+
+    @Test
+    public void passForValidCaseTypeIdLowerCase() {
+        final boolean result = caseTypeIdValidator.isValid(CASE_TYPE_ID_VALID_LOWER_CASE, constraintValidatorContext);
+        assertTrue("Case Type Id " + CASE_TYPE_ID_VALID_LOWER_CASE + " should be valid", result);
+    }
+
+    @Test
+    public void passForValidCaseTypeIdNumbers() {
+        final boolean result = caseTypeIdValidator.isValid(CASE_TYPE_ID_VALID_NUMBERS, constraintValidatorContext);
+        assertTrue("Case Type Id " + CASE_TYPE_ID_VALID_NUMBERS + " should be valid", result);
+    }
+
+    @Test
+    public void passForValidCaseTypeIdHyphens() {
+        final boolean result = caseTypeIdValidator.isValid(CASE_TYPE_ID_VALID_HYPHENS, constraintValidatorContext);
+        assertTrue("Case Type Id " + CASE_TYPE_ID_VALID_HYPHENS + " should be valid", result);
+    }
+
+    @Test
+    public void passForValidCaseTypeIdAll() {
+        final boolean result = caseTypeIdValidator.isValid(CASE_TYPE_ID_VALID_ALL, constraintValidatorContext);
+        assertTrue("Case Type Id " + CASE_TYPE_ID_VALID_ALL + " should be valid", result);
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-216 (https://tools.hmcts.net/jira/browse/CCD-216)


### Change description ###
Created DataStoreHttpStatusRequestRejectedHandler class.  This handles RequestRejectedExceptions raised by the Spring StrictHttpFirewall that occur when the URL contains forbidden characters.  The handler converts the status code of the response from 500 to 403.  Created FirewallConfiguration class to register a bean for the new handler and make it available to Spring.  Created a new functional test - S-1032.2 - to test this scenario.

Created CaseTypeIdValidator class.  This is used to validate the case type id in requests that are accepted by StrictHttpFirewall.  Created ValidCaseTypeId annotation for CaseTypeIdValidator and updated CaseController to use it to validate case type ids.

Updated RestExceptionHandler to add a new handler for ConstraintViolationExceptions.  These exceptions are raised when the case type id fails validation.  The handler returns a response with the status code 400.  Updated HttpError class to add a new constructor which is used by the new handler and reverted change to Exception & HttpServiceRequest constructor - new one provides the same functionality.  Changed existing handleException() method to also use this constructor.

Renamed S-1032 test to S-1032.1 and re-enabled it.  Changed expected response to match that returned by the new case type id validation.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
