### PR TITLE
CCD-3297: Changed location of smoke and functional dummy test results file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -788,10 +788,12 @@ task smoke() {
     description = 'Executes smoke tests against an the CCD Data Store API instance just deployed'
     dependsOn aatClasses
 
-    new File("$buildDir/test-results/test").mkdirs()
+    // Copy dummy test result file to location expected by pipeline.  This needs to be done because
+    // BEFTA tests are used for smoke tests which create test result files in a different location.
+    new File("$buildDir/test-results/smoke").mkdirs()
     copy {
         from "src/aat/resources/DummyTest.xml"
-        into "$buildDir/test-results/test"
+        into "$buildDir/test-results/smoke"
     }
 
     doLast {
@@ -822,10 +824,13 @@ task smoke() {
 task functional() {
     description = 'Executes functional tests against an the CCD Data Store API instance just deployed'
     dependsOn aatClasses
-    new File("$buildDir/test-results/test").mkdirs()
+
+    // Copy dummy test result file to location expected by pipeline.  This needs to be done because
+    // BEFTA tests are used for functional tests which create test result files in a different location.
+    new File("$buildDir/test-results/functional").mkdirs()
     copy {
         from "src/aat/resources/DummyTest.xml"
-        into "$buildDir/test-results/test"
+        into "$buildDir/test-results/functional"
     }
 
     doFirst {


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-3297 (https://tools.hmcts.net/jira/browse/CCD-3297)


### Change description ###
Changed location that DummyTest.xml is copied to for both the smoke and functional tests tasks.  The locations now match those expected by the stages of the pipeline that archive the smoke and functional test results.  These locations were recently corrected under DTSPO-6817.

The DummyTest.xml file is used because BEFTA tests are used for both smoke and functional tests.  These create test result files in a different location to that expected by the pipeline.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
