### PR TITLE
CCD-3297: Added junit formatter to smoke and functional test tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -799,8 +799,11 @@ task smoke() {
         javaexec {
             main = "uk.gov.hmcts.ccd.datastore.befta.DataStoreBeftaMain"
             classpath += configurations.cucumberRuntime + sourceSets.aat.runtimeClasspath
-            args = ['--plugin', "json:${rootDir}/target/cucumber.json", '--tags', '@Smoke and not @Ignore', '--glue',
-                    'uk.gov.hmcts.befta.player', '--glue', "uk.gov.hmcts.ccd.datastore.befta", 'src/aat/resources/features']
+            args = ['--plugin', "json:${rootDir}/target/cucumber.json",
+                    '--plugin', "junit:${buildDir}/test-results/smoke/cucumber.xml",
+                    '--tags', '@Smoke and not @Ignore',
+                    '--glue', 'uk.gov.hmcts.befta.player',
+                    '--glue', "uk.gov.hmcts.ccd.datastore.befta", 'src/aat/resources/features']
             jvmArgs = [ '--add-opens=java.base/java.lang.reflect=ALL-UNNAMED' ]
         }
     }
@@ -822,6 +825,7 @@ task smoke() {
 task functional() {
     description = 'Executes functional tests against an the CCD Data Store API instance just deployed'
     dependsOn aatClasses
+
     new File("$buildDir/test-results/test").mkdirs()
     copy {
         from "src/aat/resources/DummyTest.xml"
@@ -836,6 +840,7 @@ task functional() {
             args = [
                     '--threads', '1',
                     '--plugin', "json:${rootDir}/target/cucumber.json",
+                    '--plugin', "junit:${buildDir}/test-results/functional/cucumber.xml",
                     '--tags', 'not @Ignore',
                     '--glue', 'uk.gov.hmcts.befta.player',
                     '--glue', 'uk.gov.hmcts.ccd.datastore.befta', 'src/aat/resources/features'


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-3297 (https://tools.hmcts.net/jira/browse/CCD-3297)


### Change description ###
Added junit formatter plugin to doLast section of smoke and functional test tasks.  This causes test result XML files to be created in the locations expected by the smoke and functional stages of the pipeline.  These locations were recently corrected under DTSPO-6817.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
