### PR TITLE
CCD-3439: CVE-2022-33915 ccd-data-store-api

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -13,6 +13,7 @@
 			CVE-2007-1651 https://tools.hmcts.net/jira/browse/CCD-125
 			CVE-2007-1652 https://tools.hmcts.net/jira/browse/CCD-115
 			CVE-2016-1000027 https://tools.hmcts.net/jira/browse/CCD-3255
+			CVE-2022-33915 https://tools.hmcts.net/jira/browse/CCD-3439
 		</notes>
 		<cve>CVE-2020-23171</cve>
 		<cve>CVE-2018-1258</cve>
@@ -23,6 +24,7 @@
 		<cve>CVE-2007-1651</cve>
 		<cve>CVE-2007-1652</cve>
 		<cve>CVE-2016-1000027</cve>
+		<cve>CVE-2022-33915</cve>
 	</suppress>
 	<!--End of false positives section -->
 
@@ -30,11 +32,9 @@
 	  <suppress>
 	    <notes>Temporary Suppression
 	      CVE-2022-34305 refer https://tools.hmcts.net/jira/browse/CCD-3436
-	      CVE-2022-33915 refer https://tools.hmcts.net/jira/browse/CCD-3439
 	    </notes>
 	    <cve>CVE-2022-34305</cve>
-	    <cve>CVE-2022-33915</cve>
 	  </suppress>
 	<!--End of temporary suppression section -->
-	
+
 </suppressions>


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/CCD-3439

### Change description ###
False positive.   CVE-2022-33915 (cpe;2.3;a;apache;log4j) only impacts AWS Log4j hotpatch , and not general Log4j build.   See Jira ticket.

**Does this PR introduce a breaking change?**
```
[ ] Yes
[x] No
```