### PR TITLE
CCD-3425 Update validateSuspensionChange to cover `TTL.Suspended = null`

### DIFF
--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/F-1016.feature
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/F-1016.feature
@@ -11,7 +11,23 @@ Feature: F-1016: Submit Event to Update TTL
      When a request is prepared with appropriate values
       And the request [contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCaseworker]
       And the request [contains an event token for the case just created above]
-      And the request [has TTL.Suspension value changed to No from Yes]
+      And the request [has TTL.Suspended value changed to No from Yes]
+      And the request [has TTL.OverrideTTL set to less than today + TTL Guard]
+      And the request [has TTL.SystemTTL set to less than today + TTL Guard]
+      And it is submitted to call the [Submit event creation as Case worker] operation of [CCD Data Store]
+     Then a negative response is received
+      And the response has all other details as expected
+      And another call [to verify that the TTL.Suspended value has not changed in the database] will get the expected response as in [F-1016_GetCaseDetails_Caseworker]
+
+    @S-1016.1.repeat
+    Scenario: TTL.Suspended changed to null, SystemTTL and OverrideTTL less than Guard value and Submit Event is invoked on v1_external#/case-details-endpoint/createCaseEventForCaseWorkerUsingPOST
+    Given a user with [an active profile in CCD]
+      And a successful call [to create a case] as in [F-1016_CreateSuspendedCasePreRequisiteCaseworker]
+     When a request is prepared with appropriate values
+      And the request [is a repeat of S-1016.1 but with TTL.Suspended set to null]
+      And the request [contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCaseworker]
+      And the request [contains an event token for the case just created above]
+      And the request [has TTL.Suspended value changed to NULL from Yes]
       And the request [has TTL.OverrideTTL set to less than today + TTL Guard]
       And the request [has TTL.SystemTTL set to less than today + TTL Guard]
       And it is submitted to call the [Submit event creation as Case worker] operation of [CCD Data Store]
@@ -26,7 +42,22 @@ Feature: F-1016: Submit Event to Update TTL
      When a request is prepared with appropriate values
       And the request [contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCaseworker]
       And the request [contains an event token for the case just created above]
-      And the request [has TTL.Suspension value changed to No from Yes]
+      And the request [has TTL.Suspended value changed to No from Yes]
+      And the request [has TTL.OverrideTTL set to null]
+      And the request [has TTL.SystemTTL set to null]
+      And it is submitted to call the [Submit event creation as Case worker] operation of [CCD Data Store]
+     Then a positive response is received
+      And the response has all other details as expected
+
+    @S-1016.2.repeat
+    Scenario: TTL.Suspended changed to null, SystemTTL and OverrideTTL are NULL and Submit Event is invoked on v1_external#/case-details-endpoint/createCaseEventForCaseWorkerUsingPOST
+    Given a user with [an active profile in CCD]
+      And a successful call [to create a case] as in [F-1016_CreateSuspendedCasePreRequisiteCaseworker]
+     When a request is prepared with appropriate values
+      And the request [is a repeat of S-1016.2 but with TTL.Suspended set to null]
+      And the request [contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCaseworker]
+      And the request [contains an event token for the case just created above]
+      And the request [has TTL.Suspended value changed to NULL from Yes]
       And the request [has TTL.OverrideTTL set to null]
       And the request [has TTL.SystemTTL set to null]
       And it is submitted to call the [Submit event creation as Case worker] operation of [CCD Data Store]
@@ -40,7 +71,7 @@ Feature: F-1016: Submit Event to Update TTL
      When a request is prepared with appropriate values
       And the request [contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCaseworker]
       And the request [contains an event token for the case just created above]
-      And the request [has TTL.Suspension value changed to No from Yes]
+      And the request [has TTL.Suspended value changed to No from Yes]
       And the request [has TTL.OverrideTTL set to null]
       And the request [has TTL.SystemTTL set to greater than today + guard value]
       And it is submitted to call the [Submit event creation as Case worker] operation of [CCD Data Store]
@@ -54,7 +85,7 @@ Feature: F-1016: Submit Event to Update TTL
     When a request is prepared with appropriate values
     And the request [contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCaseworker]
     And the request [contains an event token for the case just created above]
-    And the request [has TTL.Suspension value changed to No from Yes]
+    And the request [has TTL.Suspended value changed to No from Yes]
     And the request [has TTL.OverrideTTL set to greater than today + guard value]
     And the request [has TTL.SystemTTL set to null]
     And it is submitted to call the [Submit event creation as Case worker] operation of [CCD Data Store]
@@ -68,7 +99,7 @@ Feature: F-1016: Submit Event to Update TTL
     When a request is prepared with appropriate values
     And the request [contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCaseworker]
     And the request [contains an event token for the case just created above]
-    And the request [has TTL.Suspension value changed to No from Yes]
+    And the request [has TTL.Suspended value changed to No from Yes]
     And the request [has TTL.SystemTTL set to less than today + TTL Guard]
     And the request [has TTL.OverrideTTL set to greater than today + guard value]
     And it is submitted to call the [Submit event creation as Case worker] operation of [CCD Data Store]
@@ -82,7 +113,7 @@ Feature: F-1016: Submit Event to Update TTL
     When a request is prepared with appropriate values
     And the request [contains a case Id that has just been created as in F-1016_CreateCasePreRequisiteCaseworker]
     And the request [contains an event token for the case just created above]
-    And the request [has TTL.Suspension value changed to Yes from No]
+    And the request [has TTL.Suspended value changed to Yes from No]
     And it is submitted to call the [Submit event creation as Case worker] operation of [CCD Data Store]
     Then a positive response is received
     And the response has all other details as expected
@@ -94,7 +125,7 @@ Feature: F-1016: Submit Event to Update TTL
      When a request is prepared with appropriate values
       And the request [contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCaseworker]
       And the request [contains an event token for the case just created above]
-      And the request [has TTL.Suspension value changed to No from Yes]
+      And the request [has TTL.Suspended value changed to No from Yes]
       And the request [has TTL.OverrideTTL set to greater than today + guard value]
       And the request [has TTL.SystemTTL set to greater than today + guard value]
       And the request [callback About to submit changes TTL.Suspended value]
@@ -109,7 +140,24 @@ Feature: F-1016: Submit Event to Update TTL
     When a request is prepared with appropriate values
     And the request [contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCaseworker]
     And the request [contains an event token for the case just created above]
-    And the request [has TTL.Suspension value changed to No from Yes]
+    And the request [has TTL.Suspended value changed to No from Yes]
+    And the request [has TTL.OverrideTTL set to less than today + TTL Guard]
+    And the request [has TTL.SystemTTL set to less than today + TTL Guard]
+    And it is submitted to call the [Submit event creation as Case worker] operation of [CCD Data Store]
+    Then a negative response is received
+    And the response has all other details as expected
+    And another call [to verify that the TTL.Suspended value has not changed in the database] will get the expected response as in [F-1016_GetCaseDetails_Caseworker]
+
+
+  @S-1016.8.repeat
+  Scenario: TTL.Suspended changed to null, SystemTTL and OverrideTTL less than Guard value and Submit Event is invoked on v2_external#/case-controller/createEventUsingPOST
+    Given a user with [an active profile in CCD]
+    And a successful call [to create a case] as in [F-1016_CreateSuspendedCasePreRequisiteCaseworker]
+    When a request is prepared with appropriate values
+    And the request [is a repeat of S-1016.8 but with TTL.Suspended set to null]
+    And the request [contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCaseworker]
+    And the request [contains an event token for the case just created above]
+    And the request [has TTL.Suspended value changed to NULL from Yes]
     And the request [has TTL.OverrideTTL set to less than today + TTL Guard]
     And the request [has TTL.SystemTTL set to less than today + TTL Guard]
     And it is submitted to call the [Submit event creation as Case worker] operation of [CCD Data Store]
@@ -124,7 +172,22 @@ Feature: F-1016: Submit Event to Update TTL
     When a request is prepared with appropriate values
     And the request [contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCaseworker]
     And the request [contains an event token for the case just created above]
-    And the request [has TTL.Suspension value changed to No from Yes]
+    And the request [has TTL.Suspended value changed to No from Yes]
+    And the request [has TTL.OverrideTTL set to null]
+    And the request [has TTL.SystemTTL set to null]
+    And it is submitted to call the [Submit event creation as Case worker] operation of [CCD Data Store]
+    Then a positive response is received
+    And the response has all other details as expected
+
+  @S-1016.9.repeat
+  Scenario: TTL.Suspended changed to null, SystemTTL and OverrideTTL are NULL and Submit Event is invoked on v2_external#/case-controller/createEventUsingPOST
+    Given a user with [an active profile in CCD]
+    And a successful call [to create a case] as in [F-1016_CreateSuspendedCasePreRequisiteCaseworker]
+    When a request is prepared with appropriate values
+    And the request [is a repeat of S-1016.9 but with TTL.Suspended set to null]
+    And the request [contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCaseworker]
+    And the request [contains an event token for the case just created above]
+    And the request [has TTL.Suspended value changed to NULL from Yes]
     And the request [has TTL.OverrideTTL set to null]
     And the request [has TTL.SystemTTL set to null]
     And it is submitted to call the [Submit event creation as Case worker] operation of [CCD Data Store]
@@ -138,7 +201,7 @@ Feature: F-1016: Submit Event to Update TTL
     When a request is prepared with appropriate values
     And the request [contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCaseworker]
     And the request [contains an event token for the case just created above]
-    And the request [has TTL.Suspension value changed to No from Yes]
+    And the request [has TTL.Suspended value changed to No from Yes]
     And the request [has TTL.OverrideTTL set to null]
     And the request [has TTL.SystemTTL set to greater than today + guard value]
     And it is submitted to call the [Submit event creation as Case worker] operation of [CCD Data Store]
@@ -152,7 +215,7 @@ Feature: F-1016: Submit Event to Update TTL
     When a request is prepared with appropriate values
     And the request [contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCaseworker]
     And the request [contains an event token for the case just created above]
-    And the request [has TTL.Suspension value changed to No from Yes]
+    And the request [has TTL.Suspended value changed to No from Yes]
     And the request [has TTL.OverrideTTL set to greater than today + guard value]
     And the request [has TTL.SystemTTL set to null]
     And it is submitted to call the [Submit event creation as Case worker] operation of [CCD Data Store]
@@ -166,7 +229,7 @@ Feature: F-1016: Submit Event to Update TTL
     When a request is prepared with appropriate values
     And the request [contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCaseworker]
     And the request [contains an event token for the case just created above]
-    And the request [has TTL.Suspension value changed to No from Yes]
+    And the request [has TTL.Suspended value changed to No from Yes]
     And the request [has TTL.SystemTTL set to less than today + TTL Guard]
     And the request [has TTL.OverrideTTL set to greater than today + guard value]
     And it is submitted to call the [Submit event creation as Case worker] operation of [CCD Data Store]
@@ -180,7 +243,7 @@ Feature: F-1016: Submit Event to Update TTL
     When a request is prepared with appropriate values
     And the request [contains a case Id that has just been created as in F-1016_CreateCasePreRequisiteCaseworker]
     And the request [contains an event token for the case just created above]
-    And the request [has TTL.Suspension value changed to Yes from No]
+    And the request [has TTL.Suspended value changed to Yes from No]
     And it is submitted to call the [Submit event creation as Case worker] operation of [CCD Data Store]
     Then a positive response is received
     And the response has all other details as expected
@@ -192,7 +255,7 @@ Feature: F-1016: Submit Event to Update TTL
     When a request is prepared with appropriate values
     And the request [contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCaseworker]
     And the request [contains an event token for the case just created above]
-    And the request [has TTL.Suspension value changed to No from Yes]
+    And the request [has TTL.Suspended value changed to No from Yes]
     And the request [has TTL.OverrideTTL set to greater than today + guard value]
     And the request [has TTL.SystemTTL set to greater than today + guard value]
     And the request [callback About to submit changes TTL.Suspended value]
@@ -207,7 +270,23 @@ Feature: F-1016: Submit Event to Update TTL
     When a request is prepared with appropriate values
     And the request [contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCitizen]
     And the request [contains an event token for the case just created above]
-    And the request [has TTL.Suspension value changed to No from Yes]
+    And the request [has TTL.Suspended value changed to No from Yes]
+    And the request [has TTL.OverrideTTL set to less than today + TTL Guard]
+    And the request [has TTL.SystemTTL set to less than today + TTL Guard]
+    And it is submitted to call the [submit event creation as citizen] operation of [CCD Data Store]
+    Then a negative response is received
+    And the response has all other details as expected
+    And a successful call [to verify that the TTL.Suspended value has not changed in the database] as in [F-1016_GetCaseDetails_Citizen]
+
+  @S-1016.15.repeat
+  Scenario: TTL.Suspended changed to null, SystemTTL and OverrideTTL less than Guard value and Submit Event is invoked on v1_external#/case-details-endpoint/createCaseEventForCitizenUsingPOST
+    Given a user with [an active profile in CCD]
+    And a successful call [to create a case] as in [F-1016_CreateSuspendedCasePreRequisiteCitizen]
+    When a request is prepared with appropriate values
+    And the request [is a repeat of S-1016.15 but with TTL.Suspended set to null]
+    And the request [contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCitizen]
+    And the request [contains an event token for the case just created above]
+    And the request [has TTL.Suspended value changed to NULL from Yes]
     And the request [has TTL.OverrideTTL set to less than today + TTL Guard]
     And the request [has TTL.SystemTTL set to less than today + TTL Guard]
     And it is submitted to call the [submit event creation as citizen] operation of [CCD Data Store]
@@ -222,7 +301,22 @@ Feature: F-1016: Submit Event to Update TTL
     When a request is prepared with appropriate values
     And the request [contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCitizen]
     And the request [contains an event token for the case just created above]
-    And the request [has TTL.Suspension value changed to No from Yes]
+    And the request [has TTL.Suspended value changed to No from Yes]
+    And the request [has TTL.OverrideTTL set to null]
+    And the request [has TTL.SystemTTL set to null]
+    And it is submitted to call the [submit event creation as citizen] operation of [CCD Data Store]
+    Then a positive response is received
+    And the response has all other details as expected
+
+  @S-1016.16.repeat
+  Scenario: TTL.Suspended changed to null, SystemTTL and OverrideTTL are NULL and Submit Event is invoked on v1_external#/case-details-endpoint/createCaseEventForCitizenUsingPOST
+    Given a user with [an active profile in CCD]
+    And a successful call [to create a case] as in [F-1016_CreateSuspendedCasePreRequisiteCitizen]
+    When a request is prepared with appropriate values
+    And the request [is a repeat of S-1016.16 but with TTL.Suspended set to null]
+    And the request [contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCitizen]
+    And the request [contains an event token for the case just created above]
+    And the request [has TTL.Suspended value changed to NULL from Yes]
     And the request [has TTL.OverrideTTL set to null]
     And the request [has TTL.SystemTTL set to null]
     And it is submitted to call the [submit event creation as citizen] operation of [CCD Data Store]
@@ -236,7 +330,7 @@ Feature: F-1016: Submit Event to Update TTL
     When a request is prepared with appropriate values
     And the request [contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCitizen]
     And the request [contains an event token for the case just created above]
-    And the request [has TTL.Suspension value changed to No from Yes]
+    And the request [has TTL.Suspended value changed to No from Yes]
     And the request [has TTL.OverrideTTL set to null]
     And the request [has TTL.SystemTTL set to greater than today + guard value]
     And it is submitted to call the [submit event creation as citizen] operation of [CCD Data Store]
@@ -250,7 +344,7 @@ Feature: F-1016: Submit Event to Update TTL
     When a request is prepared with appropriate values
     And the request [contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCitizen]
     And the request [contains an event token for the case just created above]
-    And the request [has TTL.Suspension value changed to No from Yes]
+    And the request [has TTL.Suspended value changed to No from Yes]
     And the request [has TTL.OverrideTTL set to greater than today + guard value]
     And the request [has TTL.SystemTTL set to null]
     And it is submitted to call the [submit event creation as citizen] operation of [CCD Data Store]
@@ -264,7 +358,7 @@ Feature: F-1016: Submit Event to Update TTL
     When a request is prepared with appropriate values
     And the request [contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCitizen]
     And the request [contains an event token for the case just created above]
-    And the request [has TTL.Suspension value changed to No from Yes]
+    And the request [has TTL.Suspended value changed to No from Yes]
     And the request [has TTL.SystemTTL set to less than today + TTL Guard]
     And the request [has TTL.OverrideTTL set to greater than today + guard value]
     And it is submitted to call the [submit event creation as citizen] operation of [CCD Data Store]
@@ -278,7 +372,7 @@ Feature: F-1016: Submit Event to Update TTL
     When a request is prepared with appropriate values
     And the request [contains a case Id that has just been created as in F-1016_CreateCasePreRequisiteCitizen]
     And the request [contains an event token for the case just created above]
-    And the request [has TTL.Suspension value changed to Yes from No]
+    And the request [has TTL.Suspended value changed to Yes from No]
     And it is submitted to call the [submit event creation as citizen] operation of [CCD Data Store]
     Then a positive response is received
     And the response has all other details as expected
@@ -290,7 +384,7 @@ Feature: F-1016: Submit Event to Update TTL
     When a request is prepared with appropriate values
     And the request [contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCitizen]
     And the request [contains an event token for the case just created above]
-    And the request [has TTL.Suspension value changed to No from Yes]
+    And the request [has TTL.Suspended value changed to No from Yes]
     And the request [has TTL.OverrideTTL set to greater than today + guard value]
     And the request [has TTL.SystemTTL set to greater than today + guard value]
     And the request [callback About to submit changes TTL.Suspended value]

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.1.repeat.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.1.repeat.td.json
@@ -1,0 +1,22 @@
+{
+  "_guid_": "S-1016.1.repeat",
+  "_extends_": "S-1016.1",
+
+  "title": "TTL.Suspended changed to null, SystemTTL and OverrideTTL less than Guard value using '/caseworkers/{uid}/jurisdictions/{jid}/case-types/{ctid}/cases/{cid}/events'",
+
+  "specs": [
+    "has TTL.Suspended value changed to NULL from Yes",
+    "is a repeat of S-1016.1 but with TTL.Suspended set to null"
+  ],
+
+  "request": {
+    "body": {
+      "data": {
+        "TTL": {
+          "Suspended": null
+        }
+      }
+    }
+  }
+
+}

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.1.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.1.td.json
@@ -13,7 +13,7 @@
     "an active profile in CCD",
     "contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCaseworker",
     "contains an event token for the case just created above",
-    "has TTL.Suspension value changed to No from Yes",
+    "has TTL.Suspended value changed to No from Yes",
     "has TTL.SystemTTL set to less than today + TTL Guard",
     "has TTL.OverrideTTL set to less than today + TTL Guard"
   ],

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.10.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.10.td.json
@@ -13,7 +13,7 @@
     "an active profile in CCD",
     "contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCaseworker",
     "contains an event token for the case just created above",
-    "has TTL.Suspension value changed to No from Yes",
+    "has TTL.Suspended value changed to No from Yes",
     "has TTL.SystemTTL set to greater than today + guard value",
     "has TTL.OverrideTTL set to null"
   ],

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.11.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.11.td.json
@@ -13,7 +13,7 @@
     "an active profile in CCD",
     "contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCaseworker",
     "contains an event token for the case just created above",
-    "has TTL.Suspension value changed to No from Yes",
+    "has TTL.Suspended value changed to No from Yes",
     "has TTL.OverrideTTL set to greater than today + guard value",
     "has TTL.SystemTTL set to null"
   ],

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.12.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.12.td.json
@@ -12,7 +12,7 @@
     "an active profile in CCD",
     "contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCaseworker",
     "contains an event token for the case just created above",
-    "has TTL.Suspension value changed to No from Yes",
+    "has TTL.Suspended value changed to No from Yes",
     "has TTL.SystemTTL set to less than today + TTL Guard",
     "has TTL.OverrideTTL set to greater than today + guard value"
   ],

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.13.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.13.td.json
@@ -13,7 +13,7 @@
     "an active profile in CCD",
     "contains a case Id that has just been created as in F-1016_CreateCasePreRequisiteCaseworker",
     "contains an event token for the case just created above",
-    "has TTL.Suspension value changed to Yes from No"
+    "has TTL.Suspended value changed to Yes from No"
   ],
 
   "request": {

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.14.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.14.td.json
@@ -13,7 +13,7 @@
     "an active profile in CCD",
     "contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCaseworker",
     "contains an event token for the case just created above",
-    "has TTL.Suspension value changed to No from Yes",
+    "has TTL.Suspended value changed to No from Yes",
     "has TTL.SystemTTL set to greater than today + guard value",
     "has TTL.OverrideTTL set to greater than today + guard value",
     "callback About to submit changes TTL.Suspended value"

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.15.repeat.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.15.repeat.td.json
@@ -1,0 +1,22 @@
+{
+  "_guid_": "S-1016.15.repeat",
+  "_extends_": "S-1016.15",
+
+  "title": "TTL.Suspended changed to null, SystemTTL and OverrideTTL less than Guard value using '/caseworkers/{uid}/jurisdictions/{jid}/case-types/{ctid}/cases/{cid}/events'",
+
+  "specs": [
+    "has TTL.Suspended value changed to NULL from Yes",
+    "is a repeat of S-1016.15 but with TTL.Suspended set to null"
+  ],
+
+  "request": {
+    "body": {
+      "data": {
+        "TTL": {
+          "Suspended": null
+        }
+      }
+    }
+  }
+
+}

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.15.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.15.td.json
@@ -12,7 +12,7 @@
     "an active profile in CCD",
     "contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCitizen",
     "contains an event token for the case just created above",
-    "has TTL.Suspension value changed to No from Yes",
+    "has TTL.Suspended value changed to No from Yes",
     "has TTL.SystemTTL set to less than today + TTL Guard",
     "has TTL.OverrideTTL set to less than today + TTL Guard"
   ],

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.16.repeat.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.16.repeat.td.json
@@ -1,0 +1,32 @@
+{
+  "_guid_": "S-1016.16.repeat",
+  "_extends_": "S-1016.16",
+
+  "title": "TTL.Suspended changed to null, SystemTTL and OverrideTTL set to NULL using '/caseworkers/{uid}/jurisdictions/{jid}/case-types/{ctid}/cases/{cid}/events'",
+
+  "specs": [
+    "has TTL.Suspended value changed to NULL from Yes",
+    "is a repeat of S-1016.16 but with TTL.Suspended set to null"
+  ],
+
+  "request": {
+    "body": {
+      "data": {
+        "TTL": {
+          "Suspended": null
+        }
+      }
+    }
+  },
+
+  "expectedResponse": {
+    "body" : {
+      "case_data" : {
+        "TTL" : {
+          "Suspended" : null
+        }
+      }
+    }
+  }
+
+}

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.16.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.16.td.json
@@ -12,7 +12,7 @@
     "an active profile in CCD",
     "contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCitizen",
     "contains an event token for the case just created above",
-    "has TTL.Suspension value changed to No from Yes",
+    "has TTL.Suspended value changed to No from Yes",
     "has TTL.OverrideTTL set to null",
     "has TTL.SystemTTL set to null"
   ],

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.17.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.17.td.json
@@ -12,7 +12,7 @@
     "an active profile in CCD",
     "contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCitizen",
     "contains an event token for the case just created above",
-    "has TTL.Suspension value changed to No from Yes",
+    "has TTL.Suspended value changed to No from Yes",
     "has TTL.SystemTTL set to greater than today + guard value",
     "has TTL.OverrideTTL set to null"
   ],

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.18.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.18.td.json
@@ -12,7 +12,7 @@
     "an active profile in CCD",
     "contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCitizen",
     "contains an event token for the case just created above",
-    "has TTL.Suspension value changed to No from Yes",
+    "has TTL.Suspended value changed to No from Yes",
     "has TTL.OverrideTTL set to greater than today + guard value",
     "has TTL.SystemTTL set to null"
   ],

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.19.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.19.td.json
@@ -12,7 +12,7 @@
     "an active profile in CCD",
     "contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCitizen",
     "contains an event token for the case just created above",
-    "has TTL.Suspension value changed to No from Yes",
+    "has TTL.Suspended value changed to No from Yes",
     "has TTL.SystemTTL set to less than today + TTL Guard",
     "has TTL.OverrideTTL set to greater than today + guard value"
   ],

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.2.repeat.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.2.repeat.td.json
@@ -1,0 +1,31 @@
+{
+  "_guid_": "S-1016.2.repeat",
+  "_extends_": "S-1016.2",
+
+  "title": "TTL.Suspended changed to null, SystemTTL and OverrideTTL set to NULL using '/caseworkers/{uid}/jurisdictions/{jid}/case-types/{ctid}/cases/{cid}/events'",
+
+  "specs": [
+    "has TTL.Suspended value changed to NULL from Yes",
+    "is a repeat of S-1016.2 but with TTL.Suspended set to null"
+  ],
+
+  "request": {
+    "body": {
+      "data": {
+        "TTL": {
+          "Suspended": null
+        }
+      }
+    }
+  },
+
+  "expectedResponse": {
+    "body" : {
+      "case_data" : {
+        "TTL" : {
+          "Suspended" : null
+        }
+      }
+    }
+  }
+}

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.2.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.2.td.json
@@ -13,7 +13,7 @@
     "an active profile in CCD",
     "contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCaseworker",
     "contains an event token for the case just created above",
-    "has TTL.Suspension value changed to No from Yes",
+    "has TTL.Suspended value changed to No from Yes",
     "has TTL.SystemTTL set to null",
     "has TTL.OverrideTTL set to null"
   ],

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.20.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.20.td.json
@@ -12,7 +12,7 @@
     "an active profile in CCD",
     "contains a case Id that has just been created as in F-1016_CreateCasePreRequisiteCitizen",
     "contains an event token for the case just created above",
-    "has TTL.Suspension value changed to Yes from No"
+    "has TTL.Suspended value changed to Yes from No"
   ],
 
   "request": {

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.21.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.21.td.json
@@ -12,7 +12,7 @@
     "an active profile in CCD",
     "contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCitizen",
     "contains an event token for the case just created above",
-    "has TTL.Suspension value changed to No from Yes",
+    "has TTL.Suspended value changed to No from Yes",
     "has TTL.SystemTTL set to greater than today + guard value",
     "has TTL.OverrideTTL set to greater than today + guard value",
     "callback About to submit changes TTL.Suspended value"

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.3.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.3.td.json
@@ -13,7 +13,7 @@
     "an active profile in CCD",
     "contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCaseworker",
     "contains an event token for the case just created above",
-    "has TTL.Suspension value changed to No from Yes",
+    "has TTL.Suspended value changed to No from Yes",
     "has TTL.SystemTTL set to greater than today + guard value",
     "has TTL.OverrideTTL set to null"
   ],

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.4.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.4.td.json
@@ -13,7 +13,7 @@
     "an active profile in CCD",
     "contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCaseworker",
     "contains an event token for the case just created above",
-    "has TTL.Suspension value changed to No from Yes",
+    "has TTL.Suspended value changed to No from Yes",
     "has TTL.OverrideTTL set to greater than today + guard value",
     "has TTL.SystemTTL set to null"
   ],

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.5.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.5.td.json
@@ -12,7 +12,7 @@
     "an active profile in CCD",
     "contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCaseworker",
     "contains an event token for the case just created above",
-    "has TTL.Suspension value changed to No from Yes",
+    "has TTL.Suspended value changed to No from Yes",
     "has TTL.SystemTTL set to less than today + TTL Guard",
     "has TTL.OverrideTTL set to greater than today + guard value"
   ],

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.6.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.6.td.json
@@ -13,7 +13,7 @@
     "an active profile in CCD",
     "contains a case Id that has just been created as in F-1016_CreateCasePreRequisiteCaseworker",
     "contains an event token for the case just created above",
-    "has TTL.Suspension value changed to Yes from No"
+    "has TTL.Suspended value changed to Yes from No"
   ],
 
   "request": {

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.7.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.7.td.json
@@ -13,7 +13,7 @@
     "an active profile in CCD",
     "contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCaseworker",
     "contains an event token for the case just created above",
-    "has TTL.Suspension value changed to No from Yes",
+    "has TTL.Suspended value changed to No from Yes",
     "has TTL.SystemTTL set to greater than today + guard value",
     "has TTL.OverrideTTL set to greater than today + guard value",
     "callback About to submit changes TTL.Suspended value"

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.8.repeat.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.8.repeat.td.json
@@ -1,0 +1,22 @@
+{
+  "_guid_": "S-1016.8.repeat",
+  "_extends_": "S-1016.8",
+
+  "title": "TTL.Suspended changed to null, SystemTTL and OverrideTTL less than Guard value using v2 '/cases/{cid}/events'",
+
+  "specs": [
+    "has TTL.Suspended value changed to NULL from Yes",
+    "is a repeat of S-1016.8 but with TTL.Suspended set to null"
+  ],
+
+  "request": {
+    "body": {
+      "data": {
+        "TTL": {
+          "Suspended": null
+        }
+      }
+    }
+  }
+
+}

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.8.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.8.td.json
@@ -13,7 +13,7 @@
     "an active profile in CCD",
     "contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCaseworker",
     "contains an event token for the case just created above",
-    "has TTL.Suspension value changed to No from Yes",
+    "has TTL.Suspended value changed to No from Yes",
     "has TTL.SystemTTL set to less than today + TTL Guard",
     "has TTL.OverrideTTL set to less than today + TTL Guard"
   ],

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.9.repeat.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.9.repeat.td.json
@@ -1,0 +1,31 @@
+{
+  "_guid_": "S-1016.9.repeat",
+  "_extends_": "S-1016.9",
+
+  "title": "TTL.Suspended changed to null, SystemTTL and OverrideTTL set to NULL using v2 '/cases/{cid}/events'",
+
+  "specs": [
+    "has TTL.Suspended value changed to NULL from Yes",
+    "is a repeat of S-1016.9 but with TTL.Suspended set to null"
+  ],
+
+  "request": {
+    "body": {
+      "data": {
+        "TTL": {
+          "Suspended": null
+        }
+      }
+    }
+  },
+
+  "expectedResponse": {
+    "body" : {
+      "data" : {
+        "TTL" : {
+          "Suspended" : null
+        }
+      }
+    }
+  }
+}

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.9.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.9.td.json
@@ -13,7 +13,7 @@
     "an active profile in CCD",
     "contains a case Id that has just been created as in F-1016_CreateSuspendedCasePreRequisiteCaseworker",
     "contains an event token for the case just created above",
-    "has TTL.Suspension value changed to No from Yes",
+    "has TTL.Suspended value changed to No from Yes",
     "has TTL.SystemTTL set to null",
     "has TTL.OverrideTTL set to null"
   ],

--- a/src/test/java/uk/gov/hmcts/ccd/domain/model/casedeletion/TTLTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/model/casedeletion/TTLTest.java
@@ -1,0 +1,54 @@
+package uk.gov.hmcts.ccd.domain.model.casedeletion;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TTLTest {
+
+    public static final String TTL_SUSPENSION_NO_PARAMETERS
+        = "uk.gov.hmcts.ccd.domain.model.casedeletion.TTLTest#ttlSuspensionNoParameters";
+    public static final String TTL_SUSPENSION_YES_PARAMETERS
+        = "uk.gov.hmcts.ccd.domain.model.casedeletion.TTLTest#ttlSuspensionYesParameters";
+
+    @SuppressWarnings("unused")
+    public static Stream<Arguments> ttlSuspensionNoParameters() {
+        // NB: scope document says: 'N' (or 'No' or 'F' or 'False' or NULL)
+        //     however YesNo fields permit only 'Yes', 'No' and null
+        return Stream.of(
+            Arguments.of(TTL.NO),
+            Arguments.of((String)null)
+        );
+    }
+
+    @SuppressWarnings("unused")
+    public static Stream<Arguments> ttlSuspensionYesParameters() {
+        // NB: scope document says: 'Y' (or 'Yes' or 'T' or 'True')
+        //     however YesNo fields permit only 'Yes', 'No' and null
+        return Stream.of(
+            Arguments.of(TTL.YES)
+        );
+    }
+
+    @ParameterizedTest(
+        name = "isSuspended No: {0}"
+    )
+    @MethodSource(TTL_SUSPENSION_NO_PARAMETERS)
+    void isSuspended_No(String ttlSuspended) {
+        assertFalse(TTL.builder().suspended(ttlSuspended).build().isSuspended());
+    }
+
+    @ParameterizedTest(
+        name = "isSuspended Yes: {0}"
+    )
+    @MethodSource(TTL_SUSPENSION_YES_PARAMETERS)
+    void isSuspended_Yes(String ttlSuspended) {
+        assertTrue(TTL.builder().suspended(ttlSuspended).build().isSuspended());
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/casedeletion/TimeToLiveServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/casedeletion/TimeToLiveServiceTest.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.ccd.domain.model.casedeletion.TTLTest.TTL_SUSPENSION_NO_PARAMETERS;
 import static uk.gov.hmcts.ccd.domain.model.casedeletion.TTLTest.TTL_SUSPENSION_YES_PARAMETERS;
+import static uk.gov.hmcts.ccd.domain.service.casedeletion.TimeToLiveService.TIME_TO_LIVE_SUSPENSION_ERROR_MESSAGE;
 
 @ExtendWith(MockitoExtension.class)
 class TimeToLiveServiceTest {
@@ -296,8 +297,7 @@ class TimeToLiveServiceTest {
             final ValidationException exception = assertThrows(ValidationException.class,
                 () -> timeToLiveService.validateSuspensionChange(updatedCaseData, caseData));
             assertThat(exception.getMessage(),
-                startsWith("Unsetting a suspension can only be allowed "
-                    + "if the deletion will occur beyond the guard period."));
+                startsWith(TIME_TO_LIVE_SUSPENSION_ERROR_MESSAGE));
         }
 
         @ParameterizedTest(
@@ -327,8 +327,7 @@ class TimeToLiveServiceTest {
             final ValidationException exception = assertThrows(ValidationException.class,
                 () -> timeToLiveService.validateSuspensionChange(updatedCaseData, caseData));
             assertThat(exception.getMessage(),
-                startsWith("Unsetting a suspension can only be allowed "
-                    + "if the deletion will occur beyond the guard period."));
+                startsWith(TIME_TO_LIVE_SUSPENSION_ERROR_MESSAGE));
         }
 
         @Test
@@ -380,8 +379,7 @@ class TimeToLiveServiceTest {
             final ValidationException exception = assertThrows(ValidationException.class,
                 () -> timeToLiveService.validateSuspensionChange(updatedCaseData, caseData));
             assertThat(exception.getMessage(),
-                startsWith("Unsetting a suspension can only be allowed "
-                    + "if the deletion will occur beyond the guard period."));
+                startsWith(TIME_TO_LIVE_SUSPENSION_ERROR_MESSAGE));
         }
 
         @Test
@@ -433,8 +431,7 @@ class TimeToLiveServiceTest {
             final ValidationException exception = assertThrows(ValidationException.class,
                 () -> timeToLiveService.validateSuspensionChange(updatedCaseData, caseData));
             assertThat(exception.getMessage(),
-                startsWith("Unsetting a suspension can only be allowed "
-                    + "if the deletion will occur beyond the guard period."));
+                startsWith(TIME_TO_LIVE_SUSPENSION_ERROR_MESSAGE));
         }
 
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###

   [CCD-3425](https://tools.hmcts.net/jira/browse/CCD-3425) _"NullPointerException occurs if TTL suspension field is null"_

### Change description ###

Update validateSuspensionChange to cover `TTL.Suspended = null`.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
