### PR TITLE
CCD-3510 TTLGuard checks when no previous TTL

### DIFF
--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/CreateCases/F-1016_CreateCasePreRequisiteCaseworkerBase.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/CreateCases/F-1016_CreateCasePreRequisiteCaseworkerBase.td.json
@@ -1,27 +1,8 @@
 {
   "_guid_": "F-1016_CreateCasePreRequisiteCaseworkerBase",
-  "_extends_": "Case_Creation_Data_Base",
-
-  "specs": [
-    "to create a case"
-  ],
-
-  "prerequisites" : [ {
-    "Token_Creation": "S-1016_GetCreateToken"
-  }
-  ],
-
-  "users": {
-    "invokingUser": {
-      "_extends_": "BeftaMasterCaseworker"
-    }
-  },
+  "_extends_": "F-1016_CreateCasePreRequisiteCaseworker_noTTL",
 
   "request": {
-    "pathVariables": {
-      "jid": "BEFTA_MASTER",
-      "ctid": "FT_MasterCaseType"
-    },
     "body": {
       "data": {
         "TTL": {
@@ -29,37 +10,25 @@
           "OverrideTTL": null,
           "SystemTTL": null
         }
-      },
-      "event": {
-        "id": "createCaseTTL",
-        "summary": "",
-        "description": ""
-      },
-      "event_token": "${[scenarioContext][childContexts][Token_Creation][testData][actualResponse][body][token]}"
+      }
     }
   },
 
   "expectedResponse": {
     "body": {
-      "jurisdiction": "BEFTA_MASTER",
-      "state": "CaseCreated",
-      "case_type_id": "FT_MasterCaseType",
       "case_data": {
         "TTL": {
           "SystemTTL": null,
           "OverrideTTL": null,
           "Suspended": "No"
-        },
-        "SearchCriteria" : { }
+        }
       },
       "data_classification": {
-        "_extends_" : "TTL_Classifications",
-        "SearchCriteria" : "[[ANYTHING_PRESENT]]"
+        "_extends_" : "TTL_Classifications"
       },
       "supplementary_data": null,
       "security_classifications": {
-        "_extends_" : "TTL_Classifications",
-        "SearchCriteria" : "[[ANYTHING_PRESENT]]"
+        "_extends_" : "TTL_Classifications"
       }
     }
   }

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/CreateCases/F-1016_CreateCasePreRequisiteCaseworker_noTTL.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/CreateCases/F-1016_CreateCasePreRequisiteCaseworker_noTTL.td.json
@@ -1,0 +1,54 @@
+{
+  "_guid_": "F-1016_CreateCasePreRequisiteCaseworker_noTTL",
+  "_extends_": "Case_Creation_Data_Base",
+
+  "specs": [
+    "to create a case"
+  ],
+
+  "prerequisites" : [ {
+    "Token_Creation": "S-1016_GetCreateToken"
+  }
+  ],
+
+  "users": {
+    "invokingUser": {
+      "_extends_": "BeftaMasterCaseworker"
+    }
+  },
+
+  "request": {
+    "pathVariables": {
+      "jid": "BEFTA_MASTER",
+      "ctid": "FT_MasterCaseType"
+    },
+    "body": {
+      "data": {
+      },
+      "event": {
+        "id": "createCaseTTL",
+        "summary": "",
+        "description": ""
+      },
+      "event_token": "${[scenarioContext][childContexts][Token_Creation][testData][actualResponse][body][token]}"
+    }
+  },
+
+  "expectedResponse": {
+    "body": {
+      "jurisdiction": "BEFTA_MASTER",
+      "state": "CaseCreated",
+      "case_type_id": "FT_MasterCaseType",
+      "case_data": {
+        "SearchCriteria" : { }
+      },
+      "data_classification": {
+        "SearchCriteria" : "[[ANYTHING_PRESENT]]"
+      },
+      "supplementary_data": null,
+      "security_classifications": {
+        "SearchCriteria" : "[[ANYTHING_PRESENT]]"
+      }
+    }
+  }
+}

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/CreateCases/F-1016_CreateCasePreRequisiteCitizen.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/CreateCases/F-1016_CreateCasePreRequisiteCitizen.td.json
@@ -1,6 +1,6 @@
 {
   "_guid_": "F-1016_CreateCasePreRequisiteCitizen",
-  "_extends_": "F-1015_CreateCasePreRequisiteCitizen",
+  "_extends_": "F-1016_CreateCasePreRequisiteCitizen_noTTL",
 
   "request": {
     "body": {
@@ -22,6 +22,13 @@
           "OverrideTTL" : null,
           "SystemTTL" : null
         }
+      },
+      "data_classification": {
+        "_extends_" : "TTL_Classifications"
+      },
+      "supplementary_data": null,
+      "security_classifications": {
+        "_extends_" : "TTL_Classifications"
       }
     }
   }

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/CreateCases/F-1016_CreateCasePreRequisiteCitizen_noTTL.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/CreateCases/F-1016_CreateCasePreRequisiteCitizen_noTTL.td.json
@@ -1,0 +1,4 @@
+{
+  "_guid_": "F-1016_CreateCasePreRequisiteCitizen_noTTL",
+  "_extends_": "F-1015_CreateCasePreRequisiteCitizen_noTTL"
+}

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/CreateCases/S-1016_GetUpdateTokenCaseworker_noTTL.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/CreateCases/S-1016_GetUpdateTokenCaseworker_noTTL.td.json
@@ -1,0 +1,10 @@
+{
+  "_guid_": "S-1016_GetUpdateTokenCaseworker_noTTL",
+  "_extends_": "S-1016_GetUpdateTokenCaseworker",
+
+  "request": {
+    "pathVariables": {
+      "cid": "${[scenarioContext][parentContext][childContexts][F-1016_CreateCasePreRequisiteCaseworker_noTTL][testData][actualResponse][body][id]}"
+    }
+  }
+}

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/CreateCases/S-1016_GetUpdateTokenCitizen_noTTL.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/CreateCases/S-1016_GetUpdateTokenCitizen_noTTL.td.json
@@ -1,0 +1,10 @@
+{
+  "_guid_": "S-1016_GetUpdateTokenCitizen_noTTL",
+  "_extends_": "S-1016_GetUpdateTokenCitizen",
+
+  "request": {
+    "pathVariables": {
+      "cid": "${[scenarioContext][parentContext][childContexts][F-1016_CreateCasePreRequisiteCitizen_noTTL][testData][actualResponse][body][id]}"
+    }
+  }
+}

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/F-1016.feature
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/F-1016.feature
@@ -907,3 +907,147 @@ Feature: F-1016: Submit Event to Update TTL
      Then a negative response is received
       And the response has all other details as expected
       And another call [to verify that the TTL data is unchanged] will get the expected response as in [S-1016.73.VerifyTtlUnchanged]
+
+
+#-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+# CCD-3510: TTL Guard checks against OverrrideTTL when no previous TTL: v1_external#/case-details-endpoint/createCaseEventForCaseWorkerUsingPOST
+#-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+  @S-1016.81 #CCD-3510
+  Scenario: Set TTL Override (TTL Guard fail) for first time when TTL data not present in case data and Submit Event is invoked on v1_external#/case-details-endpoint/createCaseEventForCaseWorkerUsingPOST
+    Given a user with [an active profile in CCD]
+    And a successful call [to create a case] as in [F-1016_CreateCasePreRequisiteCaseworker_noTTL]
+
+    When a request is prepared with appropriate values
+    And the request [contains a case Id that has just been created as in F-1016_CreateCasePreRequisiteCaseworker_noTTL]
+    And the request [contains an event token for the case just created above]
+    And the request [has TTL.OverrideTTL set to less than today + guard value]
+    And it is submitted to call the [Submit event creation as Case worker] operation of [CCD Data Store]
+
+    Then a negative response is received
+    And the response has all other details as expected
+
+  @S-1016.82 #CCD-3510
+  Scenario: Set TTL Override (TTL Guard pass) for first time when TTL data not present in case data and Submit Event is invoked on v1_external#/case-details-endpoint/createCaseEventForCaseWorkerUsingPOST
+    Given a user with [an active profile in CCD]
+    And a successful call [to create a case] as in [F-1016_CreateCasePreRequisiteCaseworker_noTTL]
+
+    When a request is prepared with appropriate values
+    And the request [contains a case Id that has just been created as in F-1016_CreateCasePreRequisiteCaseworker_noTTL]
+    And the request [contains an event token for the case just created above]
+    And the request [has TTL.OverrideTTL set to greater than today + guard value]
+    And it is submitted to call the [Submit event creation as Case worker] operation of [CCD Data Store]
+
+    Then a positive response is received
+    And the response has all other details as expected
+
+  @S-1016.83 #CCD-3510
+  Scenario: Set TTL Override and Suspend=Yes (TTL Guard pass) for first time when TTL data not present in case data and Submit Event is invoked on v1_external#/case-details-endpoint/createCaseEventForCaseWorkerUsingPOST
+    Given a user with [an active profile in CCD]
+    And a successful call [to create a case] as in [F-1016_CreateCasePreRequisiteCaseworker_noTTL]
+
+    When a request is prepared with appropriate values
+    And the request [contains a case Id that has just been created as in F-1016_CreateCasePreRequisiteCaseworker_noTTL]
+    And the request [contains an event token for the case just created above]
+    And the request [has TTL.OverrideTTL set to less than today + guard value]
+    And the request [has TTL.Suspended set to Yes]
+    And it is submitted to call the [Submit event creation as Case worker] operation of [CCD Data Store]
+
+    Then a positive response is received
+    And the response has all other details as expected
+
+
+#-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+# CCD-3510: TTL Guard checks against OverrrideTTL when no previous TTL: v2_external#/case-controller/createEventUsingPOST
+#-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+  @S-1016.86 #CCD-3510
+  Scenario: Set TTL Override (TTL Guard fail) for first time when TTL data not present in case data and Submit Event is invoked on v2_external#/case-controller/createEventUsingPOST
+    Given a user with [an active profile in CCD]
+    And a successful call [to create a case] as in [F-1016_CreateCasePreRequisiteCaseworker_noTTL]
+
+    When a request is prepared with appropriate values
+    And the request [contains a case Id that has just been created as in F-1016_CreateCasePreRequisiteCaseworker_noTTL]
+    And the request [contains an event token for the case just created above]
+    And the request [has TTL.OverrideTTL set to less than today + guard value]
+    And it is submitted to call the [Submit event creation as Case worker] operation of [CCD Data Store]
+
+    Then a negative response is received
+    And the response has all other details as expected
+
+  @S-1016.87 #CCD-3510
+  Scenario: Set TTL Override (TTL Guard pass) for first time when TTL data not present in case data and Submit Event is invoked on v2_external#/case-controller/createEventUsingPOST
+    Given a user with [an active profile in CCD]
+    And a successful call [to create a case] as in [F-1016_CreateCasePreRequisiteCaseworker_noTTL]
+
+    When a request is prepared with appropriate values
+    And the request [contains a case Id that has just been created as in F-1016_CreateCasePreRequisiteCaseworker_noTTL]
+    And the request [contains an event token for the case just created above]
+    And the request [has TTL.OverrideTTL set to greater than today + guard value]
+    And it is submitted to call the [Submit event creation as Case worker] operation of [CCD Data Store]
+
+    Then a positive response is received
+    And the response has all other details as expected
+
+  @S-1016.88 #CCD-3510
+  Scenario: Set TTL Override and Suspend=Yes (TTL Guard pass) for first time when TTL data not present in case data and Submit Event is invoked on v2_external#/case-controller/createEventUsingPOST
+    Given a user with [an active profile in CCD]
+    And a successful call [to create a case] as in [F-1016_CreateCasePreRequisiteCaseworker_noTTL]
+
+    When a request is prepared with appropriate values
+    And the request [contains a case Id that has just been created as in F-1016_CreateCasePreRequisiteCaseworker_noTTL]
+    And the request [contains an event token for the case just created above]
+    And the request [has TTL.OverrideTTL set to less than today + guard value]
+    And the request [has TTL.Suspended set to Yes]
+    And it is submitted to call the [Submit event creation as Case worker] operation of [CCD Data Store]
+
+    Then a positive response is received
+    And the response has all other details as expected
+
+
+#-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+# CCD-3510: TTL Guard checks against OverrrideTTL when no previous TTL: v1_external#/case-details-endpoint/createCaseEventForCitizenUsingPOST
+#-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+  @S-1016.91 #CCD-3510
+  Scenario: Set TTL Override (TTL Guard fail) for first time when TTL data not present in case data and Submit Event is invoked on v1_external#/case-details-endpoint/createCaseEventForCitizenUsingPOST
+    Given a user with [an active profile in CCD]
+    And a successful call [to create a case] as in [F-1016_CreateCasePreRequisiteCitizen_noTTL]
+
+    When a request is prepared with appropriate values
+    And the request [contains a case Id that has just been created as in F-1016_CreateCasePreRequisiteCitizen_noTTL]
+    And the request [contains an event token for the case just created above]
+    And the request [has TTL.OverrideTTL set to less than today + guard value]
+    And it is submitted to call the [submit event creation as citizen] operation of [CCD Data Store]
+
+    Then a negative response is received
+    And the response has all other details as expected
+
+  @S-1016.92 #CCD-3510
+  Scenario: Set TTL Override (TTL Guard pass) for first time when TTL data not present in case data and Submit Event is invoked on v1_external#/case-details-endpoint/createCaseEventForCitizenUsingPOST
+    Given a user with [an active profile in CCD]
+    And a successful call [to create a case] as in [F-1016_CreateCasePreRequisiteCitizen_noTTL]
+
+    When a request is prepared with appropriate values
+    And the request [contains a case Id that has just been created as in F-1016_CreateCasePreRequisiteCitizen_noTTL]
+    And the request [contains an event token for the case just created above]
+    And the request [has TTL.OverrideTTL set to greater than today + guard value]
+    And it is submitted to call the [submit event creation as citizen] operation of [CCD Data Store]
+
+    Then a positive response is received
+    And the response has all other details as expected
+
+  @S-1016.93 #CCD-3510
+  Scenario: Set TTL Override and Suspend=Yes (TTL Guard pass) for first time when TTL data not present in case data and Submit Event is invoked on v1_external#/case-details-endpoint/createCaseEventForCitizenUsingPOST
+    Given a user with [an active profile in CCD]
+    And a successful call [to create a case] as in [F-1016_CreateCasePreRequisiteCitizen_noTTL]
+
+    When a request is prepared with appropriate values
+    And the request [contains a case Id that has just been created as in F-1016_CreateCasePreRequisiteCitizen_noTTL]
+    And the request [contains an event token for the case just created above]
+    And the request [has TTL.OverrideTTL set to less than today + guard value]
+    And the request [has TTL.Suspended set to Yes]
+    And it is submitted to call the [submit event creation as citizen] operation of [CCD Data Store]
+
+    Then a positive response is received
+    And the response has all other details as expected

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.1.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.1.td.json
@@ -45,6 +45,6 @@
   },
 
   "expectedResponse": {
-    "_extends_": "CommonErrorMessageTTL"
+    "_extends_": "422_TTL_Guard"
   }
 }

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.15.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.15.td.json
@@ -44,6 +44,6 @@
   },
 
   "expectedResponse": {
-    "_extends_": "CommonErrorMessageTTL"
+    "_extends_": "422_TTL_Guard"
   }
 }

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.22.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.22.td.json
@@ -43,6 +43,6 @@
   },
 
   "expectedResponse": {
-    "_extends_": "CommonErrorMessageTTL"
+    "_extends_": "422_TTL_Guard"
   }
 }

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.24.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.24.td.json
@@ -43,6 +43,6 @@
   },
 
   "expectedResponse": {
-    "_extends_": "CommonErrorMessageTTL"
+    "_extends_": "422_TTL_Guard"
   }
 }

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.26.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.26.td.json
@@ -44,6 +44,6 @@
   },
 
   "expectedResponse": {
-    "_extends_": "CommonErrorMessageTTL"
+    "_extends_": "422_TTL_Guard"
   }
 }

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.28.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.28.td.json
@@ -43,6 +43,6 @@
   },
 
   "expectedResponse": {
-    "_extends_": "CommonErrorMessageTTL"
+    "_extends_": "422_TTL_Guard"
   }
 }

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.30.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.30.td.json
@@ -43,6 +43,6 @@
   },
 
   "expectedResponse": {
-    "_extends_": "CommonErrorMessageTTL"
+    "_extends_": "422_TTL_Guard"
   }
 }

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.32.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.32.td.json
@@ -44,6 +44,6 @@
   },
 
   "expectedResponse": {
-    "_extends_": "CommonErrorMessageTTL"
+    "_extends_": "422_TTL_Guard"
   }
 }

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.34.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.34.td.json
@@ -44,6 +44,6 @@
 
   "expectedResponse": {
 
-    "_extends_": "CommonErrorMessageTTL"
+    "_extends_": "422_TTL_Guard"
   }
 }

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.36.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.36.td.json
@@ -43,6 +43,6 @@
   },
 
   "expectedResponse": {
-    "_extends_": "CommonErrorMessageTTL"
+    "_extends_": "422_TTL_Guard"
   }
 }

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.38.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.38.td.json
@@ -44,6 +44,6 @@
   },
 
   "expectedResponse": {
-    "_extends_": "CommonErrorMessageTTL"
+    "_extends_": "422_TTL_Guard"
   }
 }

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.8.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.8.td.json
@@ -45,6 +45,6 @@
   },
 
   "expectedResponse": {
-    "_extends_": "CommonErrorMessageTTL"
+    "_extends_": "422_TTL_Guard"
   }
 }

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.81.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.81.td.json
@@ -44,6 +44,6 @@
   },
 
   "expectedResponse": {
-    "_extends_": "CommonErrorMessageTTL"
+    "_extends_": "422_TTL_Guard"
   }
 }

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.81.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.81.td.json
@@ -1,0 +1,49 @@
+{
+  "_guid_": "S-1016.81",
+  "_extends_": "F-1016_Test_Data_Base",
+
+  "title": "Set TTL Override (TTL Guard fail) for first time when TTL data not present in case data and Submit Event is invoked on v1_external#/case-details-endpoint/createCaseEventForCaseWorkerUsingPOST",
+
+  "prerequisites" : [ {
+    "Token_Creation": "S-1016_GetUpdateTokenCaseworker_noTTL"
+  } ],
+
+  "specs": [
+    "an active profile in CCD",
+
+    "contains a case Id that has just been created as in F-1016_CreateCasePreRequisiteCaseworker_noTTL",
+    "contains an event token for the case just created above",
+
+    "has TTL.OverrideTTL set to less than today + guard value"
+  ],
+
+  "request": {
+    "pathVariables": {
+      "cid": "${[scenarioContext][childContexts][F-1016_CreateCasePreRequisiteCaseworker_noTTL][testData][actualResponse][body][id]}"
+    },
+    "headers": {
+      "_extends_": "Common_Request_Headers"
+    },
+    "body": {
+      "data": {
+        "TTL": {
+          "Suspended": "No",
+          "OverrideTTL": "${[scenarioContext][customValues][dateLessThanTTLGuardDate]}",
+          "SystemTTL": null
+        }
+      },
+      "event": {
+        "id": "updateCaseSubmitTTL",
+        "summary": "",
+        "description": ""
+      },
+      "security_classification": "PUBLIC",
+      "event_token" : "${[scenarioContext][childContexts][Token_Creation][testData][actualResponse][body][token]}",
+      "ignore_warning": true
+    }
+  },
+
+  "expectedResponse": {
+    "_extends_": "CommonErrorMessageTTL"
+  }
+}

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.82.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.82.td.json
@@ -1,0 +1,82 @@
+{
+  "_guid_": "S-1016.82",
+  "_extends_": "F-1016_Test_Data_Base",
+
+  "title": "Set TTL Override (TTL Guard pass) for first time when TTL data not present in case data and Submit Event is invoked on v1_external#/case-details-endpoint/createCaseEventForCaseWorkerUsingPOST",
+
+  "prerequisites" : [ {
+    "Token_Creation": "S-1016_GetUpdateTokenCaseworker_noTTL"
+  } ],
+
+  "specs": [
+    "an active profile in CCD",
+
+    "contains a case Id that has just been created as in F-1016_CreateCasePreRequisiteCaseworker_noTTL",
+    "contains an event token for the case just created above",
+
+    "has TTL.OverrideTTL set to greater than today + guard value"
+  ],
+
+  "request": {
+    "pathVariables": {
+      "cid": "${[scenarioContext][childContexts][F-1016_CreateCasePreRequisiteCaseworker_noTTL][testData][actualResponse][body][id]}"
+    },
+    "headers": {
+      "_extends_": "Common_Request_Headers"
+    },
+    "body": {
+      "data": {
+        "TTL": {
+          "Suspended": "No",
+          "OverrideTTL": "${[scenarioContext][customValues][dateGreaterThanTTLGuardDate]}",
+          "SystemTTL": null
+        }
+      },
+      "event": {
+        "id": "updateCaseSubmitTTL",
+        "summary": "",
+        "description": ""
+      },
+      "security_classification": "PUBLIC",
+      "event_token" : "${[scenarioContext][childContexts][Token_Creation][testData][actualResponse][body][token]}",
+      "ignore_warning": true
+    }
+  },
+
+  "expectedResponse": {
+    "_extends_": "Common_201_Response",
+    "body" : {
+      "id" : "[[ANYTHING_PRESENT]]",
+      "jurisdiction" : "BEFTA_MASTER",
+      "state" : "CaseUpdated",
+      "version" : 1,
+      "case_type_id" : "FT_MasterCaseType",
+      "created_date" : "[[ANYTHING_PRESENT]]",
+      "last_modified" : "[[ANYTHING_PRESENT]]",
+      "last_state_modified_date" : "[[ANYTHING_PRESENT]]",
+      "security_classification" : "PUBLIC",
+      "case_data" : {
+        "TTL" : {
+          "Suspended" : "No",
+          "OverrideTTL" : "${[scenarioContext][customValues][dateGreaterThanTTLGuardDate]}",
+          "SystemTTL" : null
+        },
+        "SearchCriteria" : { }
+      },
+      "data_classification" : {
+        "_extends_": "TTL_Classifications",
+        "SearchCriteria" : "[[ANYTHING_PRESENT]]"
+      },
+      "supplementary_data" : null,
+      "after_submit_callback_response" : null,
+      "callback_response_status_code" : null,
+      "callback_response_status" : null,
+      "delete_draft_response_status_code" : null,
+      "delete_draft_response_status" : null,
+      "security_classifications" : {
+        "_extends_": "TTL_Classifications",
+        "SearchCriteria" : "[[ANYTHING_PRESENT]]"
+      }
+    }
+  }
+}

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.83.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.83.td.json
@@ -1,0 +1,83 @@
+{
+  "_guid_": "S-1016.83",
+  "_extends_": "F-1016_Test_Data_Base",
+
+  "title": "Set TTL Override and Suspend=Yes (TTL Guard pass) for first time when TTL data not present in case data and Submit Event is invoked on v1_external#/case-details-endpoint/createCaseEventForCaseWorkerUsingPOST",
+
+  "prerequisites" : [ {
+    "Token_Creation": "S-1016_GetUpdateTokenCaseworker_noTTL"
+  } ],
+
+  "specs": [
+    "an active profile in CCD",
+
+    "contains a case Id that has just been created as in F-1016_CreateCasePreRequisiteCaseworker_noTTL",
+    "contains an event token for the case just created above",
+
+    "has TTL.OverrideTTL set to less than today + guard value",
+    "has TTL.Suspended set to Yes"
+  ],
+
+  "request": {
+    "pathVariables": {
+      "cid": "${[scenarioContext][childContexts][F-1016_CreateCasePreRequisiteCaseworker_noTTL][testData][actualResponse][body][id]}"
+    },
+    "headers": {
+      "_extends_": "Common_Request_Headers"
+    },
+    "body": {
+      "data": {
+        "TTL": {
+          "Suspended": "Yes",
+          "OverrideTTL": "${[scenarioContext][customValues][dateLessThanTTLGuardDate]}",
+          "SystemTTL": null
+        }
+      },
+      "event": {
+        "id": "updateCaseSubmitTTL",
+        "summary": "",
+        "description": ""
+      },
+      "security_classification": "PUBLIC",
+      "event_token" : "${[scenarioContext][childContexts][Token_Creation][testData][actualResponse][body][token]}",
+      "ignore_warning": true
+    }
+  },
+
+  "expectedResponse": {
+    "_extends_": "Common_201_Response",
+    "body" : {
+      "id" : "[[ANYTHING_PRESENT]]",
+      "jurisdiction" : "BEFTA_MASTER",
+      "state" : "CaseUpdated",
+      "version" : 1,
+      "case_type_id" : "FT_MasterCaseType",
+      "created_date" : "[[ANYTHING_PRESENT]]",
+      "last_modified" : "[[ANYTHING_PRESENT]]",
+      "last_state_modified_date" : "[[ANYTHING_PRESENT]]",
+      "security_classification" : "PUBLIC",
+      "case_data" : {
+        "TTL" : {
+          "Suspended" : "Yes",
+          "OverrideTTL" : "${[scenarioContext][customValues][dateLessThanTTLGuardDate]}",
+          "SystemTTL" : null
+        },
+        "SearchCriteria" : { }
+      },
+      "data_classification" : {
+        "_extends_": "TTL_Classifications",
+        "SearchCriteria" : "[[ANYTHING_PRESENT]]"
+      },
+      "supplementary_data" : null,
+      "after_submit_callback_response" : null,
+      "callback_response_status_code" : null,
+      "callback_response_status" : null,
+      "delete_draft_response_status_code" : null,
+      "delete_draft_response_status" : null,
+      "security_classifications" : {
+        "_extends_": "TTL_Classifications",
+        "SearchCriteria" : "[[ANYTHING_PRESENT]]"
+      }
+    }
+  }
+}

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.86.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.86.td.json
@@ -1,0 +1,49 @@
+{
+  "_guid_": "S-1016.86",
+  "_extends_": "F-1016_Test_Data_Base_V2",
+
+  "title": "Set TTL Override (TTL Guard fail) for first time when TTL data not present in case data and Submit Event is invoked on v2_external#/case-controller/createEventUsingPOST",
+
+  "prerequisites" : [ {
+    "Token_Creation": "S-1016_GetUpdateTokenCaseworker_noTTL"
+  } ],
+
+  "specs": [
+    "an active profile in CCD",
+
+    "contains a case Id that has just been created as in F-1016_CreateCasePreRequisiteCaseworker_noTTL",
+    "contains an event token for the case just created above",
+
+    "has TTL.OverrideTTL set to less than today + guard value"
+  ],
+
+  "request": {
+    "pathVariables": {
+      "cid": "${[scenarioContext][childContexts][F-1016_CreateCasePreRequisiteCaseworker_noTTL][testData][actualResponse][body][id]}"
+    },
+    "headers": {
+      "_extends_": "Common_Request_Headers"
+    },
+    "body": {
+      "data": {
+        "TTL": {
+          "Suspended": "No",
+          "OverrideTTL" : "${[scenarioContext][customValues][dateLessThanTTLGuardDate]}",
+          "SystemTTL": null
+        }
+      },
+      "event": {
+        "id": "updateCaseSubmitTTL",
+        "summary": "",
+        "description": ""
+      },
+      "security_classification": "PUBLIC",
+      "event_token" : "${[scenarioContext][childContexts][Token_Creation][testData][actualResponse][body][token]}",
+      "ignore_warning": true
+    }
+  },
+
+  "expectedResponse": {
+    "_extends_": "CommonErrorMessageTTL"
+  }
+}

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.86.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.86.td.json
@@ -44,6 +44,6 @@
   },
 
   "expectedResponse": {
-    "_extends_": "CommonErrorMessageTTL"
+    "_extends_": "422_TTL_Guard"
   }
 }

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.87.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.87.td.json
@@ -1,0 +1,77 @@
+{
+  "_guid_": "S-1016.87",
+  "_extends_": "F-1016_Test_Data_Base_V2",
+
+  "title": "Set TTL Override (TTL Guard pass) for first time when TTL data not present in case data and Submit Event is invoked on v2_external#/case-controller/createEventUsingPOST",
+
+  "prerequisites" : [ {
+    "Token_Creation": "S-1016_GetUpdateTokenCaseworker_noTTL"
+  } ],
+
+  "specs": [
+    "an active profile in CCD",
+
+    "contains a case Id that has just been created as in F-1016_CreateCasePreRequisiteCaseworker_noTTL",
+    "contains an event token for the case just created above",
+
+    "has TTL.OverrideTTL set to greater than today + guard value"
+  ],
+
+  "request": {
+    "pathVariables": {
+      "cid": "${[scenarioContext][childContexts][F-1016_CreateCasePreRequisiteCaseworker_noTTL][testData][actualResponse][body][id]}"
+    },
+    "headers": {
+      "_extends_": "Common_Request_Headers"
+    },
+    "body": {
+      "data": {
+        "TTL": {
+          "Suspended" : "No",
+          "OverrideTTL" : "${[scenarioContext][customValues][dateGreaterThanTTLGuardDate]}",
+          "SystemTTL" : null
+        }
+      },
+      "event": {
+        "id": "updateCaseSubmitTTL",
+        "summary": "",
+        "description": ""
+      },
+      "security_classification": "PUBLIC",
+      "event_token" : "${[scenarioContext][childContexts][Token_Creation][testData][actualResponse][body][token]}",
+      "ignore_warning": true
+    }
+  },
+
+  "expectedResponse": {
+    "_extends_": "Common_201_Response",
+    "body" : {
+      "_links" : "[[ANYTHING_PRESENT]]",
+      "id" : "[[ANYTHING_PRESENT]]",
+      "jurisdiction" : "BEFTA_MASTER",
+      "state" : "CaseUpdated",
+      "case_type" : "FT_MasterCaseType",
+      "created_on" : "[[ANYTHING_PRESENT]]",
+      "last_modified_on" : "[[ANYTHING_PRESENT]]",
+      "last_state_modified_on" : "[[ANYTHING_PRESENT]]",
+      "security_classification" : "PUBLIC",
+      "data" : {
+        "TTL" : {
+          "Suspended" : "No",
+          "OverrideTTL" : "${[scenarioContext][customValues][dateGreaterThanTTLGuardDate]}",
+          "SystemTTL" : null
+        },
+        "SearchCriteria" : { }
+      },
+      "data_classification" : {
+        "_extends_": "TTL_Classifications",
+        "SearchCriteria" : "[[ANYTHING_PRESENT]]"
+      },
+      "after_submit_callback_response" : null,
+      "callback_response_status_code" : null,
+      "callback_response_status" : null,
+      "delete_draft_response_status_code" : null,
+      "delete_draft_response_status" : null
+    }
+  }
+}

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.88.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.88.td.json
@@ -1,0 +1,78 @@
+{
+  "_guid_": "S-1016.88",
+  "_extends_": "F-1016_Test_Data_Base_V2",
+
+  "title": "et TTL Override and Suspend=Yes (TTL Guard pass) for first time when TTL data not present in case data and Submit Event is invoked on v2_external#/case-controller/createEventUsingPOST",
+
+  "prerequisites" : [ {
+    "Token_Creation": "S-1016_GetUpdateTokenCaseworker_noTTL"
+  } ],
+
+  "specs": [
+    "an active profile in CCD",
+
+    "contains a case Id that has just been created as in F-1016_CreateCasePreRequisiteCaseworker_noTTL",
+    "contains an event token for the case just created above",
+
+    "has TTL.OverrideTTL set to less than today + guard value",
+    "has TTL.Suspended set to Yes"
+  ],
+
+  "request": {
+    "pathVariables": {
+      "cid": "${[scenarioContext][childContexts][F-1016_CreateCasePreRequisiteCaseworker_noTTL][testData][actualResponse][body][id]}"
+    },
+    "headers": {
+      "_extends_": "Common_Request_Headers"
+    },
+    "body": {
+      "data": {
+        "TTL": {
+          "Suspended" : "Yes",
+          "OverrideTTL" : "${[scenarioContext][customValues][dateLessThanTTLGuardDate]}",
+          "SystemTTL" : null
+        }
+      },
+      "event": {
+        "id": "updateCaseSubmitTTL",
+        "summary": "",
+        "description": ""
+      },
+      "security_classification": "PUBLIC",
+      "event_token" : "${[scenarioContext][childContexts][Token_Creation][testData][actualResponse][body][token]}",
+      "ignore_warning": true
+    }
+  },
+
+  "expectedResponse": {
+    "_extends_": "Common_201_Response",
+    "body" : {
+      "_links" : "[[ANYTHING_PRESENT]]",
+      "id" : "[[ANYTHING_PRESENT]]",
+      "jurisdiction" : "BEFTA_MASTER",
+      "state" : "CaseUpdated",
+      "case_type" : "FT_MasterCaseType",
+      "created_on" : "[[ANYTHING_PRESENT]]",
+      "last_modified_on" : "[[ANYTHING_PRESENT]]",
+      "last_state_modified_on" : "[[ANYTHING_PRESENT]]",
+      "security_classification" : "PUBLIC",
+      "data" : {
+        "TTL" : {
+          "Suspended" : "Yes",
+          "OverrideTTL" : "${[scenarioContext][customValues][dateLessThanTTLGuardDate]}",
+          "SystemTTL" : null
+        },
+        "SearchCriteria" : { }
+      },
+      "data_classification" : {
+        "_extends_": "TTL_Classifications",
+        "SearchCriteria" : "[[ANYTHING_PRESENT]]"
+      },
+      "after_submit_callback_response" : null,
+      "callback_response_status_code" : null,
+      "callback_response_status" : null,
+      "delete_draft_response_status_code" : null,
+      "delete_draft_response_status" : null
+    }
+  }
+}

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.91.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.91.td.json
@@ -45,6 +45,6 @@
   },
 
   "expectedResponse": {
-    "_extends_": "CommonErrorMessageTTL"
+    "_extends_": "422_TTL_Guard"
   }
 }

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.91.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.91.td.json
@@ -1,0 +1,50 @@
+{
+  "_guid_": "S-1016.91",
+  "_extends_": "F-1016_Test_Data_Base_Citizen",
+
+  "title": "Set TTL Override (TTL Guard fail) for first time when TTL data not present in case data and Submit Event is invoked on v1_external#/case-details-endpoint/createCaseEventForCitizenUsingPOST",
+
+  "prerequisites" : [ {
+    "Token_Creation": "S-1016_GetUpdateTokenCitizen_noTTL"
+  }
+  ],
+
+  "specs": [
+    "an active profile in CCD",
+
+    "contains a case Id that has just been created as in F-1016_CreateCasePreRequisiteCitizen_noTTL",
+    "contains an event token for the case just created above",
+
+    "has TTL.OverrideTTL set to less than today + guard value"
+  ],
+
+  "request": {
+    "pathVariables": {
+      "cid": "${[scenarioContext][childContexts][F-1016_CreateCasePreRequisiteCitizen_noTTL][testData][actualResponse][body][id]}"
+    },
+    "headers": {
+      "_extends_": "Common_Request_Headers"
+    },
+    "body": {
+      "data": {
+        "TTL": {
+          "Suspended": "No",
+          "OverrideTTL" : "${[scenarioContext][customValues][dateLessThanTTLGuardDate]}",
+          "SystemTTL": null
+        }
+      },
+      "event": {
+        "id": "updateCaseSubmitTTL",
+        "summary": "",
+        "description": ""
+      },
+      "security_classification": "PUBLIC",
+      "event_token" : "${[scenarioContext][childContexts][Token_Creation][testData][actualResponse][body][token]}",
+      "ignore_warning": true
+    }
+  },
+
+  "expectedResponse": {
+    "_extends_": "CommonErrorMessageTTL"
+  }
+}

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.92.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.92.td.json
@@ -1,0 +1,80 @@
+{
+  "_guid_": "S-1016.92",
+  "_extends_": "F-1016_Test_Data_Base_Citizen",
+
+  "title": "Set TTL Override (TTL Guard pass) for first time when TTL data not present in case data and Submit Event is invoked on v1_external#/case-details-endpoint/createCaseEventForCitizenUsingPOST",
+
+  "prerequisites" : [ {
+    "Token_Creation": "S-1016_GetUpdateTokenCitizen_noTTL"
+  }
+  ],
+
+  "specs": [
+    "an active profile in CCD",
+
+    "contains a case Id that has just been created as in F-1016_CreateCasePreRequisiteCitizen_noTTL",
+    "contains an event token for the case just created above",
+
+    "has TTL.OverrideTTL set to greater than today + guard value"
+  ],
+
+  "request": {
+    "pathVariables": {
+      "cid": "${[scenarioContext][childContexts][F-1016_CreateCasePreRequisiteCitizen_noTTL][testData][actualResponse][body][id]}"
+    },
+    "headers": {
+      "_extends_": "Common_Request_Headers"
+    },
+    "body": {
+      "data": {
+        "TTL": {
+          "Suspended" : "No",
+          "OverrideTTL" : "${[scenarioContext][customValues][dateGreaterThanTTLGuardDate]}",
+          "SystemTTL" : null
+        }
+      },
+      "event": {
+        "id": "updateCaseSubmitTTL",
+        "summary": "",
+        "description": ""
+      },
+      "security_classification": "PUBLIC",
+      "event_token" : "${[scenarioContext][childContexts][Token_Creation][testData][actualResponse][body][token]}",
+      "ignore_warning": true
+    }
+  },
+
+  "expectedResponse": {
+    "_extends_": "Common_201_Response",
+    "body" : {
+      "id" : "[[ANYTHING_PRESENT]]",
+      "jurisdiction" : "BEFTA_MASTER",
+      "state" : "CaseUpdated",
+      "version" : 1,
+      "case_type_id" : "FT_MasterCaseType",
+      "created_date" : "[[ANYTHING_PRESENT]]",
+      "last_modified" : "[[ANYTHING_PRESENT]]",
+      "last_state_modified_date" : "[[ANYTHING_PRESENT]]",
+      "security_classification" : "PUBLIC",
+      "case_data" : {
+        "TTL" : {
+          "Suspended" : "No",
+          "OverrideTTL" : "${[scenarioContext][customValues][dateGreaterThanTTLGuardDate]}",
+          "SystemTTL" : null
+        }
+      },
+      "data_classification" : {
+        "_extends_": "TTL_Classifications"
+      },
+      "supplementary_data" : null,
+      "after_submit_callback_response" : null,
+      "callback_response_status_code" : null,
+      "callback_response_status" : null,
+      "delete_draft_response_status_code" : null,
+      "delete_draft_response_status" : null,
+      "security_classifications" : {
+        "_extends_": "TTL_Classifications"
+      }
+    }
+  }
+}

--- a/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.93.td.json
+++ b/src/aat/resources/features/F-1016 - Submit Event to Update TTL/S-1016.93.td.json
@@ -1,0 +1,81 @@
+{
+  "_guid_": "S-1016.93",
+  "_extends_": "F-1016_Test_Data_Base_Citizen",
+
+  "title": "Set TTL Override and Suspend=Yes (TTL Guard pass) for first time when TTL data not present in case data and Submit Event is invoked on v1_external#/case-details-endpoint/createCaseEventForCitizenUsingPOST",
+
+  "prerequisites" : [ {
+    "Token_Creation": "S-1016_GetUpdateTokenCitizen_noTTL"
+  }
+  ],
+
+  "specs": [
+    "an active profile in CCD",
+
+    "contains a case Id that has just been created as in F-1016_CreateCasePreRequisiteCitizen_noTTL",
+    "contains an event token for the case just created above",
+
+    "has TTL.OverrideTTL set to less than today + guard value",
+    "has TTL.Suspended set to Yes"
+  ],
+
+  "request": {
+    "pathVariables": {
+      "cid": "${[scenarioContext][childContexts][F-1016_CreateCasePreRequisiteCitizen_noTTL][testData][actualResponse][body][id]}"
+    },
+    "headers": {
+      "_extends_": "Common_Request_Headers"
+    },
+    "body": {
+      "data": {
+        "TTL": {
+          "Suspended" : "Yes",
+          "OverrideTTL" : "${[scenarioContext][customValues][dateLessThanTTLGuardDate]}",
+          "SystemTTL" : null
+        }
+      },
+      "event": {
+        "id": "updateCaseSubmitTTL",
+        "summary": "",
+        "description": ""
+      },
+      "security_classification": "PUBLIC",
+      "event_token" : "${[scenarioContext][childContexts][Token_Creation][testData][actualResponse][body][token]}",
+      "ignore_warning": true
+    }
+  },
+
+  "expectedResponse": {
+    "_extends_": "Common_201_Response",
+    "body" : {
+      "id" : "[[ANYTHING_PRESENT]]",
+      "jurisdiction" : "BEFTA_MASTER",
+      "state" : "CaseUpdated",
+      "version" : 1,
+      "case_type_id" : "FT_MasterCaseType",
+      "created_date" : "[[ANYTHING_PRESENT]]",
+      "last_modified" : "[[ANYTHING_PRESENT]]",
+      "last_state_modified_date" : "[[ANYTHING_PRESENT]]",
+      "security_classification" : "PUBLIC",
+      "case_data" : {
+        "TTL" : {
+          "Suspended" : "Yes",
+          "OverrideTTL" : "${[scenarioContext][customValues][dateLessThanTTLGuardDate]}",
+          "SystemTTL" : null
+        }
+      },
+      "data_classification" : {
+        "_extends_": "TTL_Classifications"
+      },
+      "supplementary_data" : null,
+      "after_submit_callback_response" : null,
+      "callback_response_status_code" : null,
+      "callback_response_status" : null,
+      "delete_draft_response_status_code" : null,
+      "delete_draft_response_status" : null,
+      "security_classifications" : {
+        "_extends_": "TTL_Classifications"
+      }
+    }
+  }
+}

--- a/src/aat/resources/features/common/errors/422_TTL_Guard.td.json
+++ b/src/aat/resources/features/common/errors/422_TTL_Guard.td.json
@@ -1,5 +1,5 @@
 {
-  "_guid_": "CommonErrorMessageTTL",
+  "_guid_": "422_TTL_Guard",
   "_extends_": "Common_422_Response",
 
   "body" : {

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/casedeletion/TimeToLiveService.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/casedeletion/TimeToLiveService.java
@@ -132,16 +132,17 @@ public class TimeToLiveService {
         }
     }
 
-    public void validateSuspensionChange(Map<String, JsonNode> updatedCaseData,
-                                          Map<String, JsonNode> currentCaseData) {
+    public void validateTTLChangeAgainstTTLGuard(Map<String, JsonNode> updatedCaseData,
+                                                 Map<String, JsonNode> currentCaseData) {
 
         // the rule: "Updating the TTL suspension or override values only allowed if the deletion will occur beyond
         //            the guard period."
 
         TTL updatedTTL = getTTLFromCaseData(updatedCaseData);
         if (updatedTTL == null) {
-            // if `updatedTTL` is null then all is OK as either no change made (if missing)
-            //    or no TTL in place (if null) (i.e. no deletion will occur)
+            // if `updatedTTL` is null then all is OK as either:
+            //  * no change made (if missing)
+            //  * or no TTL in place (if null) i.e. no deletion will occur
             return;
         }
 

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/casedeletion/TimeToLiveService.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/casedeletion/TimeToLiveService.java
@@ -19,6 +19,7 @@ import java.time.LocalDate;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import static uk.gov.hmcts.ccd.domain.model.casedeletion.TTL.NO;
@@ -85,13 +86,9 @@ public class TimeToLiveService {
 
         if (isCaseTypeUsingTTL(caseTypeDefinition) && (ttlIncrement != null)) {
 
-            outputData = cloneOrNewJsonMap(data);
-            TTL timeToLive = null;
-
             // load existing TTL
-            if (outputData.get(TTL_CASE_FIELD_ID) != null) {
-                timeToLive = getTTLFromJson(outputData.get(TTL_CASE_FIELD_ID));
-            }
+            outputData = cloneOrNewJsonMap(data);
+            TTL timeToLive = getTTLFromCaseData(outputData);
 
             // if TTL still missing create one
             if (timeToLive == null) {
@@ -138,32 +135,30 @@ public class TimeToLiveService {
     public void validateSuspensionChange(Map<String, JsonNode> updatedCaseData,
                                           Map<String, JsonNode> currentCaseData) {
 
-        // the rule: "Unsetting a suspension can only be allowed if the deletion will occur beyond the guard period."
+        // the rule: "Updating the TTL suspension or override values only allowed if the deletion will occur beyond
+        //            the guard period."
 
-        TTL updatedTTL = null;
-        TTL currentTTL = null;
-
-        if (isTtlCaseFieldPresent(updatedCaseData) && isTtlCaseFieldPresent(currentCaseData)) {
-            updatedTTL = getTTLFromJson(updatedCaseData.get(TTL_CASE_FIELD_ID));
-            currentTTL = getTTLFromJson(currentCaseData.get(TTL_CASE_FIELD_ID));
-        }
-
-        if (updatedTTL == null || currentTTL == null) {
-            // if `updatedTTL` is null then all is OK as no TTL in place, i.e. no deletion will occur.
-            // if `currentTTL` is null then all is OK as no previous suspension to validate against.
+        TTL updatedTTL = getTTLFromCaseData(updatedCaseData);
+        if (updatedTTL == null) {
+            // if `updatedTTL` is null then all is OK as either no change made (if missing)
+            //    or no TTL in place (if null) (i.e. no deletion will occur)
             return;
         }
 
-        // checking if `TTL.suspended` has changed value
+        TTL currentTTL = getTTLFromCaseData(currentCaseData);
+        if (currentTTL == null) {
+            // if `currentTTL` is null then default to a blank one to validate against.
+            currentTTL = new TTL();
+        }
+
+        // checking if `TTL.suspended` or `TTL.overrideTTL` have changed value
         if (updatedTTL.isSuspended() != currentTTL.isSuspended()
             || overrideTTLIsChanged(currentTTL.getOverrideTTL(), updatedTTL.getOverrideTTL())) {
+
             LocalDate ttlGuardDate = LocalDate.now().plusDays(applicationParams.getTtlGuard());
             LocalDate resolvedTTL = getResolvedTTL(updatedTTL);
 
-            // NB: if `resolvedTTL` is non-null then no suspension in place  ...
-            //     ... so given we know `TTL.suspended` has changed value it must have been lifted
-
-            // validate: Unsetting a suspension can only be allowed if the deletion will occur beyond the guard period
+            // validate: suspended/overrideTTL updates only allowed if the deletion will occur beyond the guard period
             if (resolvedTTL != null && resolvedTTL.isBefore(ttlGuardDate)) {
                 throw new ValidationException(TIME_TO_LIVE_GUARD_ERROR_MESSAGE);
             }
@@ -172,20 +167,12 @@ public class TimeToLiveService {
 
     // check if overrideTTL has changed value
     private boolean overrideTTLIsChanged(LocalDate currentOverrideTTL, LocalDate updatedOverrideTTL) {
-        if (currentOverrideTTL == null && updatedOverrideTTL == null
-            || (currentOverrideTTL != null && updatedOverrideTTL != null
-            && currentOverrideTTL.equals(updatedOverrideTTL))) {
-            return false;
-        }
-        return true;
+        // null safe date comparison
+        return !Objects.equals(currentOverrideTTL, updatedOverrideTTL);
     }
 
     public LocalDate getUpdatedResolvedTTL(Map<String, JsonNode> caseData) {
-        TTL ttl = null;
-
-        if (isTtlCaseFieldPresent(caseData)) {
-            ttl = getTTLFromJson(caseData.get(TTL_CASE_FIELD_ID));
-        }
+        TTL ttl = getTTLFromCaseData(caseData);
 
         return getResolvedTTL(ttl);
     }
@@ -200,6 +187,14 @@ public class TimeToLiveService {
         }
 
         return resolvedTTL;
+    }
+
+    private TTL getTTLFromCaseData(Map<String, JsonNode> caseData) {
+        if (isTtlCaseFieldPresent(caseData)) {
+            return getTTLFromJson(caseData.get(TTL_CASE_FIELD_ID));
+        }
+
+        return null;
     }
 
     private TTL getTTLFromJson(JsonNode ttlJsonNode) {

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/createevent/CreateCaseEventService.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/createevent/CreateCaseEventService.java
@@ -180,7 +180,7 @@ public class CreateCaseEventService {
             caseTypeDefinition
         );
 
-        timeToLiveService.validateSuspensionChange(content.getData(), caseDetailsInDatabase.getData());
+        timeToLiveService.validateTTLChangeAgainstTTLGuard(content.getData(), caseDetailsInDatabase.getData());
 
         final CaseDetails updatedCaseDetailsWithoutHashes = caseDocumentService.stripDocumentHashes(updatedCaseDetails);
 

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/casedeletion/TimeToLiveServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/casedeletion/TimeToLiveServiceTest.java
@@ -606,11 +606,11 @@ class TimeToLiveServiceTest {
 
 
     @Nested
-    @DisplayName("validateSuspensionChange")
-    class ValidateSuspensionChange {
+    @DisplayName("validateTTLChangeAgainstTTLGuard")
+    class ValidateTTLChangeAgainstTTLGuard {
 
         @ParameterizedTest(
-            name = "validateSuspensionChange generates no error if supplied case data is null or empty: {0}"
+            name = "validateTTLChangeAgainstTTLGuard generates no error if supplied case data is null or empty: {0}"
         )
         @NullAndEmptySource
         void verifyTTLSuspension_NoError_whenCaseDataNullOrEmpty(Map<String, JsonNode> data) {
@@ -622,11 +622,12 @@ class TimeToLiveServiceTest {
             Map<String, JsonNode> updatedCaseData = new HashMap<>();
             updatedCaseData.put(TTL.TTL_CASE_FIELD_ID, objectMapper.valueToTree(updatedTtl));
 
-            assertDoesNotThrow(() -> timeToLiveService.validateSuspensionChange(updatedCaseData, data));
+            assertDoesNotThrow(() -> timeToLiveService.validateTTLChangeAgainstTTLGuard(updatedCaseData, data));
         }
 
         @ParameterizedTest(
-            name = "validateSuspensionChange generates no error if supplied updated case data is null or empty: {0}"
+            name = "validateTTLChangeAgainstTTLGuard generates no error if supplied updated case data is null or empty:"
+                + " {0}"
         )
         @NullAndEmptySource
         void verifyTTLSuspension_NoError_whenUpdatedCaseDataNullOrEmpty(Map<String, JsonNode> updatedData) {
@@ -638,7 +639,7 @@ class TimeToLiveServiceTest {
                 .build();
             caseData.put(TTL.TTL_CASE_FIELD_ID, objectMapper.valueToTree(ttl));
 
-            assertDoesNotThrow(() -> timeToLiveService.validateSuspensionChange(updatedData, caseData));
+            assertDoesNotThrow(() -> timeToLiveService.validateTTLChangeAgainstTTLGuard(updatedData, caseData));
         }
 
         @Test
@@ -653,7 +654,7 @@ class TimeToLiveServiceTest {
             Map<String, JsonNode> updatedCaseData = new HashMap<>();
             updatedCaseData.put(TTL.TTL_CASE_FIELD_ID, objectMapper.valueToTree(updatedTtl));
 
-            assertDoesNotThrow(() -> timeToLiveService.validateSuspensionChange(updatedCaseData, caseData));
+            assertDoesNotThrow(() -> timeToLiveService.validateTTLChangeAgainstTTLGuard(updatedCaseData, caseData));
         }
 
         @Test
@@ -669,7 +670,7 @@ class TimeToLiveServiceTest {
             Map<String, JsonNode> updatedCaseData = new HashMap<>();
             updatedCaseData.put(TTL.TTL_CASE_FIELD_ID, objectMapper.valueToTree(null));
 
-            assertDoesNotThrow(() -> timeToLiveService.validateSuspensionChange(updatedCaseData, caseData));
+            assertDoesNotThrow(() -> timeToLiveService.validateTTLChangeAgainstTTLGuard(updatedCaseData, caseData));
         }
 
         @Test
@@ -690,7 +691,7 @@ class TimeToLiveServiceTest {
             Map<String, JsonNode> updatedCaseData = new HashMap<>();
             updatedCaseData.put(TTL.TTL_CASE_FIELD_ID, objectMapper.valueToTree(updatedTtl));
 
-            assertDoesNotThrow(() -> timeToLiveService.validateSuspensionChange(updatedCaseData, caseData));
+            assertDoesNotThrow(() -> timeToLiveService.validateTTLChangeAgainstTTLGuard(updatedCaseData, caseData));
         }
 
         @Test
@@ -711,11 +712,11 @@ class TimeToLiveServiceTest {
             Map<String, JsonNode> updatedCaseData = new HashMap<>();
             updatedCaseData.put(TTL.TTL_CASE_FIELD_ID, objectMapper.valueToTree(updatedTtl));
 
-            assertDoesNotThrow(() -> timeToLiveService.validateSuspensionChange(updatedCaseData, caseData));
+            assertDoesNotThrow(() -> timeToLiveService.validateTTLChangeAgainstTTLGuard(updatedCaseData, caseData));
         }
 
         @ParameterizedTest(
-            name = "validateSuspensionChange generates no error if TTL.suspended changed: {0} -> Yes"
+            name = "validateTTLChangeAgainstTTLGuard generates no error if TTL.suspended changed: {0} -> Yes"
         )
         @MethodSource(TTL_SUSPENDED_VALUES_FOR_IS_SUSPENDED_FALSE)
         void verifyTTLSuspensionChanged_NoToYes_alternativeNos(String ttlSuspended) {
@@ -735,11 +736,11 @@ class TimeToLiveServiceTest {
             Map<String, JsonNode> updatedCaseData = new HashMap<>();
             updatedCaseData.put(TTL.TTL_CASE_FIELD_ID, objectMapper.valueToTree(updatedTtl));
 
-            assertDoesNotThrow(() -> timeToLiveService.validateSuspensionChange(updatedCaseData, caseData));
+            assertDoesNotThrow(() -> timeToLiveService.validateTTLChangeAgainstTTLGuard(updatedCaseData, caseData));
         }
 
         @ParameterizedTest(
-            name = "validateSuspensionChange generates no error if TTL.suspended changed: No -> {0}"
+            name = "validateTTLChangeAgainstTTLGuard generates no error if TTL.suspended changed: No -> {0}"
         )
         @MethodSource(TTL_SUSPENDED_VALUES_FOR_IS_SUSPENDED_TRUE)
         void verifyTTLSuspensionChanged_NoToYes_alternativeYeses(String updatedTtlSuspended) {
@@ -759,11 +760,11 @@ class TimeToLiveServiceTest {
             Map<String, JsonNode> updatedCaseData = new HashMap<>();
             updatedCaseData.put(TTL.TTL_CASE_FIELD_ID, objectMapper.valueToTree(updatedTtl));
 
-            assertDoesNotThrow(() -> timeToLiveService.validateSuspensionChange(updatedCaseData, caseData));
+            assertDoesNotThrow(() -> timeToLiveService.validateTTLChangeAgainstTTLGuard(updatedCaseData, caseData));
         }
 
         @ParameterizedTest(
-            name = "validateSuspensionChange generates error if TTL.suspended changed: Yes -> {0}"
+            name = "validateTTLChangeAgainstTTLGuard generates error if TTL.suspended changed: Yes -> {0}"
         )
         @MethodSource(TTL_SUSPENDED_VALUES_FOR_IS_SUSPENDED_FALSE)
         void verifyTTLSuspensionChanged_YesToNo_alternativeNos(String updatedTtlSuspended) {
@@ -787,13 +788,13 @@ class TimeToLiveServiceTest {
             updatedCaseData.put(TTL.TTL_CASE_FIELD_ID, objectMapper.valueToTree(updatedTtl));
 
             final ValidationException exception = assertThrows(ValidationException.class,
-                () -> timeToLiveService.validateSuspensionChange(updatedCaseData, caseData));
+                () -> timeToLiveService.validateTTLChangeAgainstTTLGuard(updatedCaseData, caseData));
             assertThat(exception.getMessage(),
                 startsWith(TIME_TO_LIVE_GUARD_ERROR_MESSAGE));
         }
 
         @ParameterizedTest(
-            name = "validateSuspensionChange generates error if TTL.suspended changed: {0} -> No"
+            name = "validateTTLChangeAgainstTTLGuard generates error if TTL.suspended changed: {0} -> No"
         )
         @MethodSource(TTL_SUSPENDED_VALUES_FOR_IS_SUSPENDED_TRUE)
         void verifyTTLSuspensionChanged_YesToNo_alternativeYeses(String ttlSuspended) {
@@ -817,7 +818,7 @@ class TimeToLiveServiceTest {
             updatedCaseData.put(TTL.TTL_CASE_FIELD_ID, objectMapper.valueToTree(updatedTtl));
 
             final ValidationException exception = assertThrows(ValidationException.class,
-                () -> timeToLiveService.validateSuspensionChange(updatedCaseData, caseData));
+                () -> timeToLiveService.validateTTLChangeAgainstTTLGuard(updatedCaseData, caseData));
             assertThat(exception.getMessage(),
                 startsWith(TIME_TO_LIVE_GUARD_ERROR_MESSAGE));
         }
@@ -841,7 +842,7 @@ class TimeToLiveServiceTest {
             Map<String, JsonNode> updatedCaseData = new HashMap<>();
             updatedCaseData.put(TTL.TTL_CASE_FIELD_ID, objectMapper.valueToTree(updatedTtl));
 
-            assertDoesNotThrow(() -> timeToLiveService.validateSuspensionChange(updatedCaseData, caseData));
+            assertDoesNotThrow(() -> timeToLiveService.validateTTLChangeAgainstTTLGuard(updatedCaseData, caseData));
         }
 
         @Test
@@ -864,7 +865,7 @@ class TimeToLiveServiceTest {
             updatedCaseData.put(TTL.TTL_CASE_FIELD_ID, objectMapper.valueToTree(updatedTtl));
 
             final ValidationException exception = assertThrows(ValidationException.class,
-                () -> timeToLiveService.validateSuspensionChange(updatedCaseData, caseData));
+                () -> timeToLiveService.validateTTLChangeAgainstTTLGuard(updatedCaseData, caseData));
             assertThat(exception.getMessage(),
                 startsWith(TIME_TO_LIVE_GUARD_ERROR_MESSAGE));
         }
@@ -887,7 +888,7 @@ class TimeToLiveServiceTest {
             Map<String, JsonNode> updatedCaseData = new HashMap<>();
             updatedCaseData.put(TTL.TTL_CASE_FIELD_ID, objectMapper.valueToTree(updatedTtl));
 
-            assertDoesNotThrow(() -> timeToLiveService.validateSuspensionChange(updatedCaseData, caseData));
+            assertDoesNotThrow(() -> timeToLiveService.validateTTLChangeAgainstTTLGuard(updatedCaseData, caseData));
         }
 
         @Test
@@ -910,7 +911,7 @@ class TimeToLiveServiceTest {
             updatedCaseData.put(TTL.TTL_CASE_FIELD_ID, objectMapper.valueToTree(updatedTtl));
 
             final ValidationException exception = assertThrows(ValidationException.class,
-                () -> timeToLiveService.validateSuspensionChange(updatedCaseData, caseData));
+                () -> timeToLiveService.validateTTLChangeAgainstTTLGuard(updatedCaseData, caseData));
             assertThat(exception.getMessage(),
                 startsWith(TIME_TO_LIVE_GUARD_ERROR_MESSAGE));
         }
@@ -933,7 +934,7 @@ class TimeToLiveServiceTest {
             Map<String, JsonNode> updatedCaseData = new HashMap<>();
             updatedCaseData.put(TTL.TTL_CASE_FIELD_ID, objectMapper.valueToTree(updatedTtl));
 
-            assertDoesNotThrow(() -> timeToLiveService.validateSuspensionChange(updatedCaseData, caseData));
+            assertDoesNotThrow(() -> timeToLiveService.validateTTLChangeAgainstTTLGuard(updatedCaseData, caseData));
         }
 
         @Test
@@ -955,7 +956,7 @@ class TimeToLiveServiceTest {
             updatedCaseData.put(TTL.TTL_CASE_FIELD_ID, objectMapper.valueToTree(updatedTtl));
 
             final ValidationException exception = assertThrows(ValidationException.class,
-                () -> timeToLiveService.validateSuspensionChange(updatedCaseData, caseData));
+                () -> timeToLiveService.validateTTLChangeAgainstTTLGuard(updatedCaseData, caseData));
             assertThat(exception.getMessage(),
                 startsWith(TIME_TO_LIVE_GUARD_ERROR_MESSAGE));
         }
@@ -978,7 +979,7 @@ class TimeToLiveServiceTest {
             Map<String, JsonNode> updatedCaseData = new HashMap<>();
             updatedCaseData.put(TTL.TTL_CASE_FIELD_ID, objectMapper.valueToTree(updatedTtl));
 
-            assertDoesNotThrow(() -> timeToLiveService.validateSuspensionChange(updatedCaseData, caseData));
+            assertDoesNotThrow(() -> timeToLiveService.validateTTLChangeAgainstTTLGuard(updatedCaseData, caseData));
         }
 
         @Test
@@ -1002,7 +1003,7 @@ class TimeToLiveServiceTest {
             Map<String, JsonNode> updatedCaseData = new HashMap<>();
             updatedCaseData.put(TTL.TTL_CASE_FIELD_ID, objectMapper.valueToTree(updatedTtl));
 
-            assertDoesNotThrow(() -> timeToLiveService.validateSuspensionChange(updatedCaseData, caseData));
+            assertDoesNotThrow(() -> timeToLiveService.validateTTLChangeAgainstTTLGuard(updatedCaseData, caseData));
         }
 
         @Test
@@ -1028,7 +1029,7 @@ class TimeToLiveServiceTest {
             updatedCaseData.put(TTL.TTL_CASE_FIELD_ID, objectMapper.valueToTree(updatedTtl));
 
             final ValidationException exception = assertThrows(ValidationException.class,
-                () -> timeToLiveService.validateSuspensionChange(updatedCaseData, caseData));
+                () -> timeToLiveService.validateTTLChangeAgainstTTLGuard(updatedCaseData, caseData));
             assertThat(exception.getMessage(),
                 startsWith(TIME_TO_LIVE_GUARD_ERROR_MESSAGE));
         }
@@ -1054,7 +1055,7 @@ class TimeToLiveServiceTest {
             Map<String, JsonNode> updatedCaseData = new HashMap<>();
             updatedCaseData.put(TTL.TTL_CASE_FIELD_ID, objectMapper.valueToTree(updatedTtl));
 
-            assertDoesNotThrow(() -> timeToLiveService.validateSuspensionChange(updatedCaseData, caseData));
+            assertDoesNotThrow(() -> timeToLiveService.validateTTLChangeAgainstTTLGuard(updatedCaseData, caseData));
         }
 
         @Test
@@ -1080,13 +1081,13 @@ class TimeToLiveServiceTest {
             updatedCaseData.put(TTL.TTL_CASE_FIELD_ID, objectMapper.valueToTree(updatedTtl));
 
             final ValidationException exception = assertThrows(ValidationException.class,
-                () -> timeToLiveService.validateSuspensionChange(updatedCaseData, caseData));
+                () -> timeToLiveService.validateTTLChangeAgainstTTLGuard(updatedCaseData, caseData));
             assertThat(exception.getMessage(),
                 startsWith(TIME_TO_LIVE_GUARD_ERROR_MESSAGE));
         }
 
         @ParameterizedTest(
-            name = "validateSuspensionChange generates no error if TTL added with valid override: "
+            name = "validateTTLChangeAgainstTTLGuard generates no error if TTL added with valid override: "
                 + "current case data {0}"
         )
         @MethodSource(TTL_MISSING_OR_NULL)
@@ -1101,11 +1102,13 @@ class TimeToLiveServiceTest {
             Map<String, JsonNode> updatedCaseData = new HashMap<>();
             updatedCaseData.put(TTL.TTL_CASE_FIELD_ID, objectMapper.valueToTree(updatedTtl));
 
-            assertDoesNotThrow(() -> timeToLiveService.validateSuspensionChange(updatedCaseData, currentCaseData));
+            assertDoesNotThrow(
+                () -> timeToLiveService.validateTTLChangeAgainstTTLGuard(updatedCaseData, currentCaseData)
+            );
         }
 
         @ParameterizedTest(
-            name = "validateSuspensionChange generates errors if TTL added with invalid override: "
+            name = "validateTTLChangeAgainstTTLGuard generates errors if TTL added with invalid override: "
                 + "current case data {0}"
         )
         @MethodSource(TTL_MISSING_OR_NULL)
@@ -1122,14 +1125,14 @@ class TimeToLiveServiceTest {
             updatedCaseData.put(TTL.TTL_CASE_FIELD_ID, objectMapper.valueToTree(updatedTtl));
 
             final ValidationException exception = assertThrows(ValidationException.class,
-                () -> timeToLiveService.validateSuspensionChange(updatedCaseData, currentCaseData));
+                () -> timeToLiveService.validateTTLChangeAgainstTTLGuard(updatedCaseData, currentCaseData));
             assertThat(exception.getMessage(),
                 startsWith(TIME_TO_LIVE_GUARD_ERROR_MESSAGE));
         }
 
         @ParameterizedTest(
-            name = "validateSuspensionChange generates no error if TTL added with invalid override but suspended Yes: "
-                + "current case data {0}"
+            name = "validateTTLChangeAgainstTTLGuard generates no error if TTL added with invalid override but"
+                + " suspended Yes: current case data {0}"
         )
         @MethodSource(TTL_MISSING_OR_NULL)
         void verifyTTLAdded_OverrideAddedWithInvalidValueButSuspendedYes(Map<String, JsonNode> currentCaseData) {
@@ -1143,11 +1146,13 @@ class TimeToLiveServiceTest {
             Map<String, JsonNode> updatedCaseData = new HashMap<>();
             updatedCaseData.put(TTL.TTL_CASE_FIELD_ID, objectMapper.valueToTree(updatedTtl));
 
-            assertDoesNotThrow(() -> timeToLiveService.validateSuspensionChange(updatedCaseData, currentCaseData));
+            assertDoesNotThrow(
+                () -> timeToLiveService.validateTTLChangeAgainstTTLGuard(updatedCaseData, currentCaseData)
+            );
         }
 
         @ParameterizedTest(
-            name = "validateSuspensionChange generates no error if TTL added with null override and suspended: "
+            name = "validateTTLChangeAgainstTTLGuard generates no error if TTL added with null override and suspended: "
                 + "current case data {0}"
         )
         @MethodSource(TTL_MISSING_OR_NULL)
@@ -1160,7 +1165,9 @@ class TimeToLiveServiceTest {
             Map<String, JsonNode> updatedCaseData = new HashMap<>();
             updatedCaseData.put(TTL.TTL_CASE_FIELD_ID, objectMapper.valueToTree(updatedTtl));
 
-            assertDoesNotThrow(() -> timeToLiveService.validateSuspensionChange(updatedCaseData, currentCaseData));
+            assertDoesNotThrow(
+                () -> timeToLiveService.validateTTLChangeAgainstTTLGuard(updatedCaseData, currentCaseData)
+            );
         }
 
     }

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/createevent/CreateCaseEventServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/createevent/CreateCaseEventServiceTest.java
@@ -446,7 +446,7 @@ class CreateCaseEventServiceTest extends TestFixtures {
         underTest.createCaseEvent(CASE_REFERENCE, caseDataContent);
 
         // THEN
-        verify(timeToLiveService).validateSuspensionChange(any(), any());
+        verify(timeToLiveService).validateTTLChangeAgainstTTLGuard(any(), any());
         verify(timeToLiveService).getUpdatedResolvedTTL(any());
 
         // verify saved case details reflects resolved TTL


### PR DESCRIPTION
### JIRA link (if applicable) ###

   [CCD-3510](https://tools.hmcts.net/jira/browse/CCD-3510) _"TTL Guard checks against OverrrideTTL not functioning correctly if no previous TTL set."_

### Change description ###

TTLGuard checks must also apply when no previous TTL to compare against.

> NB: this branch/PR is based of CCD-3532 (#2047) to allow them to be relased together.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
