### PR TITLE
CCD-3602: Temporarily suppress CVE-2022-31197

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -37,6 +37,7 @@
 			CVE-2021-22112 refer https://tools.hmcts.net/jira/browse/CCD-3514
 			CVE-2022-22976 refer https://tools.hmcts.net/jira/browse/CCD-3515
 			CVE-2021-22044 refer https://tools.hmcts.net/jira/browse/CCD-3509
+			CVE-2022-31197 refer https://tools.hmcts.net/jira/browse/CCD-3602
 	    </notes>
 	    <cve>CVE-2022-34305</cve>
 	    <cve>CVE-2022-31569</cve>
@@ -44,6 +45,7 @@
 		<cve>CVE-2021-22112</cve>
 		<cve>CVE-2022-22976</cve>
 		<cve>CVE-2021-22044</cve>
+		<cve>CVE-2022-31197</cve>
 	  </suppress>
 	<!--End of temporary suppression section -->
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-3602 (https://tools.hmcts.net/jira/browse/CCD-3602)


### Change description ###
Updated dependency-check-suppressions.xml to temporarily suppress CVE-2022-31197


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
