### PR TITLE
CCD-3630 - Take access profiles into account with Global Search post-filtering

### DIFF
--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/search/elasticsearch/mapper/CaseDetailsMapper.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/search/elasticsearch/mapper/CaseDetailsMapper.java
@@ -3,12 +3,19 @@ package uk.gov.hmcts.ccd.domain.service.search.elasticsearch.mapper;
 import java.util.List;
 
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseDetails;
 import uk.gov.hmcts.ccd.domain.service.search.elasticsearch.dto.ElasticSearchCaseDetailsDTO;
 
 @Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE, componentModel = "spring")
 public interface CaseDetailsMapper {
+
+    String EMPTY_MAP = "java(new HashMap<>())";
+
+    @Mapping(source = "data", target = "data", defaultExpression = EMPTY_MAP)
+    @Mapping(source = "dataClassification", target = "dataClassification", defaultExpression = EMPTY_MAP)
+    CaseDetails dtoToCaseDetails(ElasticSearchCaseDetailsDTO caseDetailsDTO);
 
     List<CaseDetails> dtosToCaseDetailsList(List<ElasticSearchCaseDetailsDTO> caseDetailsDTOs);
 }

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/globalsearch/GlobalSearchParserTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/globalsearch/GlobalSearchParserTest.java
@@ -10,7 +10,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import uk.gov.hmcts.ccd.config.JacksonUtils;
 import uk.gov.hmcts.ccd.data.casedetails.SecurityClassification;
-import uk.gov.hmcts.ccd.data.user.UserRepository;
+import uk.gov.hmcts.ccd.domain.model.casedataaccesscontrol.AccessProfile;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseDetails;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseFieldDefinition;
 import uk.gov.hmcts.ccd.domain.model.definition.CaseTypeDefinition;
@@ -18,6 +18,7 @@ import uk.gov.hmcts.ccd.domain.model.definition.FieldTypeDefinition;
 import uk.gov.hmcts.ccd.domain.model.definition.JurisdictionDefinition;
 import uk.gov.hmcts.ccd.domain.model.search.global.Party;
 import uk.gov.hmcts.ccd.domain.model.search.global.SearchCriteria;
+import uk.gov.hmcts.ccd.domain.service.casedataaccesscontrol.CaseDataAccessControl;
 import uk.gov.hmcts.ccd.domain.service.common.CaseTypeService;
 import uk.gov.hmcts.ccd.domain.service.common.SecurityClassificationServiceImpl;
 
@@ -48,8 +49,10 @@ class GlobalSearchParserTest {
     private static final String ROLE_IN_USER_ROLES = "caseworker-probate-loa1";
     private static final String ROLE_IN_USER_ROLES_2 = "caseworker-divorce-loa";
     private static final String ROLE_IN_USER_ROLE_1 = "Role 1";
-    private static final Set<String> USER_ROLES = newHashSet(ROLE_IN_USER_ROLES,
-        ROLE_IN_USER_ROLES_2, ROLE_IN_USER_ROLE_1);
+    private static final Set<AccessProfile> USER_ACCESS_PROFILES = newHashSet(
+        new AccessProfile(ROLE_IN_USER_ROLES),
+        new AccessProfile(ROLE_IN_USER_ROLES_2),
+        new AccessProfile(ROLE_IN_USER_ROLE_1));
 
     private static final String CASE_TYPE_ID_1 = "CASE_TYPE_1";
     private static final String CASE_TYPE_ID_2 = "CASE_TYPE_2";
@@ -68,7 +71,7 @@ class GlobalSearchParserTest {
     private  CaseTypeDefinition caseTypeDefinition3;
 
     @Mock
-    private UserRepository userRepository;
+    private CaseDataAccessControl caseDataAccessControl;
     @Mock
     private CaseTypeService caseTypeService;
     @Mock
@@ -83,7 +86,7 @@ class GlobalSearchParserTest {
         Party party = new Party();
         party.setPartyName("name");
         parties = List.of(party);
-        doReturn(USER_ROLES).when(userRepository).getUserRoles();
+        doReturn(USER_ACCESS_PROFILES).when(caseDataAccessControl).generateAccessProfilesByCaseDetails(any());
 
         jurisdiction = new JurisdictionDefinition();
         jurisdiction.setId(JURISDICTION);
@@ -201,7 +204,8 @@ class GlobalSearchParserTest {
         when(caseTypeService.getCaseType(CASE_TYPE_ID_2)).thenReturn(caseTypeDefinition2);
         when(caseTypeService.getCaseType(CASE_TYPE_ID_3)).thenReturn(caseTypeDefinition3);
 
-        globalSearchParser = new GlobalSearchParser(userRepository, caseTypeService, securityClassificationService);
+        globalSearchParser =
+            new GlobalSearchParser(caseDataAccessControl, caseTypeService, securityClassificationService);
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CCD-3630


### Change description ###
Take access profiles into account with Global Search post-filtering

> NB: ES test PRs are:
> * hmcts/ccd-data-store-api#2081
> * hmcts/ccd-definition-store-api#1274
>
> **Both PRs above should be closed once this PR is merged**

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
