### PR TITLE
Revert "CCD-3436 CVE-2022-34305 tomcat upgrade 9.0.65, suppression removed"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -303,7 +303,9 @@ dependencyManagement {
         // Versions prior to 30.0 vulnerable to CVE-2020-8908
         dependency 'com.google.guava:guava:30.1-jre'
 
-        dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.65') {
+        // CVE-2019-0232 - Java and Command Line injections in Windows (updated to version 9.0.19)
+        // CVE-2021-42340 - Memory leak (updated to version 9.0.54)
+        dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.63') {
             entry 'tomcat-embed-core'
             entry 'tomcat-embed-el'
             entry 'tomcat-embed-websocket'

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -6,12 +6,14 @@
 		<notes>False Positives
 			CVE-2018-1258 https://tools.hmcts.net/jira/browse/CCD-765
 			CVE-2016-1000027 https://tools.hmcts.net/jira/browse/CCD-3255
+			CVE-2022-34305 refer https://tools.hmcts.net/jira/browse/CCD-3436
 			CVE-2022-22978 refer https://tools.hmcts.net/jira/browse/CCD-3513
 			CVE-2021-22112 refer https://tools.hmcts.net/jira/browse/CCD-3514
 			CVE-2022-22976 refer https://tools.hmcts.net/jira/browse/CCD-3515
 		</notes>
 		<cve>CVE-2018-1258</cve>
 		<cve>CVE-2016-1000027</cve>
+		<cve>CVE-2022-34305</cve>
 		<cve>CVE-2022-22978</cve>
 		<cve>CVE-2021-22112</cve>
 		<cve>CVE-2022-22976</cve>


### PR DESCRIPTION
Reverts hmcts/ccd-data-store-api#2087

created because failed FTs in master build 