### PR TITLE
CCD 3658 CVE 2022 25857 fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -173,7 +173,7 @@ dependencies {
     implementation group: 'io.springfox', name: 'springfox-boot-starter', version: swagger2Version
 
     compile "org.flywaydb:flyway-core:6.5.7"
-    compile group: 'org.yaml', name: 'snakeyaml', version: '1.26'
+    compile group: 'org.yaml', name: 'snakeyaml', version: '1.31'
     compile group: 'io.jsonwebtoken', name: 'jjwt', version:'0.9.1'
     compile group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '4.0.3'
     compile group: 'com.github.hmcts', name: 'idam-java-client', version: '2.0.1'

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -24,10 +24,8 @@
 	  <suppress>
 	    <notes>Temporary Suppression
 	      CVE-2021-22044 refer https://tools.hmcts.net/jira/browse/CCD-3509
-	      CVE-2022-25857 refer https://tools.hmcts.net/jira/browse/CCD-3658
 	    </notes>
 	    <cve>CVE-2021-22044</cve>
-	    <cve>CVE-2022-25857</cve>
 	  </suppress>
 	<!--End of temporary suppression section -->
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-3658

### Change description ###

CCD 3658 CVE 2022 25857 fix. Removed temporary suppressions and updated snakeyaml to 1.31

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
