### PR TITLE
Ccd 3675 updated

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -25,9 +25,15 @@
 	    <notes>Temporary Suppression
 	      CVE-2021-22044 refer https://tools.hmcts.net/jira/browse/CCD-3509
 	      CVE-2022-25857 refer https://tools.hmcts.net/jira/browse/CCD-3658
+		  CVE-2022-38751 refer https://tools.hmcts.net/jira/browse/CCD-3682
+		  CVE-2022-38750 refer https://tools.hmcts.net/jira/browse/CCD-3682
+		  CVE-2022-38749 refer https://tools.hmcts.net/jira/browse/CCD-3682
 	    </notes>
 	    <cve>CVE-2021-22044</cve>
 	    <cve>CVE-2022-25857</cve>
+		<cve>CVE-2022-38751</cve>
+		<cve>CVE-2022-38750</cve>
+		<cve>CVE-2022-38749</cve>
 	  </suppress>
 	<!--End of temporary suppression section -->
 

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/casedataaccesscontrol/DefaultCaseDataAccessControl.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/casedataaccesscontrol/DefaultCaseDataAccessControl.java
@@ -36,6 +36,7 @@ import uk.gov.hmcts.ccd.infrastructure.user.UserAuthorisation;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -44,6 +45,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static uk.gov.hmcts.ccd.data.caseaccess.GlobalCaseRole.CREATOR;
+import static uk.gov.hmcts.ccd.domain.service.common.AccessControlService.CAN_READ;
 
 @Component
 @ConditionalOnProperty(name = "enable-attribute-based-access-control", havingValue = "true")
@@ -53,6 +55,7 @@ public class DefaultCaseDataAccessControl implements NoCacheCaseDataAccessContro
     private final RoleAssignmentService roleAssignmentService;
     private final SecurityUtils securityUtils;
     private final RoleAssignmentsFilteringService roleAssignmentsFilteringService;
+    private final AccessControlService accessControlService;
     private final AccessProfileService accessProfileService;
     private final PseudoRoleAssignmentsGenerator pseudoRoleAssignmentsGenerator;
     private final ApplicationParams applicationParams;
@@ -64,24 +67,26 @@ public class DefaultCaseDataAccessControl implements NoCacheCaseDataAccessContro
 
     @Autowired
     public DefaultCaseDataAccessControl(RoleAssignmentService roleAssignmentService,
-                                                SecurityUtils securityUtils,
-                                                RoleAssignmentsFilteringService roleAssignmentsFilteringService,
-                                                PseudoRoleAssignmentsGenerator pseudoRoleAssignmentsGenerator,
-                                                ApplicationParams applicationParams,
-                                                AccessProfileService accessProfileService,
-                                                PseudoRoleToAccessProfileGenerator pseudoRoleToAccessProfileGenerator,
-                                                @Qualifier(CachedCaseDefinitionRepository.QUALIFIER)
+                                        SecurityUtils securityUtils,
+                                        RoleAssignmentsFilteringService roleAssignmentsFilteringService,
+                                        PseudoRoleAssignmentsGenerator pseudoRoleAssignmentsGenerator,
+                                        ApplicationParams applicationParams,
+                                        AccessControlService accessControlService,
+                                        AccessProfileService accessProfileService,
+                                        PseudoRoleToAccessProfileGenerator pseudoRoleToAccessProfileGenerator,
+                                        @Qualifier(CachedCaseDefinitionRepository.QUALIFIER)
                                             final CaseDefinitionRepository caseDefinitionRepository,
-                                                @Qualifier(CachedCaseDetailsRepository.QUALIFIER)
-                                                CaseDetailsRepository caseDetailsRepository,
-                                                UserAuthorisation userAuthorisation,
+                                        @Qualifier(CachedCaseDetailsRepository.QUALIFIER)
+                                            CaseDetailsRepository caseDetailsRepository,
+                                        UserAuthorisation userAuthorisation,
                                         @Qualifier(CachedCaseUserRepository.QUALIFIER)
-                                                CaseUserRepository caseUserRepository) {
+                                            CaseUserRepository caseUserRepository) {
         this.roleAssignmentService = roleAssignmentService;
         this.securityUtils = securityUtils;
         this.roleAssignmentsFilteringService = roleAssignmentsFilteringService;
         this.pseudoRoleAssignmentsGenerator = pseudoRoleAssignmentsGenerator;
         this.applicationParams = applicationParams;
+        this.accessControlService = accessControlService;
         this.accessProfileService = accessProfileService;
         this.pseudoRoleToAccessProfileGenerator = pseudoRoleToAccessProfileGenerator;
         this.caseDefinitionRepository = caseDefinitionRepository;
@@ -234,8 +239,9 @@ public class DefaultCaseDataAccessControl implements NoCacheCaseDataAccessContro
 
     private List<AccessProfile> generateAccessProfiles(List<RoleAssignment> filteredRoleAssignments,
                                                        CaseTypeDefinition caseTypeDefinition) {
-        List<RoleToAccessProfileDefinition> pseudoAccessProfilesMappings = new ArrayList<>();
-        pseudoAccessProfilesMappings.addAll(caseTypeDefinition.getRoleToAccessProfiles());
+        List<RoleToAccessProfileDefinition> pseudoAccessProfilesMappings =
+            new ArrayList<>(caseTypeDefinition.getRoleToAccessProfiles());
+
         if (pseudoAccessProfilesMappings.isEmpty()) {
             List<RoleToAccessProfileDefinition> generated =
                 pseudoRoleToAccessProfileGenerator.generate(caseTypeDefinition);
@@ -292,7 +298,7 @@ public class DefaultCaseDataAccessControl implements NoCacheCaseDataAccessContro
                     roleAssignmentService.getRoleAssignments(securityUtils.getUserId()),
                     caseDetails.get());
 
-            populateCaseAccessMetadata(caseAccessMetadata, filteredRoleAssignments);
+            populateCaseAccessMetadata(caseDetails.get(), caseAccessMetadata, filteredRoleAssignments);
         }
         return caseAccessMetadata;
     }
@@ -345,13 +351,15 @@ public class DefaultCaseDataAccessControl implements NoCacheCaseDataAccessContro
             .collect(Collectors.toSet());
     }
 
-    private void populateCaseAccessMetadata(CaseAccessMetadata caseAccessMetadata,
+    private void populateCaseAccessMetadata(CaseDetails caseDetails,
+                                            CaseAccessMetadata caseAccessMetadata,
                                             FilteredRoleAssignments filteredRoleAssignments) {
         List<RoleAssignment> pseudoRoleAssignments
             = appendGeneratedPseudoRoleAssignments(filteredRoleAssignments.getFilteredMatchingRoleAssignments());
 
         caseAccessMetadata.setAccessGrants(generatePostFilteringAccessGrants(pseudoRoleAssignments));
         caseAccessMetadata.setAccessProcess(generatePostFilteringAccessProcess(
+            caseDetails,
             filteredRoleAssignments,
             pseudoRoleAssignments));
     }
@@ -365,25 +373,47 @@ public class DefaultCaseDataAccessControl implements NoCacheCaseDataAccessContro
         return filteringResults;
     }
 
-    private AccessProcess generatePostFilteringAccessProcess(FilteredRoleAssignments filteredRoleAssignments,
-                                                             List<RoleAssignment> pseudoGeneratedRoleAssignments) {
-        boolean userHasAccessToCase = pseudoGeneratedRoleAssignments.stream()
-            .map(roleAssignment -> GrantType.valueOf(roleAssignment.getGrantType()))
-            .anyMatch(DefaultCaseDataAccessControl::isUserAllowedAccessToCase);
+    private AccessProcess generatePostFilteringAccessProcess(CaseDetails caseDetails,
+                                                             FilteredRoleAssignments filteredRoleAssignments,
+                                                             List<RoleAssignment> matchingAndPsuedoRoleAssignments) {
+        boolean userHasAccessToCase = userHasAccessToCaseWithGivenRoleAssignments(
+            caseDetails,
+            matchingAndPsuedoRoleAssignments
+        );
 
         if (userHasAccessToCase) {
             return AccessProcess.NONE;
-        } else if (!filteredRoleAssignments.getFilteredRoleAssignmentsFailedOnRegionOrBaseLocationMatcher().isEmpty()) {
+        } else if (// retry using just those RoleAssignments that failed ONLY on region/baseLocation
+            userHasAccessToCaseWithGivenRoleAssignments(
+                caseDetails,
+                filteredRoleAssignments.getFilteredRoleAssignmentsFailedOnRegionOrBaseLocationMatcher()
+            )
+        ) {
             return AccessProcess.CHALLENGED;
         } else {
             return AccessProcess.SPECIFIC;
         }
     }
 
-    private static boolean isUserAllowedAccessToCase(GrantType grantType) {
-        return grantType.equals(GrantType.STANDARD)
-            || grantType.equals(GrantType.SPECIFIC)
-            || grantType.equals(GrantType.CHALLENGED);
+    private boolean userHasAccessToCaseWithGivenRoleAssignments(CaseDetails caseDetails,
+                                                                List<RoleAssignment> roleAssignments) {
+        List<RoleAssignment> roleAssignmentsOfInterest = roleAssignments.stream()
+            .filter(DefaultCaseDataAccessControl::isRoleAssignmentsOfInterestToAccessProcessCheck)
+            .collect(Collectors.toList());
+
+        CaseTypeDefinition caseType = caseDefinitionRepository.getCaseType(caseDetails.getCaseTypeId());
+        Set<AccessProfile> accessProfiles = new HashSet<>(generateAccessProfiles(roleAssignmentsOfInterest, caseType));
+
+        String caseState = caseDetails.getState();
+
+        return accessControlService.canAccessCaseTypeWithCriteria(caseType, accessProfiles, CAN_READ)
+            && accessControlService.canAccessCaseStateWithCriteria(caseState, caseType, accessProfiles, CAN_READ);
+    }
+
+    private static boolean isRoleAssignmentsOfInterestToAccessProcessCheck(RoleAssignment roleAssignment) {
+        return roleAssignment.getGrantType().equals(GrantType.STANDARD.name())
+            || roleAssignment.getGrantType().equals(GrantType.SPECIFIC.name())
+            || roleAssignment.getGrantType().equals(GrantType.CHALLENGED.name());
     }
 
     private List<GrantType> generatePostFilteringAccessGrants(List<RoleAssignment> roleAssignments) {

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/casedataaccesscontrol/RoleAssignmentFilteringResult.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/casedataaccesscontrol/RoleAssignmentFilteringResult.java
@@ -16,7 +16,9 @@ public class RoleAssignmentFilteringResult {
 
     private static boolean isRegionOrLocationFilteringResult(Map.Entry<String, Boolean> mapEntry) {
         return mapEntry.getKey().equals(RegionMatcher.class.getSimpleName())
-            || mapEntry.getKey().equals(LocationMatcher.class.getSimpleName());
+            || mapEntry.getKey().equals(RegionMatcher.class.getName())
+            || mapEntry.getKey().equals(LocationMatcher.class.getSimpleName())
+            || mapEntry.getKey().equals(LocationMatcher.class.getName());
     }
 
     public boolean hasPassedFiltering() {

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/casedataaccesscontrol/RoleAssignmentFilteringResultTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/casedataaccesscontrol/RoleAssignmentFilteringResultTest.java
@@ -2,6 +2,8 @@ package uk.gov.hmcts.ccd.domain.service.casedataaccesscontrol;
 
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.ccd.domain.model.casedataaccesscontrol.RoleAssignment;
+import uk.gov.hmcts.ccd.domain.model.casedataaccesscontrol.matcher.LocationMatcher;
+import uk.gov.hmcts.ccd.domain.model.casedataaccesscontrol.matcher.RegionMatcher;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -127,5 +129,23 @@ class RoleAssignmentFilteringResultTest {
             new RoleAssignmentFilteringResult(roleAssignment, filteringResults);
 
         assertFalse(roleAssignmentFilteringResult.hasFailedFilteringOnRegionAndBaseLocation());
+    }
+
+    @Test
+    void hasFailedFilteringBasedOnRegionAndLocationReturnsTrueWhenUsingOtherNames() {
+        Map<String, Boolean> filteringResults = new HashMap<>();
+
+        filteringResults.put("roleMatcher1", Boolean.TRUE);
+        filteringResults.put(RegionMatcher.class.getSimpleName(), Boolean.FALSE);
+        filteringResults.put(RegionMatcher.class.getName(), Boolean.FALSE);
+        filteringResults.put("roleMatcher3", Boolean.TRUE);
+        filteringResults.put("roleMatcher4", Boolean.TRUE);
+        filteringResults.put(LocationMatcher.class.getSimpleName(), Boolean.FALSE);
+        filteringResults.put(LocationMatcher.class.getName(), Boolean.FALSE);
+
+        RoleAssignmentFilteringResult roleAssignmentFilteringResult =
+            new RoleAssignmentFilteringResult(roleAssignment, filteringResults);
+
+        assertTrue(roleAssignmentFilteringResult.hasFailedFilteringOnRegionAndBaseLocation());
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

   [CCD-3675](https://tools.hmcts.net/jira/browse/CCD-3675) _"CCD-3675 Global Search - Access Process should take into account mapped access profiles"_

### Change description ###

Global Search - Access Process should take into account mapped access profiles

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
