### PR TITLE
CCD-3736: Suppress CVE-2022-38752

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -27,11 +27,13 @@
 		  CVE-2022-38751 refer https://tools.hmcts.net/jira/browse/CCD-3682
 		  CVE-2022-38750 refer https://tools.hmcts.net/jira/browse/CCD-3682
 		  CVE-2022-38749 refer https://tools.hmcts.net/jira/browse/CCD-3682
+		  CVE-2022-38752 refer https://tools.hmcts.net/jira/browse/CCD-3736
 	    </notes>
 	    <cve>CVE-2022-25857</cve>
 		<cve>CVE-2022-38751</cve>
 		<cve>CVE-2022-38750</cve>
 		<cve>CVE-2022-38749</cve>
+		<cve>CVE-2022-38752</cve>
 	  </suppress>
 	<!--End of temporary suppression section -->
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-3736 (https://tools.hmcts.net/jira/browse/CCD-3736)


### Change description ###
Updated suppressions file to temporarily suppress CVE-2022-38752 pending fix.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
