### PR TITLE
CCD-4128: NullPointerException on calling getCategoriesAndDocuments

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -15,8 +15,12 @@
   <suppress>
     <notes>Temporary Suppression
         CVE-2021-37533 refer [Ticket]
-        CVE-2021-4277 refer [Ticket]</notes>
+        CVE-2021-4277 refer [Ticket]
+        CVE-2022-3064 refer [Ticket]
+        CVE-2021-4235 refer [Ticket]</notes>
     <cve>CVE-2021-37533</cve>
     <cve>CVE-2021-4277</cve>
+    <cve>CVE-2022-3064</cve>
+    <cve>CVE-2021-4235</cve>
   </suppress>
 </suppressions>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -16,7 +16,7 @@
     <notes>Temporary Suppression
         CVE-2021-37533 refer [Ticket]
         CVE-2021-4277 refer [Ticket]
-	      CVE-2022-3064 refer https://tools.hmcts.net/jira/browse/CCD-4157
+	CVE-2022-3064 refer https://tools.hmcts.net/jira/browse/CCD-4157
         CVE-2021-4235 refer https://tools.hmcts.net/jira/browse/CCD-4157</notes>
     <cve>CVE-2021-37533</cve>
     <cve>CVE-2021-4277</cve>

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/casefileview/CategoriesAndDocumentsService.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/casefileview/CategoriesAndDocumentsService.java
@@ -18,6 +18,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -139,6 +140,7 @@ public class CategoriesAndDocumentsService {
 
         return caseFieldExtracts.stream()
             .map(caseFieldExtract -> transformDocument(caseFieldExtract, caseData))
+            .filter(Objects::nonNull)
             .collect(Collectors.groupingBy(tuple -> tuple._1,
                 collectingAndThen(toUnmodifiableList(), DOCUMENTS_FUNCTION)));
     }
@@ -147,6 +149,10 @@ public class CategoriesAndDocumentsService {
                                                          @NonNull final Map<String, JsonNode> caseData) {
         final Tuple2<String, Map<String, String>> documentNode =
             fileViewDocumentService.getDocumentNode(caseFieldMetadata.getPath(), caseData);
+
+        if (documentNode._2 == null) {
+            return null;
+        }
 
         final Document document = buildDocument(documentNode._1, documentNode._2);
 

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/casefileview/CategoriesAndDocumentsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/casefileview/CategoriesAndDocumentsServiceTest.java
@@ -148,6 +148,22 @@ class CategoriesAndDocumentsServiceTest extends TestFixtures {
     }
 
     @Test
+    void testShouldTransformNullDocumentToNull() throws Exception {
+        final CaseFieldMetadata caseFieldExtract = new CaseFieldMetadata("draftOrderDoc", null);
+        final Tuple2<String, Map<String, String>> documentNode = new Tuple2<>(
+            "draftOrderDoc",
+            null
+        );
+
+        final Map<String, JsonNode> caseData =
+            loadCaseDataFromJson(String.format("tests/%s", "CaseDataExtractorDocumentData.json"));
+        doReturn(documentNode).when(fileViewDocumentService).getDocumentNode(caseFieldExtract.getPath(), caseData);
+
+        final Tuple2<String, Optional<Document>> actualResult = underTest.transformDocument(caseFieldExtract, caseData);
+        assertThat(actualResult).isNull();
+    }
+
+    @Test
     void testBuildCategorisedDocumentDictionary() throws Exception {
         final List<Document> expectedDocuments = getExpectedDocumentsForDocumentDictionary();
         final String documentType = "Document";


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/CCD-4128

### Change description ###
Transform document node containing null caseData to null.

**Does this PR introduce a breaking change?**
```
[ ] Yes
[x] No
```