### PR TITLE
CCD-4233 CVE-2022-45143 Upgrade Tomcat to 9.0.69, suppression removed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -305,7 +305,7 @@ dependencyManagement {
         // Versions prior to 30.0 vulnerable to CVE-2020-8908
         dependency 'com.google.guava:guava:30.1-jre'
 
-        dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.68') {
+        dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.69') {
             entry 'tomcat-embed-core'
             entry 'tomcat-embed-el'
             entry 'tomcat-embed-websocket'

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress>
-     <notes>Temporary Suppression
-         CVE-2022-36437 refer https://tools.hmcts.net/jira/browse/CCD-4207 </notes>
-     <cve>CVE-2022-36437</cve>
-   </suppress>
+    <notes>Temporary Suppression
+        CVE-2022-36437 refer https://tools.hmcts.net/jira/browse/CCD-4207 </notes>
+    <cve>CVE-2022-36437</cve>
+  </suppress>
 </suppressions>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -5,12 +5,10 @@
         CVE-2021-4277 refer [Ticket]
 	CVE-2022-3064 refer https://tools.hmcts.net/jira/browse/CCD-4157
         CVE-2021-4235 refer https://tools.hmcts.net/jira/browse/CCD-4157
-        CVE-2022-36437 refer [Ticket]
-        CVE-2022-45143 refer [Ticket]</notes>
+        CVE-2022-36437 refer [Ticket]</notes>
     <cve>CVE-2021-4277</cve>
     <cve>CVE-2022-3064</cve>
     <cve>CVE-2021-4235</cve>
     <cve>CVE-2022-36437</cve>
-    <cve>CVE-2022-45143</cve>
   </suppress>
 </suppressions>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -1,3 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-
+  <suppress>
+     <notes>Temporary Suppression
+         CVE-2022-36437 refer https://tools.hmcts.net/jira/browse/CCD-4207 </notes>
+     <cve>CVE-2022-36437</cve>
+   </suppress>
 </suppressions>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?><suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress>
     <notes>Temporary Suppression
-        CVE-2021-37533 refer [Ticket]
-        CVE-2021-4277 refer [Ticket]
-	CVE-2022-3064 refer https://tools.hmcts.net/jira/browse/CCD-4157
+        CVE-2021-4277 refer https://tools.hmcts.net/jira/browse/CCD-4148
+	    CVE-2022-3064 refer https://tools.hmcts.net/jira/browse/CCD-4157
         CVE-2021-4235 refer https://tools.hmcts.net/jira/browse/CCD-4157
-        CVE-2022-36437 refer [Ticket]</notes>
+        CVE-2022-36437 refer https://tools.hmcts.net/jira/browse/CCD-4207</notes>
     <cve>CVE-2021-4277</cve>
     <cve>CVE-2022-3064</cve>
     <cve>CVE-2021-4235</cve>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-4233
CVE-2022-45143 Upgrade Tomcat to 9.0.69, suppression removed

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
