### PR TITLE
CCD-4476 : replace reform-api-docs with cnp-api-docs

### DIFF
--- a/.github/workflows/publish-swagger-specs.yml
+++ b/.github/workflows/publish-swagger-specs.yml
@@ -28,7 +28,7 @@ jobs:
           git init
           git config user.email "github-actions@users.noreply.github.com"
           git config user.name "GitHub action"
-          git remote add upstream "https://jenkins-reform-hmcts:${{ secrets.GH_TOKEN }}@github.com/hmcts/reform-api-docs.git"
+          git remote add upstream "https://jenkins-reform-hmcts:${{ secrets.GH_TOKEN }}@github.com/hmcts/cnp-api-docs.git"
           git pull upstream master
           repo=`echo "$GITHUB_REPOSITORY" | cut -f2- -d/`
           echo "$(cat /tmp/ccd-data-store-api.v1_internal.json)" > "docs/specs/ccd-data-store-api.v1_internal.json"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
     - MAX_NUM_PARALLEL_THREADS=2
 
 before_install:
-  - curl https://raw.githubusercontent.com/hmcts/reform-api-docs/master/bin/publish-swagger-group-docs.sh > publish-swagger-group-docs.sh
+  - curl https://raw.githubusercontent.com/hmcts/cnp-api-docs/master/bin/publish-swagger-group-docs.sh > publish-swagger-group-docs.sh
 
 after_success:
   - 'bash <(curl -s https://codecov.io/bash) || echo "Codecov failed to upload"'

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # ccd-data-store-api 
-[![API v1_internal](https://img.shields.io/badge/API%20Docs-v1_internal-e140ad.svg)](https://hmcts.github.io/reform-api-docs/swagger.html?url=https://hmcts.github.io/reform-api-docs/specs/ccd-data-store-api.v1_internal.json)
-[![API v1_external](https://img.shields.io/badge/API%20Docs-v1_external-e140ad.svg)](https://hmcts.github.io/reform-api-docs/swagger.html?url=https://hmcts.github.io/reform-api-docs/specs/ccd-data-store-api.v1_external.json)
-[![API v2_internal (beta)](https://img.shields.io/badge/API%20Docs-v2_internal%20%28beta%29-4286f4.svg)](https://hmcts.github.io/reform-api-docs/swagger.html?url=https://hmcts.github.io/reform-api-docs/specs/ccd-data-store-api.v2_internal.json)
-[![API v2_external (beta)](https://img.shields.io/badge/API%20Docs-v2_external%20%28beta%29-4286f4.svg)](https://hmcts.github.io/reform-api-docs/swagger.html?url=https://hmcts.github.io/reform-api-docs/specs/ccd-data-store-api.v2_external.json)
+[![API v1_internal](https://img.shields.io/badge/API%20Docs-v1_internal-e140ad.svg)](https://hmcts.github.io/cnp-api-docs/swagger.html?url=https://hmcts.github.io/cnp-api-docs/specs/ccd-data-store-api.v1_internal.json)
+[![API v1_external](https://img.shields.io/badge/API%20Docs-v1_external-e140ad.svg)](https://hmcts.github.io/cnp-api-docs/swagger.html?url=https://hmcts.github.io/cnp-api-docs/specs/ccd-data-store-api.v1_external.json)
+[![API v2_internal (beta)](https://img.shields.io/badge/API%20Docs-v2_internal%20%28beta%29-4286f4.svg)](https://hmcts.github.io/cnp-api-docs/swagger.html?url=https://hmcts.github.io/cnp-api-docs/specs/ccd-data-store-api.v2_internal.json)
+[![API v2_external (beta)](https://img.shields.io/badge/API%20Docs-v2_external%20%28beta%29-4286f4.svg)](https://hmcts.github.io/cnp-api-docs/swagger.html?url=https://hmcts.github.io/cnp-api-docs/specs/ccd-data-store-api.v2_external.json)
 [![Build Status](https://travis-ci.org/hmcts/ccd-data-store-api.svg?branch=master)](https://travis-ci.org/hmcts/ccd-data-store-api)
 [![Docker Build Status](https://img.shields.io/docker/build/hmcts/ccd-data-store-api.svg)](https://hub.docker.com/r/hmcts/ccd-data-store-api)
 [![codecov](https://codecov.io/gh/hmcts/ccd-data-store-api/branch/master/graph/badge.svg)](https://codecov.io/gh/hmcts/ccd-data-store-api)

--- a/src/aat/resources/features/F-125 - Swagger Pages and API Specs/F-125_Swagger_JSON.td.json
+++ b/src/aat/resources/features/F-125 - Swagger Pages and API Specs/F-125_Swagger_JSON.td.json
@@ -6,7 +6,7 @@
   "operationName": "Get Swagger JSON",
 
   "method": "GET",
-  "uri": "https://hmcts.github.io/reform-api-docs/specs/{ccd-data-store-api-version}",
+  "uri": "https://hmcts.github.io/cnp-api-docs/specs/{ccd-data-store-api-version}",
 
   "expectedResponse": {
     "headers" : {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-4476

### Change description ###

CCD-4476 : replace reform-api-docs with cnp-api-docs

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
