### PR TITLE
CCD-4412: Deprecated usage of '.internal' URLs for preview and AAT Staging in CCD repos

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -90,10 +90,10 @@ def vaultOverrides = [
 ]
 // vars needed for functional tests
 // Other env variables needed for BEFTA.
-env.DM_STORE_BASE_URL = "http://dm-store-aat.service.core-compute-aat.internal"
+env.DM_STORE_BASE_URL = "http://dm-store-aat.aat.platform.hmcts.net"
 env.CASE_DOCUMENT_AM_URL = "http://ccd-case-document-am-api-aat.service.core-compute-aat.internal"
-env.RD_LOCATION_REF_API_BASE_URL = "http://rd-location-ref-api-aat.service.core-compute-aat.internal"
-env.RD_PROFESSIONAL_API_BASE_URL = "http://rd-professional-api-aat.service.core-compute-aat.internal"
+env.RD_LOCATION_REF_API_BASE_URL = "http://rd-location-ref-api-aat.aat.platform.hmcts.net"
+env.RD_PROFESSIONAL_API_BASE_URL = "http://rd-professional-api-aat.aat.platform.hmcts.net"
 env.BEFTA_RESPONSE_HEADER_CHECK_POLICY="JUST_WARN"
 env.ELASTIC_SEARCH_FTA_ENABLED = "false"
 env.PACT_BROKER_FULL_URL = "https://pact-broker.platform.hmcts.net"
@@ -104,7 +104,7 @@ env.DEFAULT_COLLECTION_ASSERTION_MODE="UNORDERED"
 env.MAX_NUM_PARALLEL_THREADS=6
 env.BEFTA_S2S_CLIENT_ID = "ccd_gw"
 env.ROLE_ASSIGNMENT_API_GATEWAY_S2S_CLIENT_ID = "ccd_data"
-env.BEFTA_TEST_STUB_SERVICE_BASE_URL = "http://ccd-test-stubs-service-aat.service.core-compute-aat.internal"
+env.BEFTA_TEST_STUB_SERVICE_BASE_URL = "http://ccd-test-stubs-service-aat.aat.platform.hmcts.net"
 env.BEFTA_S2S_CLIENT_ID_OF_CCD_DATA = "ccd_data"
 env.BEFTA_S2S_CLIENT_ID_OF_XUI_WEBAPP = "xui_webapp"
 
@@ -137,7 +137,7 @@ withPipeline(type, product, component) {
     // Check if the build should be wired to an environment higher than 'preview'.
     if (env.BRANCH_NAME == 'master' || env.BRANCH_NAME == 'demo' || env.BRANCH_NAME == 'perftest' || env.BRANCH_NAME == 'ithc' || prsToUseAat.toLowerCase().contains(env.BRANCH_NAME.toLowerCase())) {
         env.ELASTIC_SEARCH_FTA_ENABLED = "true"
-        env.DEFINITION_STORE_HOST = "http://ccd-definition-store-api-aat.service.core-compute-aat.internal"
+        env.DEFINITION_STORE_HOST = "http://ccd-definition-store-api-aat.aat.platform.hmcts.net"
     } else {
         env.DEFINITION_STORE_URL_BASE = "https://ccd-definition-store-api-${definitionStoreDevelopPr}.service.core-compute-preview.internal".toLowerCase()
         env.DEFINITION_STORE_HOST = env.DEFINITION_STORE_URL_BASE

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -80,21 +80,21 @@ def vaultOverrides = [
 ]
 // vars needed for functional tests
 // Assume a feature build branched off 'develop', with dependencies develop-to-develop.
-env.TEST_URL = "http://ccd-data-store-api-aat.service.core-compute-aat.internal"
+env.TEST_URL = "http://ccd-data-store-api-aat.aat.platform.hmcts.net"
 
 // Other env variables needed for BEFTA.
 env.BEFTA_S2S_CLIENT_ID = "ccd_gw"
 env.ROLE_ASSIGNMENT_API_GATEWAY_S2S_CLIENT_ID = "ccd_data"
 env.BEFTA_S2S_CLIENT_ID_OF_CCD_DATA = "ccd_data"
-env.DM_STORE_BASE_URL = "http://dm-store-aat.service.core-compute-aat.internal"
+env.DM_STORE_BASE_URL = "http://dm-store-aat.aat.platform.hmcts.net"
 env.CASE_DOCUMENT_AM_URL = "http://ccd-case-document-am-api-aat.service.core-compute-aat.internal"
-env.RD_LOCATION_REF_API_BASE_URL = "http://rd-location-ref-api-aat.service.core-compute-aat.internal"
-env.RD_PROFESSIONAL_API_BASE_URL = "http://rd-professional-api-aat.service.core-compute-aat.internal"
+env.RD_LOCATION_REF_API_BASE_URL = "http://rd-location-ref-api-aat.aat.platform.hmcts.net"
+env.RD_PROFESSIONAL_API_BASE_URL = "http://rd-professional-api-aat.aat.platform.hmcts.net"
 env.BEFTA_RESPONSE_HEADER_CHECK_POLICY="JUST_WARN" // Temporary workaround for platform changes: turn BEFTA header checks to warning mode
 env.ELASTIC_SEARCH_FTA_ENABLED = "true"
 env.DEFAULT_COLLECTION_ASSERTION_MODE="UNORDERED"
-env.BEFTA_TEST_STUB_SERVICE_BASE_URL = "http://ccd-test-stubs-service-aat.service.core-compute-aat.internal"
-env.DEFINITION_STORE_HOST = "http://ccd-definition-store-api-aat.service.core-compute-aat.internal"
+env.BEFTA_TEST_STUB_SERVICE_BASE_URL = "http://ccd-test-stubs-service-aat.aat.platform.hmcts.net"
+env.DEFINITION_STORE_HOST = "http://ccd-definition-store-api-aat.aat.platform.hmcts.net"
 
 withNightlyPipeline(type, product, component) {
     overrideVaultEnvironments(vaultOverrides)


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/CCD-4412

### Change description ###
Replacing deprecated internal URLss with up to date versions in Jenkinsfile_CNP and Jenkinsfile_nightly.

**Does this PR introduce a breaking change?**
```
[ ] Yes
[x] No
```