### PR TITLE
CCD-4559: ccd-data-store-api-pr-1260 failing with error resource mapping not found for name: “ccd-data-store-api-pr-1260-logstash-pdb”

### DIFF
--- a/charts/ccd-data-store-api/Chart.yaml
+++ b/charts/ccd-data-store-api/Chart.yaml
@@ -2,7 +2,7 @@ description: Helm chart for the HMCTS CCD Data Store
 name: ccd-data-store-api
 apiVersion: v2
 home: https://github.com/hmcts/ccd-data-store-api
-version: 2.0.20
+version: 2.0.21
 maintainers:
   - name: HMCTS CCD Dev Team
     email: ccd-devops@HMCTS.NET
@@ -15,6 +15,6 @@ dependencies:
     repository: 'https://helm.elastic.co'
     condition: elastic.enabled
   - name: logstash
-    version: 6.8.22
+    version: 7.17.3
     repository: 'https://helm.elastic.co'
     condition: elastic.enabled


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/CCD-4559

### Change description ###
Update logstash chart version.

**Does this PR introduce a breaking change?**
```
[ ] Yes
[x] No
```