### PR TITLE
CCD-4739 : Fix CVE-2023-20863 (bumped versions for springframework and springsecurity)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        springBootVersion = '2.6.10'
+        springBootVersion = '2.7.11'
     }
     dependencies {
         classpath 'org.jsonschema2pojo:jsonschema2pojo-gradle-plugin:1.1.1'
@@ -48,8 +48,8 @@ apply from: './gradle/suppress.gradle'
 def versions = [
         pact_version    : '4.1.7',
 ]
-ext['spring-security.version'] = '5.6.9'
-ext['spring-framework.version'] = '5.3.26'
+ext['spring-security.version'] = '5.7.8'
+ext['spring-framework.version'] = '5.3.27'
 ext['jackson.version'] = '2.14.1'
 
 

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -3,13 +3,12 @@
     <notes>Temporary Suppression
         CVE-2022-45688 refer https://tools.hmcts.net/jira/browse/CCD-4373
         CVE-2022-1471 refer https://tools.hmcts.net/jira/browse/CCD-4454
-        CVE-2023-20863 refer [Ticket]
         CVE-2023-33264 refer [Ticket]
         CVE-2023-28709 refer [Ticket]
-        CVE-2023-20883 refer [Ticket]</notes>
+        CVE-2023-20883 refer [Ticket]
+    </notes>
     <cve>CVE-2022-45688</cve>
     <cve>CVE-2022-1471</cve>
-    <cve>CVE-2023-20863</cve>
     <cve>CVE-2023-33264</cve>
     <cve>CVE-2023-28709</cve>
     <cve>CVE-2023-20883</cve>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-4739

### Change description ###

CCD-4739 : Fix CVE-2023-20863 (bumped versions for springframework and springsecurity)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
