### PR TITLE
Fix Pact verification publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -872,7 +872,9 @@ task runProviderPactVerification(type:Test) {
     useJUnitPlatform()
     testClassesDirs = sourceSets.contractTest.output.classesDirs
     classpath = sourceSets.contractTest.runtimeClasspath
-    systemProperty 'pact.verifier.publishResults', System.getProperty('pact.verifier.publishResults')
+    if (project.hasProperty('pact.verifier.publishResults')) {
+        systemProperty 'pact.verifier.publishResults', project.property('pact.verifier.publishResults')
+    }
     systemProperty 'pact.provider.version', project.pactVersion
     include "uk/gov/hmcts/ccd/v2/external/controller/**"
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFR-2413


### Change description ###
Pact verification results are not being published on the Pact Broker due to incorrect configuration in build.gradle.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
