### PR TITLE
GA-168 Feature fixes for expecting "organisationStatus" and "organisationPro…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ ext {
             'class'      : 98
     ]
     springCloudVersion = '2021.0.3'
-    beftaFwVersion = '8.8.0'
+    beftaFwVersion = '8.8.3'
 }
 
 java {
@@ -267,7 +267,7 @@ dependencies {
     implementation 'org.jooq:jool-java-8:0.9.14'
     implementation 'com.github.hmcts:ccd-case-document-am-client:1.7.1'
 
-    testImplementation group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.19.12'
+    testImplementation group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.21.3'
 
     testImplementation group: 'com.github.hmcts', name: 'befta-fw', version: beftaFwVersion
     testRuntimeOnly group: 'com.github.hmcts', name: 'befta-fw', version: beftaFwVersion

--- a/src/aat/resources/features/F-105 - Add Case-Assigned Users and Roles/With Organisation Context/common/F-105_Get_Organisation_Identifier_Base.td.json
+++ b/src/aat/resources/features/F-105 - Add Case-Assigned Users and Roles/With Organisation Context/common/F-105_Get_Organisation_Identifier_Base.td.json
@@ -31,7 +31,9 @@
     },
     "body": {
       "organisationIdentifier": "[[ANYTHING_PRESENT]]",
-      "users": "[[ANYTHING_PRESENT]]"
+      "users": "[[ANYTHING_PRESENT]]",
+      "organisationStatus": "[[ANYTHING_PRESENT]]",
+      "organisationProfileIds": "[[ANYTHING_PRESENT]]"
     }
   }
 }

--- a/src/aat/resources/features/F-111 - Remove Case-Assigned Users and Roles/With Organisation Context/common/common/F-111_Get_Organisation_Identifier_Base.td.json
+++ b/src/aat/resources/features/F-111 - Remove Case-Assigned Users and Roles/With Organisation Context/common/common/F-111_Get_Organisation_Identifier_Base.td.json
@@ -31,7 +31,9 @@
     },
     "body": {
       "organisationIdentifier": "[[ANYTHING_PRESENT]]",
-      "users": "[[ANYTHING_PRESENT]]"
+      "users": "[[ANYTHING_PRESENT]]",
+      "organisationStatus": "[[ANYTHING_PRESENT]]",
+      "organisationProfileIds": "[[ANYTHING_PRESENT]]"
     }
   }
 }


### PR DESCRIPTION
…fileIds" in response for some of the tests calling http://rd-professional-api-aat.service.core-compute-aat.internal/refdata/external/v1/organisations/users.

**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] the `keep-helm` label has been added, if the helm release should be persisted after a successful build

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
