### PR TITLE
Fix CVE-2023-41080 : Update org.apache.tomcat.embed to 9.0.82

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -357,7 +357,8 @@ dependencyManagement {
         // Versions prior to 30.0 vulnerable to CVE-2020-8908
         dependency 'com.google.guava:guava:32.1.2-jre'
 
-        dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.75') {
+        // CVE-2023-41080
+        dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.82') {
             entry 'tomcat-embed-core'
             entry 'tomcat-embed-el'
             entry 'tomcat-embed-websocket'

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -1,30 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?><suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress>
     <notes>Temporary Suppression
-        CVE-2023-2976  refer https://tools.hmcts.net/jira/browse/CCD-4967
-        CVE-2023-34036 refer https://tools.hmcts.net/jira/browse/CCD-4968
-        CVE-2023-20873 refer https://tools.hmcts.net/jira/browse/CCD-4604
-        CVE-2023-41080 refer https://tools.hmcts.net/jira/browse/CCD-4972
-        CVE-2023-42794 refer https://tools.hmcts.net/jira/browse/CCD-4973
-        CVE-2023-42795 refer https://tools.hmcts.net/jira/browse/CCD-4973
-        CVE-2023-45648 refer https://tools.hmcts.net/jira/browse/CCD-4973
-        CVE-2023-44487 refer https://tools.hmcts.net/jira/browse/CCD-4974
-        CVE-2023-34055 refer [Ticket]
-        CVE-2023-46589 refer [Ticket]
-        CVE-2023-6378  refer [Ticket]
         CVE-2023-35116 refer [Ticket]
-        CVE-2023-34042 refer [Ticket]</notes>
-    <cve>CVE-2023-34036</cve>
-    <cve>CVE-2023-20873</cve>
-    <cve>CVE-2023-41080</cve>
-    <cve>CVE-2023-42794</cve>
-    <cve>CVE-2023-42795</cve>
-    <cve>CVE-2023-45648</cve>
-    <cve>CVE-2023-44487</cve>
-    <cve>CVE-2023-34055</cve>
-    <cve>CVE-2023-46589</cve>
-    <cve>CVE-2023-6378</cve>
+        CVE-2023-6378 refer [Ticket]
+        CVE-2023-34055 refer [Ticket]
+        CVE-2023-20873 refer [Ticket]
+        CVE-2023-34036 refer [Ticket]
+        CVE-2023-34042 refer [Ticket]
+        CVE-2023-46589 refer [Ticket]</notes>
     <cve>CVE-2023-35116</cve>
+    <cve>CVE-2023-6378</cve>
+    <cve>CVE-2023-34055</cve>
+    <cve>CVE-2023-20873</cve>
+    <cve>CVE-2023-34036</cve>
     <cve>CVE-2023-34042</cve>
+    <cve>CVE-2023-46589</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-4972
Fix CVE-2023-41080 : Update org.apache.tomcat.embed to 9.0.82


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
