### PR TITLE
Hardcoding memory allocation of higher value due to pipeline failure

### DIFF
--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -4,7 +4,7 @@ database_sku_capacity = "32"
 database_storage_mb   = "2048000"
 
 pgsql_sku        = "MO_Standard_E16ds_v4"
-pgsql_storage_mb = 2097152
+pgsql_storage_mb = 4193280
 auto_grow_enabled = true
 subnet_suffix = "expanded"
 


### PR DESCRIPTION
https://build.hmcts.net/view/CDM/job/HMCTS_a_to_c/job/ccd-data-store-api/job/master/520/execution/node/606/log/

1m1 error occurred:
* 'storage_mb' can only be scaled up, expected the new 'storage_mb' value (2097152) to be larger than the previous 'storage_mb' value (4193280)

### Change description ###

Therefore hardcoding a higher value in order to overcome pipeline error 

