### PR TITLE
CCD-5408 - Use same `DateTimeValidator` formatter with CFV

### DIFF
--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/casefileview/CategoriesAndDocumentsService.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/casefileview/CategoriesAndDocumentsService.java
@@ -14,7 +14,6 @@ import uk.gov.hmcts.ccd.domain.service.common.CaseDataExtractor;
 import uk.gov.hmcts.ccd.domain.service.common.CaseTypeService;
 
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -28,6 +27,7 @@ import javax.inject.Named;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.toUnmodifiableList;
+import static uk.gov.hmcts.ccd.domain.types.DateTimeValidator.DATE_TIME_FORMATTER;
 
 @Named
 public class CategoriesAndDocumentsService {
@@ -39,8 +39,6 @@ public class CategoriesAndDocumentsService {
     private static final String DOCUMENT_FILENAME = "document_filename";
     private static final String CATEGORY_ID = "category_id";
     private static final String UPLOAD_TIMESTAMP = "upload_timestamp";
-
-    private static final String UPLOAD_TIMESTAMP_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS";
 
     private final CaseDataExtractor caseDataExtractor;
     private final CaseTypeService caseTypeService;
@@ -197,10 +195,7 @@ public class CategoriesAndDocumentsService {
 
     LocalDateTime parseUploadTimestamp(final String uploadTimestamp) {
         return Optional.ofNullable(uploadTimestamp)
-            .map(timestamp -> {
-                final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(UPLOAD_TIMESTAMP_PATTERN);
-                return LocalDateTime.parse(timestamp, dateTimeFormatter);
-            })
+            .map(timestamp -> LocalDateTime.parse(timestamp, DATE_TIME_FORMATTER))
             .orElse(null);
     }
 

--- a/src/main/java/uk/gov/hmcts/ccd/domain/types/DateTimeValidator.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/types/DateTimeValidator.java
@@ -24,7 +24,7 @@ import static uk.gov.hmcts.ccd.domain.types.TextValidator.checkRegex;
 public class DateTimeValidator implements BaseTypeValidator {
     static final String TYPE_ID = "DateTime";
 
-    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ISO_DATE_TIME;
+    public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ISO_DATE_TIME;
 
     public BaseType getType() {
         return BaseType.get(TYPE_ID);

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/casefileview/CategoriesAndDocumentsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/casefileview/CategoriesAndDocumentsServiceTest.java
@@ -254,17 +254,34 @@ class CategoriesAndDocumentsServiceTest extends TestFixtures {
             .isInstanceOf(RuntimeException.class);
     }
 
-    @Test
-    void testShouldParseTimestamp() {
-        final String timestamp = "2022-04-06T16:44:52.000000000";
-        final LocalDateTime expectedTimestamp = LocalDateTime.of(2022, 4, 6, 16,
-            44, 52);
-
+    @ParameterizedTest
+    @MethodSource("provideTimestampParameters")
+    void testShouldParseTimestamps(String timestamp, LocalDateTime expectedTimestamp) {
         final LocalDateTime result = underTest.parseUploadTimestamp(timestamp);
 
         assertThat(result)
             .isNotNull()
             .isEqualTo(expectedTimestamp);
+    }
+
+    private static Stream<Arguments> provideTimestampParameters() {
+        return Stream.of(
+            Arguments.of(
+                "2022-04-06T16:44:52.000000000Z", LocalDateTime.of(2022, 4, 6, 16, 44, 52)
+            ),
+            Arguments.of(
+                "2022-04-06T16:44:52.000000000", LocalDateTime.of(2022, 4, 6, 16, 44, 52)
+            ),
+            Arguments.of(
+                "2022-04-06T16:44:52.000", LocalDateTime.of(2022, 4, 6, 16, 44, 52)
+            ),
+            Arguments.of(
+                "2022-04-06T16:44:52.123", LocalDateTime.of(2022, 4, 6, 16, 44, 52, 123000000)
+            ),
+            Arguments.of(
+                "2022-04-06T16:44:52", LocalDateTime.of(2022, 4, 6, 16, 44, 52)
+            )
+        );
     }
 
     private static Stream<Arguments> provideCaseFieldExtractParameters() {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CCD-5408


### Change description ###
Use same formatter for CFV as used by the `DateTimeValidator` to ensure any values created can be read by CFV.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
