### PR TITLE
Reference to the ft timeout extension branch

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -11,7 +11,7 @@ properties(
     ]
 )
 
-@Library("Infrastructure")
+@Library("Infrastructure@DO-NOT-MERGE-FT-TIMEOUT-EXTENSION")
 
 def type = "java"
 def product = "ccd"


### PR DESCRIPTION

### Change description ###
Reference to the branch 'DO-NOT-MERGE-FT-TIMEOUT-EXTENSION' within cnp-jenkins-library repo that extends the ft timeout from 40 to 60 minutes. 

https://github.com/hmcts/cnp-jenkins-library/pull/1229
