### PR TITLE
CCD-6096: Disallow less than and greater than symbols in Email addresses

### DIFF
--- a/src/main/java/uk/gov/hmcts/ccd/domain/types/EmailValidator.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/types/EmailValidator.java
@@ -70,6 +70,9 @@ public class EmailValidator implements BaseTypeValidator {
     }
 
     private boolean isValidEmailAddress(final String email) {
+        if (email.contains("<") || email.contains(">")) {
+            return false;
+        }
         try {
             new InternetAddress(email).validate();
             return true;

--- a/src/test/java/uk/gov/hmcts/ccd/domain/types/EmailValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/types/EmailValidatorTest.java
@@ -66,7 +66,7 @@ class EmailValidatorTest {
         final List<ValidationResult> result03 = validator.validate(FIELD_ID,
                                                                    NODE_FACTORY.textNode("test@test.org"),
             caseFieldDefinition);
-        assertEquals(0, result03.size(), result01.toString());
+        assertEquals(0, result03.size(), result03.toString());
 
         final List<ValidationResult> result04 = validator.validate(FIELD_ID,
                                                                    NODE_FACTORY.textNode("test@test.org.uk"),
@@ -94,12 +94,22 @@ class EmailValidatorTest {
         final List<ValidationResult> result02 = validator.validate(FIELD_ID,
                                                                    NODE_FACTORY.textNode("test.com"),
             caseFieldDefinition);
-        assertEquals(1, result01.size(), result02.toString());
+        assertEquals(1, result02.size(), result02.toString());
 
         final List<ValidationResult> result03 = validator.validate(FIELD_ID,
                                                                    NODE_FACTORY.textNode("test@test@test"),
             caseFieldDefinition);
         assertEquals(1, result03.size(), result03.toString());
+
+        final List<ValidationResult> result04 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode("<a@a.a"),
+            caseFieldDefinition);
+        assertEquals(1, result04.size(), result04.toString());
+
+        final List<ValidationResult> result05 = validator.validate(FIELD_ID,
+                                                                   NODE_FACTORY.textNode("a@a.a>"),
+            caseFieldDefinition);
+        assertEquals(1, result05.size(), result05.toString());
     }
 
     @Test


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/CCD-6096

### Change description ###
Disallow less than and greater than symbols in Email addresses.
Also fixed minor typos in unit tests (result01 to result03 and result01 to result02).

**Does this PR introduce a breaking change?**
```
[ ] Yes
[x] No
```