### PR TITLE
CCD-6372: Increase "spring.datasource.hikari.maximum-pool-size" to 75

### DIFF
--- a/charts/ccd-data-store-api/Chart.yaml
+++ b/charts/ccd-data-store-api/Chart.yaml
@@ -2,7 +2,7 @@ description: Helm chart for the HMCTS CCD Data Store
 name: ccd-data-store-api
 apiVersion: v2
 home: https://github.com/hmcts/ccd-data-store-api
-version: 2.0.34
+version: 2.0.35
 maintainers:
   - name: HMCTS CCD Dev Team
     email: ccd-devops@HMCTS.NET

--- a/charts/ccd-data-store-api/values.yaml
+++ b/charts/ccd-data-store-api/values.yaml
@@ -41,7 +41,7 @@ java:
     DATA_STORE_DB_NAME: ccd_data_store
     DATA_STORE_DB_HOST: ccd-data-store-api-postgres-db-v15-{{ .Values.global.environment }}.postgres.database.azure.com
     DATA_STORE_DB_OPTIONS: "?stringtype=unspecified&sslmode=require&gssEncMode=disable"
-    DATA_STORE_DB_MAX_POOL_SIZE: 48
+    DATA_STORE_DB_MAX_POOL_SIZE: 75
 # this variable takes a comma separated list of callback urls for which details needs to be logged, or '*' for all
     LOG_CALLBACK_DETAILS:
     CCD_DRAFT_TTL_DAYS: 180


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/CCD-6372
https://tools.hmcts.net/jira/browse/CCD-6455

### Change description ###
Increase "spring.datasource.hikari.maximum-pool-size" to 75 , to avoid request timeouts when pipelines are running tests using ccd-data-store-api.

**Does this PR introduce a breaking change?**
```
[ ] Yes
[x] No
```