### PR TITLE
CCD-6752 :: Bump com.github.hmcts:service-auth-provider-java-client to version 5.3.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -247,7 +247,7 @@ dependencies {
     implementation "org.flywaydb:flyway-core:8.5.13"
     implementation group: 'org.yaml', name: 'snakeyaml', version: '2.0'
     implementation group: 'io.jsonwebtoken', name: 'jjwt', version:'0.9.1'
-    implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '4.0.2'
+    implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '5.3.3'
     implementation group: 'com.github.hmcts', name: 'idam-java-client', version: '2.0.1'
     implementation group: 'org.bouncycastle', name: 'bcpkix-jdk15to18', version: '1.77'
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-6752

### Change description ###

CCD-6752 :: Bump com.github.hmcts:service-auth-provider-java-client to version 5.3.3

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
