### PR TITLE
CCD-6129:

### DIFF
--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/search/builder/ExcludedGrantTypeQueryBuilder.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/search/builder/ExcludedGrantTypeQueryBuilder.java
@@ -4,9 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -47,18 +45,20 @@ public class ExcludedGrantTypeQueryBuilder extends GrantTypeSqlQueryBuilder {
     @SuppressWarnings("java:S2789")
     private String getCaseReferences(Supplier<Stream<RoleAssignment>> streamSupplier,
                                      Map<String, Object> params) {
-        Set<String> caseReferences = streamSupplier.get()
+        Long[] caseReferences = streamSupplier.get()
             .filter(roleAssignment -> roleAssignment.getAttributes() != null)
             .map(roleAssignment -> roleAssignment.getAttributes().getCaseId())
             .filter(Objects::nonNull)
             .map(Optional::get)
             .filter(StringUtils::isNotBlank)
-            .collect(Collectors.toSet());
+            .filter(ref -> ref.matches("\\d+"))
+            .map(Long::parseLong)
+            .toArray(Long[]::new);
 
-        if (!caseReferences.isEmpty()) {
+        if (caseReferences.length > 0) {
             String paramName = "case_ids_excluded";
             params.put(paramName, caseReferences);
-            return String.format(QUERY, REFERENCE, paramName);
+            return String.format(QUERY_ANY, REFERENCE, paramName);
         }
         return EMPTY;
     }

--- a/src/main/java/uk/gov/hmcts/ccd/data/casedetails/search/builder/GrantTypeSqlQueryBuilder.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/casedetails/search/builder/GrantTypeSqlQueryBuilder.java
@@ -24,6 +24,10 @@ public abstract class GrantTypeSqlQueryBuilder extends GrantTypeQueryBuilder {
 
     public static final String QUERY = "%s in (:%s)";
 
+    // Used for reference lists to avoid PostgreSQL's 65,535 parameter limit
+    // = ANY() treats the entire array as a single parameter unlike IN which expands each element
+    public static final String QUERY_ANY = "%s = ANY(ARRAY(SELECT unnest(CAST(:%s AS bigint[]))))";
+
     public static final String EMPTY = "";
 
     public static final String SECURITY_CLASSIFICATION = "security_classification";
@@ -123,11 +127,14 @@ public abstract class GrantTypeSqlQueryBuilder extends GrantTypeQueryBuilder {
                                           int index) {
         if (allRoleAssignmentsHaveCaseReference(searchRoleAssignments)) {
             String referencesParam = String.format(REFERENCES_PARAM, index, paramName);
-            params.put(referencesParam, searchRoleAssignments.stream()
+            Long[] caseReferences = searchRoleAssignments.stream()
                 .map(SearchRoleAssignment::getCaseReference)
-                .collect(Collectors.toList()));
+                .filter(ref -> ref != null && ref.matches("\\d+"))
+                .map(Long::parseLong)
+                .toArray(Long[]::new);
+            params.put(referencesParam, caseReferences);
             parentQuery = parentQuery + getOperator(parentQuery, AND)
-                + String.format(QUERY, REFERENCE, referencesParam);
+                + String.format(QUERY_ANY, REFERENCE, referencesParam);
         }
         return parentQuery;
     }

--- a/src/test/java/uk/gov/hmcts/ccd/data/casedetails/DefaultCaseDetailsRepositoryTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/data/casedetails/DefaultCaseDetailsRepositoryTest.java
@@ -46,6 +46,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
+import java.util.ArrayList;
+import uk.gov.hmcts.ccd.data.casedataaccesscontrol.RoleAssignmentResource;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
@@ -76,6 +78,7 @@ import static uk.gov.hmcts.ccd.test.RoleAssignmentsHelper.createRoleAssignmentRe
 import static uk.gov.hmcts.ccd.test.RoleAssignmentsHelper.createRoleAssignmentResponse;
 import static uk.gov.hmcts.ccd.test.RoleAssignmentsHelper.emptyRoleAssignmentResponseJson;
 import static uk.gov.hmcts.ccd.test.RoleAssignmentsHelper.roleToAccessProfileDefinition;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 @Transactional
 public class DefaultCaseDetailsRepositoryTest extends WireMockBaseTest {
@@ -329,7 +332,7 @@ public class DefaultCaseDetailsRepositoryTest extends WireMockBaseTest {
             .direction("DESC")
             .build());
 
-        assertThrows(BadRequestException.class, () -> 
+        assertThrows(BadRequestException.class, () ->
             caseDetailsRepository.findByMetaDataAndFieldData(metadata, Maps.newHashMap())
         );
     }
@@ -355,7 +358,7 @@ public class DefaultCaseDetailsRepositoryTest extends WireMockBaseTest {
 
         // If any input is not correctly validated it will pass the query to jdbc driver creating potential sql
         // injection vulnerability
-        assertThrows(IllegalArgumentException.class, () -> 
+        assertThrows(IllegalArgumentException.class, () ->
             caseDetailsRepository.findByMetaDataAndFieldData(metadata, Maps.newHashMap()));
     }
 
@@ -859,6 +862,59 @@ public class DefaultCaseDetailsRepositoryTest extends WireMockBaseTest {
         assertThat(caseDetails.getId(), equalTo(id));
         assertThat(caseDetails.getJurisdiction(), equalTo(jurisdictionId));
         assertThat(caseDetails.getReference(), equalTo(caseReference));
+    }
+
+    @Test
+    @Sql(executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD, scripts = {
+        "classpath:sql/insert_cases.sql",
+        "classpath:sql/insert_case_users.sql"
+    })
+    public void searchWithParams_shouldNotExceedPostgresMaxParametersWithLargeNumberOfRoleAssignments()
+        throws Exception {
+        // Regression test for CCD-6129
+        // Verifies that a user with a large number of specific case-level role assignments
+        // does not cause PSQLException: PreparedStatement can have at most 65,535 parameters
+        String userId = "123";
+        CaseTypeDefinition caseTypeDefinition = loadCaseTypeDefinition("mappings/bookcase-definition.json");
+        caseTypeDefinition.setRoleToAccessProfiles(asList(roleToAccessProfileDefinition("[CREATOR]")));
+
+        stubFor(WireMock.get(urlMatching("/api/data/case-type/TestAddressBookCase"))
+            .willReturn(okJson(defaultObjectMapper.writeValueAsString(caseTypeDefinition))
+                .withStatus(200)));
+
+        // Create 70,000 role assignments to simulate a user with a large number of specific case assignments
+        List<RoleAssignmentResource> roleAssignmentRecords = new ArrayList<>();
+        for (int i = 0; i < 70000; i++) {
+            roleAssignmentRecords.add(createRoleAssignmentRecord(
+                "assignment_" + i,
+                String.valueOf(1504254784737847L + i),
+                "TestAddressBookCase",
+                JURISDICTION,
+                "[CREATOR]",
+                userId,
+                false));
+        }
+
+        stubFor(WireMock.get(urlMatching(GET_ROLE_ASSIGNMENTS_PREFIX + userId))
+            .willReturn(okJson(defaultObjectMapper.writeValueAsString(
+                createRoleAssignmentResponse(roleAssignmentRecords)))
+                .withStatus(200)));
+
+        CaseStateDefinition caseStateDefinition = new CaseStateDefinition();
+        caseStateDefinition.setId("CaseCreated");
+
+        when(accessControlService
+            .filterCaseStatesByAccess(anyList(), anySet(), any(Predicate.class)))
+            .thenReturn(asList(caseStateDefinition), asList());
+
+        MetaData metadata = new MetaData("TestAddressBookCase", "PROBATE");
+        HashMap<String, String> searchParams = new HashMap<>();
+        searchParams.put("PersonFirstName", "Janet");
+
+        // Should complete without throwing PSQLException
+        assertDoesNotThrow(() ->
+            caseDetailsRepository.findByMetaDataAndFieldData(metadata, searchParams)
+        );
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/ccd/data/casedetails/search/builder/AccessControlGrantTypeQueryBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/data/casedetails/search/builder/AccessControlGrantTypeQueryBuilderTest.java
@@ -24,6 +24,10 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class AccessControlGrantTypeQueryBuilderTest extends GrantTypeQueryBuilderTest {
 
@@ -84,7 +88,7 @@ class AccessControlGrantTypeQueryBuilderTest extends GrantTypeQueryBuilderTest {
         RoleAssignment roleAssignment = createRoleAssignment(GrantType.BASIC,
             "CASE", "ROLE1", "PRIVATE", "", "", null);
         RoleAssignment specificRoleAssignment = createRoleAssignment(GrantType.SPECIFIC,
-            "CASE", "ROLE2", "PRIVATE", "Test", "", "", null, "caseId1");
+            "CASE", "ROLE2", "PRIVATE", "Test", "", "", null, "1111111111");
         String query = accessControlGrantTypeQueryBuilder
             .createQuery(Lists.newArrayList(roleAssignment,
                 specificRoleAssignment),
@@ -92,7 +96,8 @@ class AccessControlGrantTypeQueryBuilderTest extends GrantTypeQueryBuilderTest {
                 caseTypeDefinition);
         String expectedValue = " AND ( ( ( state in (:states_1_basic) "
             + "AND security_classification in (:classifications_1_basic) ) OR ( jurisdiction='Test' "
-            + "AND reference in (:references_1_specific) AND state in (:states_1_specific) "
+            + "AND reference = ANY(ARRAY(SELECT unnest(CAST(:references_1_specific AS bigint[])))) "
+            + "AND state in (:states_1_specific) "
             + "AND security_classification in (:classifications_1_specific) ) ) )";
         assertNotNull(query);
         assertEquals(expectedValue, query);
@@ -103,27 +108,30 @@ class AccessControlGrantTypeQueryBuilderTest extends GrantTypeQueryBuilderTest {
         RoleAssignment roleAssignment = createRoleAssignment(GrantType.BASIC,
             "CASE", "ROLE1", "PRIVATE", "", "", null);
         RoleAssignment specificRoleAssignment = createRoleAssignment(GrantType.SPECIFIC,
-            "CASE", "ROLE2", "PRIVATE", "Test", "", "", null, "caseId1");
+            "CASE", "ROLE2", "PRIVATE", "Test", "", "", null, "1111111111");
 
         RoleAssignment challengedRoleAssignment = createRoleAssignment(GrantType.CHALLENGED,
             "CASE", "ROLE3", "PRIVATE", "Test", "", "",
-            Lists.newArrayList("auth1"), "caseId1");
+            Lists.newArrayList("auth1"), "1111111111");
 
         RoleAssignment standardRoleAssignment = createRoleAssignment(GrantType.STANDARD,
-            "CASE", "ROLE4", "PRIVATE", "Test", "loc1", "reg1", null, "caseId1");
+            "CASE", "ROLE4", "PRIVATE", "Test", "loc1", "reg1", null, "1111111111");
         String query = accessControlGrantTypeQueryBuilder.createQuery(Lists.newArrayList(roleAssignment,
             specificRoleAssignment, challengedRoleAssignment, standardRoleAssignment),
             Maps.newHashMap(), caseTypeDefinition);
 
         String expectedValue =  " AND ( ( ( state in (:states_1_basic) "
             + "AND security_classification in (:classifications_1_basic) ) OR ( jurisdiction='Test' "
-            + "AND reference in (:references_1_specific) AND state in (:states_1_specific) "
+            + "AND reference = ANY(ARRAY(SELECT unnest(CAST(:references_1_specific AS bigint[])))) "
+            + "AND state in (:states_1_specific) "
             + "AND security_classification in (:classifications_1_specific) ) ) OR ( ( jurisdiction='Test' "
             + "AND data #>> '{caseManagementLocation,region}'='reg1' "
             + "AND data #>> '{caseManagementLocation,baseLocation}'='loc1' "
-            + "AND reference in (:references_1_standard) AND state in (:states_1_standard) "
+            + "AND reference = ANY(ARRAY(SELECT unnest(CAST(:references_1_standard AS bigint[])))) "
+            + "AND state in (:states_1_standard) "
             + "AND security_classification in (:classifications_1_standard) ) OR ( jurisdiction='Test' "
-            + "AND reference in (:references_1_challenged) AND state in (:states_1_challenged) "
+            + "AND reference = ANY(ARRAY(SELECT unnest(CAST(:references_1_challenged AS bigint[])))) "
+            + "AND state in (:states_1_challenged) "
             + "AND security_classification in (:classifications_1_challenged) ) ) )";
 
         assertNotNull(query);
@@ -135,17 +143,17 @@ class AccessControlGrantTypeQueryBuilderTest extends GrantTypeQueryBuilderTest {
         RoleAssignment roleAssignment = createRoleAssignment(GrantType.BASIC,
             "CASE", "ROLE1", "PRIVATE", "", "", null);
         RoleAssignment specificRoleAssignment = createRoleAssignment(GrantType.SPECIFIC,
-            "CASE", "ROLE2", "PRIVATE", "Test", "", "", null, "caseId1");
+            "CASE", "ROLE2", "PRIVATE", "Test", "", "", null, "1111111111");
 
         RoleAssignment challengedRoleAssignment = createRoleAssignment(GrantType.CHALLENGED,
             "CASE", "ROLE3", "PRIVATE", "Test", "", "",
-            Lists.newArrayList("auth1"), "caseId1");
+            Lists.newArrayList("auth1"), "1111111111");
 
         RoleAssignment standardRoleAssignment = createRoleAssignment(GrantType.STANDARD,
-            "CASE", "ROLE4", "PRIVATE", "Test", "loc1", "reg1", null, "caseId1");
+            "CASE", "ROLE4", "PRIVATE", "Test", "loc1", "reg1", null, "1111111111");
 
         RoleAssignment excludedRoleAssignment = createRoleAssignment(GrantType.EXCLUDED,
-            "CASE", "ROLE5", "PRIVATE", "Test", "loc1", "reg1", null, "caseId1");
+            "CASE", "ROLE5", "PRIVATE", "Test", "loc1", "reg1", null, "1111111111");
 
         String query = accessControlGrantTypeQueryBuilder.createQuery(Lists.newArrayList(roleAssignment,
             specificRoleAssignment, challengedRoleAssignment,
@@ -155,14 +163,17 @@ class AccessControlGrantTypeQueryBuilderTest extends GrantTypeQueryBuilderTest {
 
         String expectedValue =  " AND ( ( ( state in (:states_1_basic) "
             + "AND security_classification in (:classifications_1_basic) ) "
-            + "OR ( jurisdiction='Test' AND reference in (:references_1_specific) "
+            + "OR ( jurisdiction='Test' "
+            + "AND reference = ANY(ARRAY(SELECT unnest(CAST(:references_1_specific AS bigint[])))) "
             + "AND state in (:states_1_specific) AND security_classification in (:classifications_1_specific) ) ) "
             + "OR ( ( ( jurisdiction='Test' AND data #>> '{caseManagementLocation,region}'='reg1' "
-            + "AND data #>> '{caseManagementLocation,baseLocation}'='loc1' AND reference in (:references_1_standard) "
+            + "AND data #>> '{caseManagementLocation,baseLocation}'='loc1' "
+            + "AND reference = ANY(ARRAY(SELECT unnest(CAST(:references_1_standard AS bigint[])))) "
             + "AND state in (:states_1_standard) AND security_classification in (:classifications_1_standard) ) "
-            + "OR ( jurisdiction='Test' AND reference in (:references_1_challenged) "
+            + "OR ( jurisdiction='Test' "
+            + "AND reference = ANY(ARRAY(SELECT unnest(CAST(:references_1_challenged AS bigint[])))) "
             + "AND state in (:states_1_challenged) AND security_classification in (:classifications_1_challenged) ) ) "
-            + "AND NOT reference in (:case_ids_excluded) ) )";
+            + "AND NOT reference = ANY(ARRAY(SELECT unnest(CAST(:case_ids_excluded AS bigint[])))) ) )";
 
         assertNotNull(query);
         assertEquals(expectedValue, query);
@@ -172,10 +183,10 @@ class AccessControlGrantTypeQueryBuilderTest extends GrantTypeQueryBuilderTest {
     void shouldReturnChallengedAndExcludedOrganisationalQueryWhenRoleAssignmentsGrantTypeExists() {
         RoleAssignment challengedRoleAssignment = createRoleAssignment(GrantType.CHALLENGED,
             "CASE", "ROLE1", "PRIVATE", "Test", "", "",
-            Lists.newArrayList("auth1"), "caseId1");
+            Lists.newArrayList("auth1"), "1111111111");
 
         RoleAssignment excludedRoleAssignment = createRoleAssignment(GrantType.EXCLUDED,
-            "CASE", "ROLE2", "PRIVATE", "Test", "loc1", "reg1", null, "caseId1");
+            "CASE", "ROLE2", "PRIVATE", "Test", "loc1", "reg1", null, "1111111111");
 
         String query = accessControlGrantTypeQueryBuilder
             .createQuery(Lists.newArrayList(challengedRoleAssignment,
@@ -183,9 +194,10 @@ class AccessControlGrantTypeQueryBuilderTest extends GrantTypeQueryBuilderTest {
                 Maps.newHashMap(),
                 caseTypeDefinition);
 
-        String expectedValue =  " AND ( ( ( jurisdiction='Test' AND reference in (:references_1_challenged) "
+        String expectedValue =  " AND ( ( ( jurisdiction='Test' "
+            + "AND reference = ANY(ARRAY(SELECT unnest(CAST(:references_1_challenged AS bigint[])))) "
             + "AND state in (:states_1_challenged) AND security_classification in (:classifications_1_challenged) ) ) "
-            + "AND NOT reference in (:case_ids_excluded) )";
+            + "AND NOT reference = ANY(ARRAY(SELECT unnest(CAST(:case_ids_excluded AS bigint[])))) )";
 
         assertNotNull(query);
         assertEquals(expectedValue, query);
@@ -197,7 +209,7 @@ class AccessControlGrantTypeQueryBuilderTest extends GrantTypeQueryBuilderTest {
             "CASE", "ROLE1", "PRIVATE", "", "", null);
 
         RoleAssignment excludedRoleAssignment = createRoleAssignment(GrantType.EXCLUDED,
-            "CASE", "ROLE2", "PRIVATE", "Test", "loc1", "reg1", null, "caseId1");
+            "CASE", "ROLE2", "PRIVATE", "Test", "loc1", "reg1", null, "1111111111");
 
         String query = accessControlGrantTypeQueryBuilder
             .createQuery(Lists.newArrayList(roleAssignment, excludedRoleAssignment),
@@ -206,7 +218,7 @@ class AccessControlGrantTypeQueryBuilderTest extends GrantTypeQueryBuilderTest {
 
         String expectedValue =  " AND ( ( state in (:states_1_basic) "
             + "AND security_classification in (:classifications_1_basic) ) "
-            + "AND NOT reference in (:case_ids_excluded) )";
+            + "AND NOT reference = ANY(ARRAY(SELECT unnest(CAST(:case_ids_excluded AS bigint[])))) )";
 
         assertNotNull(query);
         assertEquals(expectedValue, query);
@@ -216,14 +228,15 @@ class AccessControlGrantTypeQueryBuilderTest extends GrantTypeQueryBuilderTest {
     void shouldReturnChallengedOrganisationalQueryWhenRoleAssignmentsGrantTypeExists() {
         RoleAssignment challengedRoleAssignment = createRoleAssignment(GrantType.CHALLENGED,
             "CASE", "ROLE1", "PRIVATE", "Test", "", "",
-            Lists.newArrayList("auth1"), "caseId1");
+            Lists.newArrayList("auth1"), "1111111111");
 
         String query = accessControlGrantTypeQueryBuilder
             .createQuery(Lists.newArrayList(challengedRoleAssignment),
                 Maps.newHashMap(),
                 caseTypeDefinition);
 
-        String expectedValue = " AND ( ( ( jurisdiction='Test' AND reference in (:references_1_challenged) "
+        String expectedValue = " AND ( ( ( jurisdiction='Test' "
+            + "AND reference = ANY(ARRAY(SELECT unnest(CAST(:references_1_challenged AS bigint[])))) "
             + "AND state in (:states_1_challenged) "
             + "AND security_classification in (:classifications_1_challenged) ) ) )";
         assertNotNull(query);
@@ -233,16 +246,47 @@ class AccessControlGrantTypeQueryBuilderTest extends GrantTypeQueryBuilderTest {
     @Test
     void shouldReturnOnlyExcludedOrganisationalQuery() {
         RoleAssignment excludedRoleAssignment = createRoleAssignment(GrantType.EXCLUDED,
-            "CASE", "ROLE1", "PRIVATE", "Test", "loc1", "reg1", null, "caseId1");
+            "CASE", "ROLE1", "PRIVATE", "Test", "loc1", "reg1", null, "1111111111");
 
         String query = accessControlGrantTypeQueryBuilder
             .createQuery(Lists.newArrayList(excludedRoleAssignment),
                 Maps.newHashMap(),
                 caseTypeDefinition);
 
-        String expectedValue =  " AND NOT reference in (:case_ids_excluded)";
+        String expectedValue =  " AND NOT reference = ANY(ARRAY(SELECT unnest(CAST(:case_ids_excluded AS bigint[]))))";
 
         assertNotNull(query);
         assertEquals(expectedValue, query);
+    }
+
+    @Test
+    void shouldNotExceedPostgresMaxParametersWithLargeNumberOfRoleAssignments() {
+        // Regression test for CCD-6129
+        // When a user has a large number of specific case role assignments (e.g. from a bulk grant),
+        // the generated SQL query must not exceed PostgreSQL's hard limit of 65,535 parameters.
+        // Previously the IN clause expanded each case reference into an individual parameter,
+        // causing PSQLException: PreparedStatement can have at most 65,535 parameters.
+        List<RoleAssignment> roleAssignments = new ArrayList<>();
+        for (int i = 0; i < 70000; i++) {
+            roleAssignments.add(createRoleAssignment(
+                GrantType.SPECIFIC,
+                "CASE",
+                "ROLE1",
+                "PRIVATE",
+                "Test",
+                "",
+                "",
+                null,
+                String.valueOf(i)
+            ));
+        }
+
+        Map<String, Object> params = Maps.newHashMap();
+        String result = accessControlGrantTypeQueryBuilder.createQuery(
+            roleAssignments, params, caseTypeDefinition
+        );
+
+        assertThat(result).contains("reference = ANY");
+        assertThat(result).doesNotContain("reference in (:");
     }
 }


### PR DESCRIPTION
*### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CCD-6129


### Change description ###
Fixes a PSQLException thrown when users with large numbers of specific case-level role assignments search for cases. The JDBC driver rejected queries where the IN (:p1, :p2, ...) clause exceeded PostgreSQL's 65,535 parameter limit.

Replaced the IN clause with = ANY(ARRAY(SELECT unnest(CAST(:references_param AS bigint[])))) in GrantTypeSqlQueryBuilder and ExcludedGrantTypeQueryBuilder, passing case references as a single bigint[] array parameter instead of individual JDBC parameters.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
