### PR TITLE
Add provider PACT test for the validate-case-data endpoint

### DIFF
--- a/src/contractTest/java/uk/gov/hmcts/ccd/endpoint/std/GlobalSearchProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/ccd/endpoint/std/GlobalSearchProviderTest.java
@@ -11,24 +11,13 @@ import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.mockito.Mock;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import uk.gov.hmcts.ccd.ApplicationParams;
-import uk.gov.hmcts.ccd.WireMockBaseContractTest;
-import uk.gov.hmcts.ccd.data.SecurityUtils;
 import uk.gov.hmcts.ccd.domain.model.search.CaseSearchResult;
 import uk.gov.hmcts.ccd.domain.model.search.global.GlobalSearchResponsePayload;
 import uk.gov.hmcts.ccd.domain.service.globalsearch.GlobalSearchParser;
 import uk.gov.hmcts.ccd.domain.service.search.elasticsearch.CaseSearchOperation;
 import uk.gov.hmcts.ccd.domain.service.search.global.GlobalSearchService;
-import uk.gov.hmcts.ccd.v2.external.controller.TestIdamConfiguration;
 
 import java.util.Collections;
 import java.util.List;
@@ -39,44 +28,37 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.when;
 
 /**
- * Provider PACT verification for the Global Search endpoint
- * (POST /globalSearch, served by {@link GlobalSearchEndpoint}).
- *
- * <p>Verifies the consumer contract published by xui_webapp under the provider name
- * {@code ccdDataStoreAPI_search} (see rpx-xui-webapp api/test/pact/pact-tests/wa2/getSearchResults.spec.ts).</p>
+ * Provider PACT verification for POST /globalSearch (GlobalSearchEndpoint). Verifies the consumer
+ * contract published by xui_webapp (state "Search for case id").
  */
 @Provider("ccdDataStoreAPI_search")
 @PactBroker(url = "${PACT_BROKER_FULL_URL:http://localhost:9292}",
     consumerVersionSelectors = {@VersionSelector(tag = "${PACT_BRANCH_NAME:Dev}")},
     providerTags = "${pactbroker.providerTags:master}",
     enablePendingPacts = "${pactbroker.enablePending:true}")
-@TestPropertySource(locations = "/application.properties")
-@WebMvcTest({GlobalSearchEndpoint.class})
-@AutoConfigureMockMvc(addFilters = false)
-@ActiveProfiles("SECURITY_MOCK")
-@ContextConfiguration(classes = {TestIdamConfiguration.class})
 @IgnoreNoPactsToVerify
 @ExtendWith(SpringExtension.class)
-public class GlobalSearchProviderTest extends WireMockBaseContractTest {
+public class GlobalSearchProviderTest {
 
-    @MockitoBean
-    ApplicationParams applicationParams;
+    @Mock
+    private CaseSearchOperation caseSearchOperation;
 
-    @MockitoBean
-    SecurityUtils securityUtils;
+    @Mock
+    private GlobalSearchService globalSearchService;
 
-    @MockitoBean
-    @Qualifier("AuthorisedCaseSearchOperation")
-    CaseSearchOperation caseSearchOperation;
+    @Mock
+    private GlobalSearchParser globalSearchParser;
 
-    @MockitoBean
-    GlobalSearchService globalSearchService;
 
-    @MockitoBean
-    GlobalSearchParser globalSearchParser;
-
-    @Autowired
-    GlobalSearchEndpoint globalSearchEndpoint;
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        testTarget.setControllers(new GlobalSearchEndpoint(
+            caseSearchOperation, globalSearchService, globalSearchParser));
+        if (context != null) {
+            context.setTarget(testTarget);
+        }
+    }
 
     @TestTemplate
     @ExtendWith(PactVerificationInvocationContextProvider.class)
@@ -86,15 +68,6 @@ public class GlobalSearchProviderTest extends WireMockBaseContractTest {
         }
     }
 
-    @BeforeEach
-    void before(PactVerificationContext context) {
-        System.getProperties().setProperty("pact.verifier.publishResults", "true");
-        MockMvcTestTarget testTarget = new MockMvcTestTarget();
-        testTarget.setControllers(globalSearchEndpoint);
-        if (context != null) {
-            context.setTarget(testTarget);
-        }
-    }
 
     @State("Search for case id")
     public void searchForCaseId() {

--- a/src/contractTest/java/uk/gov/hmcts/ccd/endpoint/std/GlobalSearchProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/ccd/endpoint/std/GlobalSearchProviderTest.java
@@ -35,7 +35,6 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.when;
 

--- a/src/contractTest/java/uk/gov/hmcts/ccd/endpoint/std/GlobalSearchProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/ccd/endpoint/std/GlobalSearchProviderTest.java
@@ -1,0 +1,128 @@
+package uk.gov.hmcts.ccd.endpoint.std;
+
+import au.com.dius.pact.provider.junit5.PactVerificationContext;
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify;
+import au.com.dius.pact.provider.junitsupport.Provider;
+import au.com.dius.pact.provider.junitsupport.State;
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker;
+import au.com.dius.pact.provider.junitsupport.loader.VersionSelector;
+import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.ccd.ApplicationParams;
+import uk.gov.hmcts.ccd.WireMockBaseContractTest;
+import uk.gov.hmcts.ccd.data.SecurityUtils;
+import uk.gov.hmcts.ccd.domain.model.search.CaseSearchResult;
+import uk.gov.hmcts.ccd.domain.model.search.global.GlobalSearchResponsePayload;
+import uk.gov.hmcts.ccd.domain.service.globalsearch.GlobalSearchParser;
+import uk.gov.hmcts.ccd.domain.service.search.elasticsearch.CaseSearchOperation;
+import uk.gov.hmcts.ccd.domain.service.search.global.GlobalSearchService;
+import uk.gov.hmcts.ccd.v2.external.controller.TestIdamConfiguration;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.when;
+
+/**
+ * Provider PACT verification for the Global Search endpoint
+ * (POST /globalSearch, served by {@link GlobalSearchEndpoint}).
+ *
+ * <p>Verifies the consumer contract published by xui_webapp under the provider name
+ * {@code ccdDataStoreAPI_search} (see rpx-xui-webapp api/test/pact/pact-tests/wa2/getSearchResults.spec.ts).</p>
+ */
+@Provider("ccdDataStoreAPI_search")
+@PactBroker(url = "${PACT_BROKER_FULL_URL:http://localhost:9292}",
+    consumerVersionSelectors = {@VersionSelector(tag = "${PACT_BRANCH_NAME:Dev}")},
+    providerTags = "${pactbroker.providerTags:master}",
+    enablePendingPacts = "${pactbroker.enablePending:true}")
+@TestPropertySource(locations = "/application.properties")
+@WebMvcTest({GlobalSearchEndpoint.class})
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("SECURITY_MOCK")
+@ContextConfiguration(classes = {TestIdamConfiguration.class})
+@IgnoreNoPactsToVerify
+@ExtendWith(SpringExtension.class)
+public class GlobalSearchProviderTest extends WireMockBaseContractTest {
+
+    @MockitoBean
+    ApplicationParams applicationParams;
+
+    @MockitoBean
+    SecurityUtils securityUtils;
+
+    @MockitoBean
+    @Qualifier("AuthorisedCaseSearchOperation")
+    CaseSearchOperation caseSearchOperation;
+
+    @MockitoBean
+    GlobalSearchService globalSearchService;
+
+    @MockitoBean
+    GlobalSearchParser globalSearchParser;
+
+    @Autowired
+    GlobalSearchEndpoint globalSearchEndpoint;
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider.class)
+    void pactVerificationTestTemplate(PactVerificationContext context) {
+        if (context != null) {
+            context.verifyInteraction();
+        }
+    }
+
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        System.getProperties().setProperty("pact.verifier.publishResults", "true");
+        MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        testTarget.setControllers(globalSearchEndpoint);
+        if (context != null) {
+            context.setTarget(testTarget);
+        }
+    }
+
+    @State("Search for case id")
+    public void searchForCaseId() {
+        when(caseSearchOperation.execute(any(), anyBoolean()))
+            .thenReturn(new CaseSearchResult(1L, Collections.emptyList()));
+        when(globalSearchParser.filterCases(anyList(), any())).thenReturn(Collections.emptyList());
+
+        GlobalSearchResponsePayload.Result result = GlobalSearchResponsePayload.Result.builder()
+            .stateId("PREPARE_FOR_HEARING")
+            .processForAccess("SPECIFIC")
+            .caseReference("1675871084353511")
+            .otherReferences(Collections.emptyList())
+            .ccdJurisdictionId("PUBLICLAW")
+            .ccdJurisdictionName("Public Law")
+            .ccdCaseTypeId("CARE_SUPERVISION_EPO")
+            .ccdCaseTypeName("Public Law Applications")
+            .build();
+
+        GlobalSearchResponsePayload payload = GlobalSearchResponsePayload.builder()
+            .resultInfo(GlobalSearchResponsePayload.ResultInfo.builder()
+                .casesReturned(1)
+                .caseStartRecord(1)
+                .moreResultsToGo(false)
+                .build())
+            .results(List.of(result))
+            .build();
+
+        when(globalSearchService.transformResponse(any(), any(), anyList())).thenReturn(payload);
+    }
+}

--- a/src/contractTest/java/uk/gov/hmcts/ccd/v2/external/controller/CaseDataValidatorProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/ccd/v2/external/controller/CaseDataValidatorProviderTest.java
@@ -1,0 +1,97 @@
+package uk.gov.hmcts.ccd.v2.external.controller;
+
+import au.com.dius.pact.provider.junit5.PactVerificationContext;
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify;
+import au.com.dius.pact.provider.junitsupport.Provider;
+import au.com.dius.pact.provider.junitsupport.State;
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker;
+import au.com.dius.pact.provider.junitsupport.loader.VersionSelector;
+import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.ccd.ApplicationParams;
+import uk.gov.hmcts.ccd.WireMockBaseContractTest;
+import uk.gov.hmcts.ccd.data.SecurityUtils;
+import uk.gov.hmcts.ccd.domain.service.validate.AuthorisedValidateCaseFieldsOperation;
+import uk.gov.hmcts.ccd.domain.service.validate.OperationContext;
+import uk.gov.hmcts.ccd.domain.service.validate.ValidateCaseFieldsOperation;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * Provider PACT verification for the CCD Data Store "Validate Case Data" endpoint
+ * (POST /case-types/{caseTypeId}/validate, served by {@link CaseDataValidatorController}).
+ *
+ * <p>Verifies any consumer contract published to the broker under the provider name
+ * {@code ccdDataStoreAPI_validateCaseData}. {@code @IgnoreNoPactsToVerify} keeps the build
+ * green when no such contract exists yet.</p>
+ */
+@Provider("ccdDataStoreAPI_validateCaseData")
+@PactBroker(url = "${PACT_BROKER_FULL_URL:http://localhost:9292}",
+    consumerVersionSelectors = {@VersionSelector(tag = "${PACT_BRANCH_NAME:Dev}")},
+    providerTags = "${pactbroker.providerTags:master}",
+    enablePendingPacts = "${pactbroker.enablePending:true}"
+)
+@TestPropertySource(locations = "/application.properties")
+@WebMvcTest({CaseDataValidatorController.class})
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("SECURITY_MOCK")
+@ContextConfiguration(classes = {TestIdamConfiguration.class})
+@IgnoreNoPactsToVerify
+@ExtendWith(SpringExtension.class)
+public class CaseDataValidatorProviderTest extends WireMockBaseContractTest {
+
+    @MockitoBean
+    ApplicationParams applicationParams;
+
+    @MockitoBean
+    SecurityUtils securityUtils;
+
+    @MockitoBean
+    @Qualifier(AuthorisedValidateCaseFieldsOperation.QUALIFIER)
+    ValidateCaseFieldsOperation validateCaseFieldsOperation;
+
+    @Autowired
+    CaseDataValidatorController caseDataValidatorController;
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider.class)
+    void pactVerificationTestTemplate(PactVerificationContext context) {
+        if (context != null) {
+            context.verifyInteraction();
+        }
+    }
+
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        System.getProperties().setProperty("pact.verifier.publishResults", "true");
+        MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        testTarget.setControllers(caseDataValidatorController);
+        if (context != null) {
+            context.setTarget(testTarget);
+        }
+    }
+
+    @State("A request to validate case data")
+    public void setUpValidateCaseData() {
+        Map<String, JsonNode> validatedData = Collections.emptyMap();
+        when(validateCaseFieldsOperation.validateCaseDetails(any(OperationContext.class)))
+            .thenReturn(validatedData);
+    }
+}

--- a/src/contractTest/java/uk/gov/hmcts/ccd/v2/external/controller/CaseDataValidatorProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/ccd/v2/external/controller/CaseDataValidatorProviderTest.java
@@ -8,67 +8,43 @@ import au.com.dius.pact.provider.junitsupport.State;
 import au.com.dius.pact.provider.junitsupport.loader.PactBroker;
 import au.com.dius.pact.provider.junitsupport.loader.VersionSelector;
 import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
-import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.mockito.Mock;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import uk.gov.hmcts.ccd.ApplicationParams;
-import uk.gov.hmcts.ccd.WireMockBaseContractTest;
-import uk.gov.hmcts.ccd.data.SecurityUtils;
-import uk.gov.hmcts.ccd.domain.service.validate.AuthorisedValidateCaseFieldsOperation;
 import uk.gov.hmcts.ccd.domain.service.validate.OperationContext;
 import uk.gov.hmcts.ccd.domain.service.validate.ValidateCaseFieldsOperation;
 
 import java.util.Collections;
-import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 /**
- * Provider PACT verification for the CCD Data Store "Validate Case Data" endpoint
- * (POST /case-types/{caseTypeId}/validate, served by {@link CaseDataValidatorController}).
- *
- * <p>Verifies any consumer contract published to the broker under the provider name
- * {@code ccdDataStoreAPI_validateCaseData}. {@code @IgnoreNoPactsToVerify} keeps the build
- * green when no such contract exists yet.</p>
+ * Provider PACT verification for POST /case-types/{caseTypeId}/validate (CaseDataValidatorController).
  */
 @Provider("ccdDataStoreAPI_validateCaseData")
 @PactBroker(url = "${PACT_BROKER_FULL_URL:http://localhost:9292}",
     consumerVersionSelectors = {@VersionSelector(tag = "${PACT_BRANCH_NAME:Dev}")},
     providerTags = "${pactbroker.providerTags:master}",
-    enablePendingPacts = "${pactbroker.enablePending:true}"
-)
-@TestPropertySource(locations = "/application.properties")
-@WebMvcTest({CaseDataValidatorController.class})
-@AutoConfigureMockMvc(addFilters = false)
-@ActiveProfiles("SECURITY_MOCK")
-@ContextConfiguration(classes = {TestIdamConfiguration.class})
+    enablePendingPacts = "${pactbroker.enablePending:true}")
 @IgnoreNoPactsToVerify
 @ExtendWith(SpringExtension.class)
-public class CaseDataValidatorProviderTest extends WireMockBaseContractTest {
+public class CaseDataValidatorProviderTest {
 
-    @MockitoBean
-    ApplicationParams applicationParams;
+    @Mock
+    private ValidateCaseFieldsOperation validateCaseFieldsOperation;
 
-    @MockitoBean
-    SecurityUtils securityUtils;
 
-    @MockitoBean
-    @Qualifier(AuthorisedValidateCaseFieldsOperation.QUALIFIER)
-    ValidateCaseFieldsOperation validateCaseFieldsOperation;
-
-    @Autowired
-    CaseDataValidatorController caseDataValidatorController;
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        testTarget.setControllers(new CaseDataValidatorController(validateCaseFieldsOperation));
+        if (context != null) {
+            context.setTarget(testTarget);
+        }
+    }
 
     @TestTemplate
     @ExtendWith(PactVerificationInvocationContextProvider.class)
@@ -78,20 +54,10 @@ public class CaseDataValidatorProviderTest extends WireMockBaseContractTest {
         }
     }
 
-    @BeforeEach
-    void before(PactVerificationContext context) {
-        System.getProperties().setProperty("pact.verifier.publishResults", "true");
-        MockMvcTestTarget testTarget = new MockMvcTestTarget();
-        testTarget.setControllers(caseDataValidatorController);
-        if (context != null) {
-            context.setTarget(testTarget);
-        }
-    }
 
     @State("A request to validate case data")
     public void setUpValidateCaseData() {
-        Map<String, JsonNode> validatedData = Collections.emptyMap();
         when(validateCaseFieldsOperation.validateCaseDetails(any(OperationContext.class)))
-            .thenReturn(validatedData);
+            .thenReturn(Collections.emptyMap());
     }
 }

--- a/src/contractTest/java/uk/gov/hmcts/ccd/v2/external/controller/CaseDocumentProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/ccd/v2/external/controller/CaseDocumentProviderTest.java
@@ -11,42 +11,34 @@ import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.mockito.Mock;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import uk.gov.hmcts.ccd.ApplicationParams;
-import uk.gov.hmcts.ccd.WireMockBaseContractTest;
-import uk.gov.hmcts.ccd.data.SecurityUtils;
 import uk.gov.hmcts.ccd.domain.service.getcasedocument.GetCaseDocumentOperation;
 
-/** Provider PACT verification for GET /cases/{caseId}/documents/{documentId} (CaseDocumentController). */
+/**
+ * Provider PACT verification for GET /cases/{caseId}/documents/{documentId} (CaseDocumentController).
+ */
 @Provider("ccdDataStoreAPI_caseDocument")
 @PactBroker(url = "${PACT_BROKER_FULL_URL:http://localhost:9292}",
     consumerVersionSelectors = {@VersionSelector(tag = "${PACT_BRANCH_NAME:Dev}")},
     providerTags = "${pactbroker.providerTags:master}",
     enablePendingPacts = "${pactbroker.enablePending:true}")
-@TestPropertySource(locations = "/application.properties")
-@WebMvcTest({CaseDocumentController.class})
-@AutoConfigureMockMvc(addFilters = false)
-@ActiveProfiles("SECURITY_MOCK")
-@ContextConfiguration(classes = {TestIdamConfiguration.class})
 @IgnoreNoPactsToVerify
 @ExtendWith(SpringExtension.class)
-public class CaseDocumentProviderTest extends WireMockBaseContractTest {
+public class CaseDocumentProviderTest {
 
-    @MockitoBean
-    ApplicationParams applicationParams;
-    @MockitoBean
-    SecurityUtils securityUtils;
-    @MockitoBean
-    GetCaseDocumentOperation getCaseDocumentOperation;
-    @Autowired
-    CaseDocumentController caseDocumentController;
+    @Mock
+    private GetCaseDocumentOperation getCaseDocumentOperation;
+
+
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        testTarget.setControllers(new CaseDocumentController(getCaseDocumentOperation));
+        if (context != null) {
+            context.setTarget(testTarget);
+        }
+    }
 
     @TestTemplate
     @ExtendWith(PactVerificationInvocationContextProvider.class)
@@ -56,15 +48,6 @@ public class CaseDocumentProviderTest extends WireMockBaseContractTest {
         }
     }
 
-    @BeforeEach
-    void before(PactVerificationContext context) {
-        System.getProperties().setProperty("pact.verifier.publishResults", "true");
-        MockMvcTestTarget testTarget = new MockMvcTestTarget();
-        testTarget.setControllers(caseDocumentController);
-        if (context != null) {
-            context.setTarget(testTarget);
-        }
-    }
 
     @State("A case document metadata request")
     public void caseDocumentMetadataRequest() {

--- a/src/contractTest/java/uk/gov/hmcts/ccd/v2/external/controller/CaseDocumentProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/ccd/v2/external/controller/CaseDocumentProviderTest.java
@@ -1,0 +1,73 @@
+package uk.gov.hmcts.ccd.v2.external.controller;
+
+import au.com.dius.pact.provider.junit5.PactVerificationContext;
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify;
+import au.com.dius.pact.provider.junitsupport.Provider;
+import au.com.dius.pact.provider.junitsupport.State;
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker;
+import au.com.dius.pact.provider.junitsupport.loader.VersionSelector;
+import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.ccd.ApplicationParams;
+import uk.gov.hmcts.ccd.WireMockBaseContractTest;
+import uk.gov.hmcts.ccd.data.SecurityUtils;
+import uk.gov.hmcts.ccd.domain.service.getcasedocument.GetCaseDocumentOperation;
+
+/** Provider PACT verification for GET /cases/{caseId}/documents/{documentId} (CaseDocumentController). */
+@Provider("ccdDataStoreAPI_caseDocument")
+@PactBroker(url = "${PACT_BROKER_FULL_URL:http://localhost:9292}",
+    consumerVersionSelectors = {@VersionSelector(tag = "${PACT_BRANCH_NAME:Dev}")},
+    providerTags = "${pactbroker.providerTags:master}",
+    enablePendingPacts = "${pactbroker.enablePending:true}")
+@TestPropertySource(locations = "/application.properties")
+@WebMvcTest({CaseDocumentController.class})
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("SECURITY_MOCK")
+@ContextConfiguration(classes = {TestIdamConfiguration.class})
+@IgnoreNoPactsToVerify
+@ExtendWith(SpringExtension.class)
+public class CaseDocumentProviderTest extends WireMockBaseContractTest {
+
+    @MockitoBean
+    ApplicationParams applicationParams;
+    @MockitoBean
+    SecurityUtils securityUtils;
+    @MockitoBean
+    GetCaseDocumentOperation getCaseDocumentOperation;
+    @Autowired
+    CaseDocumentController caseDocumentController;
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider.class)
+    void pactVerificationTestTemplate(PactVerificationContext context) {
+        if (context != null) {
+            context.verifyInteraction();
+        }
+    }
+
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        System.getProperties().setProperty("pact.verifier.publishResults", "true");
+        MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        testTarget.setControllers(caseDocumentController);
+        if (context != null) {
+            context.setTarget(testTarget);
+        }
+    }
+
+    @State("A case document metadata request")
+    public void caseDocumentMetadataRequest() {
+        // State setup (mock getCaseDocumentOperation) to be completed when a consumer contract is published.
+    }
+}

--- a/src/contractTest/java/uk/gov/hmcts/ccd/v2/external/controller/CaseFileViewProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/ccd/v2/external/controller/CaseFileViewProviderTest.java
@@ -1,0 +1,85 @@
+package uk.gov.hmcts.ccd.v2.external.controller;
+
+import au.com.dius.pact.provider.junit5.PactVerificationContext;
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify;
+import au.com.dius.pact.provider.junitsupport.Provider;
+import au.com.dius.pact.provider.junitsupport.State;
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker;
+import au.com.dius.pact.provider.junitsupport.loader.VersionSelector;
+import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.ccd.ApplicationParams;
+import uk.gov.hmcts.ccd.WireMockBaseContractTest;
+import uk.gov.hmcts.ccd.data.SecurityUtils;
+import uk.gov.hmcts.ccd.domain.service.casefileview.CategoriesAndDocumentsService;
+import uk.gov.hmcts.ccd.domain.service.common.UIDService;
+import uk.gov.hmcts.ccd.domain.service.createevent.CreateEventOperation;
+import uk.gov.hmcts.ccd.domain.service.getcase.GetCaseOperation;
+
+/** Provider PACT verification for GET /categoriesAndDocuments/{cid} (CaseFileViewController). */
+@Provider("ccdDataStoreAPI_caseFileView")
+@PactBroker(url = "${PACT_BROKER_FULL_URL:http://localhost:9292}",
+    consumerVersionSelectors = {@VersionSelector(tag = "${PACT_BRANCH_NAME:Dev}")},
+    providerTags = "${pactbroker.providerTags:master}",
+    enablePendingPacts = "${pactbroker.enablePending:true}")
+@TestPropertySource(locations = "/application.properties")
+@WebMvcTest({CaseFileViewController.class})
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("SECURITY_MOCK")
+@ContextConfiguration(classes = {TestIdamConfiguration.class})
+@IgnoreNoPactsToVerify
+@ExtendWith(SpringExtension.class)
+public class CaseFileViewProviderTest extends WireMockBaseContractTest {
+
+    @MockitoBean
+    ApplicationParams applicationParams;
+    @MockitoBean
+    SecurityUtils securityUtils;
+    @MockitoBean
+    @Qualifier("creator")
+    GetCaseOperation getCaseOperation;
+    @MockitoBean
+    UIDService caseReferenceService;
+    @MockitoBean
+    @Qualifier("authorised")
+    CreateEventOperation createEventOperation;
+    @MockitoBean
+    CategoriesAndDocumentsService categoriesAndDocumentsService;
+    @Autowired
+    CaseFileViewController caseFileViewController;
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider.class)
+    void pactVerificationTestTemplate(PactVerificationContext context) {
+        if (context != null) {
+            context.verifyInteraction();
+        }
+    }
+
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        System.getProperties().setProperty("pact.verifier.publishResults", "true");
+        MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        testTarget.setControllers(caseFileViewController);
+        if (context != null) {
+            context.setTarget(testTarget);
+        }
+    }
+
+    @State("Categories and documents exist for a case")
+    public void categoriesAndDocumentsExist() {
+        // State setup (mock categoriesAndDocumentsService) to be completed when a consumer contract is published.
+    }
+}

--- a/src/contractTest/java/uk/gov/hmcts/ccd/v2/external/controller/CaseFileViewProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/ccd/v2/external/controller/CaseFileViewProviderTest.java
@@ -11,54 +11,47 @@ import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.mockito.Mock;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import uk.gov.hmcts.ccd.ApplicationParams;
-import uk.gov.hmcts.ccd.WireMockBaseContractTest;
-import uk.gov.hmcts.ccd.data.SecurityUtils;
 import uk.gov.hmcts.ccd.domain.service.casefileview.CategoriesAndDocumentsService;
 import uk.gov.hmcts.ccd.domain.service.common.UIDService;
 import uk.gov.hmcts.ccd.domain.service.createevent.CreateEventOperation;
 import uk.gov.hmcts.ccd.domain.service.getcase.GetCaseOperation;
 
-/** Provider PACT verification for GET /categoriesAndDocuments/{cid} (CaseFileViewController). */
+/**
+ * Provider PACT verification for GET /categoriesAndDocuments/{cid} (CaseFileViewController).
+ */
 @Provider("ccdDataStoreAPI_caseFileView")
 @PactBroker(url = "${PACT_BROKER_FULL_URL:http://localhost:9292}",
     consumerVersionSelectors = {@VersionSelector(tag = "${PACT_BRANCH_NAME:Dev}")},
     providerTags = "${pactbroker.providerTags:master}",
     enablePendingPacts = "${pactbroker.enablePending:true}")
-@TestPropertySource(locations = "/application.properties")
-@WebMvcTest({CaseFileViewController.class})
-@AutoConfigureMockMvc(addFilters = false)
-@ActiveProfiles("SECURITY_MOCK")
-@ContextConfiguration(classes = {TestIdamConfiguration.class})
 @IgnoreNoPactsToVerify
 @ExtendWith(SpringExtension.class)
-public class CaseFileViewProviderTest extends WireMockBaseContractTest {
+public class CaseFileViewProviderTest {
 
-    @MockitoBean
-    ApplicationParams applicationParams;
-    @MockitoBean
-    SecurityUtils securityUtils;
-    @MockitoBean
-    @Qualifier("creator")
-    GetCaseOperation getCaseOperation;
-    @MockitoBean
-    UIDService caseReferenceService;
-    @MockitoBean
-    @Qualifier("authorised")
-    CreateEventOperation createEventOperation;
-    @MockitoBean
-    CategoriesAndDocumentsService categoriesAndDocumentsService;
-    @Autowired
-    CaseFileViewController caseFileViewController;
+    @Mock
+    private GetCaseOperation getCaseOperation;
+
+    @Mock
+    private UIDService caseReferenceService;
+
+    @Mock
+    private CreateEventOperation createEventOperation;
+
+    @Mock
+    private CategoriesAndDocumentsService categoriesAndDocumentsService;
+
+
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        testTarget.setControllers(new CaseFileViewController(
+            getCaseOperation, caseReferenceService, createEventOperation, categoriesAndDocumentsService));
+        if (context != null) {
+            context.setTarget(testTarget);
+        }
+    }
 
     @TestTemplate
     @ExtendWith(PactVerificationInvocationContextProvider.class)
@@ -68,15 +61,6 @@ public class CaseFileViewProviderTest extends WireMockBaseContractTest {
         }
     }
 
-    @BeforeEach
-    void before(PactVerificationContext context) {
-        System.getProperties().setProperty("pact.verifier.publishResults", "true");
-        MockMvcTestTarget testTarget = new MockMvcTestTarget();
-        testTarget.setControllers(caseFileViewController);
-        if (context != null) {
-            context.setTarget(testTarget);
-        }
-    }
 
     @State("Categories and documents exist for a case")
     public void categoriesAndDocumentsExist() {

--- a/src/contractTest/java/uk/gov/hmcts/ccd/v2/external/controller/CaseSupplementaryDataProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/ccd/v2/external/controller/CaseSupplementaryDataProviderTest.java
@@ -11,19 +11,8 @@ import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.mockito.Mock;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import uk.gov.hmcts.ccd.ApplicationParams;
-import uk.gov.hmcts.ccd.WireMockBaseContractTest;
-import uk.gov.hmcts.ccd.data.SecurityUtils;
-import uk.gov.hmcts.ccd.domain.model.std.SupplementaryData;
 import uk.gov.hmcts.ccd.domain.model.std.validator.SupplementaryDataUpdateRequestValidator;
 import uk.gov.hmcts.ccd.domain.service.caselinking.CaseLinkRetrievalService;
 import uk.gov.hmcts.ccd.domain.service.caselinking.GetLinkedCasesResponseCreator;
@@ -33,6 +22,7 @@ import uk.gov.hmcts.ccd.domain.service.createevent.CreateEventOperation;
 import uk.gov.hmcts.ccd.domain.service.getcase.GetCaseOperation;
 import uk.gov.hmcts.ccd.domain.service.getevents.GetEventsOperation;
 import uk.gov.hmcts.ccd.domain.service.supplementarydata.SupplementaryDataUpdateOperation;
+import uk.gov.hmcts.ccd.domain.model.std.SupplementaryData;
 
 import java.util.Map;
 
@@ -41,72 +31,59 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 /**
- * Provider PACT verification for the Update Case Supplementary Data endpoint
- * (POST /cases/{caseId}/supplementary-data, served by {@link CaseController}).
- *
- * <p>Verifies consumer contracts published under the provider name
- * {@code ccdDataStoreAPI_supplementaryUpdate} (consumers: ia_caseApi, ia-bail-case-api;
- * see e.g. ia-case-api src/contractTest/.../ccd/CcdSupplementaryConsumerTest.java).</p>
- *
- * <p>NB: the endpoint responds with the updated values wrapped in a
- * {@code supplementary_data} object. If the consumer contract expects the values at the
- * root of the body, verification will report a body mismatch — that is genuine contract
- * feedback for the consumer team rather than a provider-test defect.</p>
+ * Provider PACT verification for POST /cases/{caseId}/supplementary-data (CaseController).
+ * Verifies consumer contracts from ia-case-api / ia-bail-case-api
+ * (state "Supplementary data updated successfully"). NB: the endpoint wraps the updated values in a
+ * supplementary_data object; a contract expecting root-level values will surface as genuine feedback.
  */
 @Provider("ccdDataStoreAPI_supplementaryUpdate")
 @PactBroker(url = "${PACT_BROKER_FULL_URL:http://localhost:9292}",
     consumerVersionSelectors = {@VersionSelector(tag = "${PACT_BRANCH_NAME:Dev}")},
     providerTags = "${pactbroker.providerTags:master}",
     enablePendingPacts = "${pactbroker.enablePending:true}")
-@TestPropertySource(locations = "/application.properties")
-@WebMvcTest({CaseController.class})
-@AutoConfigureMockMvc(addFilters = false)
-@ActiveProfiles("SECURITY_MOCK")
-@ContextConfiguration(classes = {TestIdamConfiguration.class})
 @IgnoreNoPactsToVerify
 @ExtendWith(SpringExtension.class)
-public class CaseSupplementaryDataProviderTest extends WireMockBaseContractTest {
+public class CaseSupplementaryDataProviderTest {
 
-    @MockitoBean
-    ApplicationParams applicationParams;
+    @Mock
+    private GetCaseOperation getCaseOperation;
 
-    @MockitoBean
-    SecurityUtils securityUtils;
+    @Mock
+    private CreateEventOperation createEventOperation;
 
-    @MockitoBean
-    @Qualifier("creator")
-    GetCaseOperation getCaseOperation;
+    @Mock
+    private CreateCaseOperation createCaseOperation;
 
-    @MockitoBean
-    @Qualifier("authorised")
-    CreateEventOperation createEventOperation;
+    @Mock
+    private UIDService caseReferenceService;
 
-    @MockitoBean
-    @Qualifier("authorised")
-    CreateCaseOperation createCaseOperation;
+    @Mock
+    private GetEventsOperation getEventsOperation;
 
-    @MockitoBean
-    UIDService caseReferenceService;
+    @Mock
+    private SupplementaryDataUpdateOperation supplementaryDataUpdateOperation;
 
-    @MockitoBean
-    @Qualifier("authorised")
-    GetEventsOperation getEventsOperation;
+    @Mock
+    private SupplementaryDataUpdateRequestValidator requestValidator;
 
-    @MockitoBean
-    @Qualifier("authorised")
-    SupplementaryDataUpdateOperation supplementaryDataUpdateOperation;
+    @Mock
+    private CaseLinkRetrievalService caseLinkRetrievalService;
 
-    @MockitoBean
-    SupplementaryDataUpdateRequestValidator requestValidator;
+    @Mock
+    private GetLinkedCasesResponseCreator getLinkedCasesResponseCreator;
 
-    @MockitoBean
-    CaseLinkRetrievalService caseLinkRetrievalService;
 
-    @MockitoBean
-    GetLinkedCasesResponseCreator getLinkedCasesResponseCreator;
-
-    @Autowired
-    CaseController caseController;
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        testTarget.setControllers(new CaseController(
+            getCaseOperation, createEventOperation, createCaseOperation, caseReferenceService,
+            getEventsOperation, supplementaryDataUpdateOperation, requestValidator, caseLinkRetrievalService,
+            getLinkedCasesResponseCreator));
+        if (context != null) {
+            context.setTarget(testTarget);
+        }
+    }
 
     @TestTemplate
     @ExtendWith(PactVerificationInvocationContextProvider.class)
@@ -116,15 +93,6 @@ public class CaseSupplementaryDataProviderTest extends WireMockBaseContractTest 
         }
     }
 
-    @BeforeEach
-    void before(PactVerificationContext context) {
-        System.getProperties().setProperty("pact.verifier.publishResults", "true");
-        MockMvcTestTarget testTarget = new MockMvcTestTarget();
-        testTarget.setControllers(caseController);
-        if (context != null) {
-            context.setTarget(testTarget);
-        }
-    }
 
     @State("Supplementary data updated successfully")
     public void supplementaryDataUpdated() {

--- a/src/contractTest/java/uk/gov/hmcts/ccd/v2/external/controller/CaseSupplementaryDataProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/ccd/v2/external/controller/CaseSupplementaryDataProviderTest.java
@@ -1,0 +1,135 @@
+package uk.gov.hmcts.ccd.v2.external.controller;
+
+import au.com.dius.pact.provider.junit5.PactVerificationContext;
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify;
+import au.com.dius.pact.provider.junitsupport.Provider;
+import au.com.dius.pact.provider.junitsupport.State;
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker;
+import au.com.dius.pact.provider.junitsupport.loader.VersionSelector;
+import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.ccd.ApplicationParams;
+import uk.gov.hmcts.ccd.WireMockBaseContractTest;
+import uk.gov.hmcts.ccd.data.SecurityUtils;
+import uk.gov.hmcts.ccd.domain.model.std.SupplementaryData;
+import uk.gov.hmcts.ccd.domain.model.std.validator.SupplementaryDataUpdateRequestValidator;
+import uk.gov.hmcts.ccd.domain.service.caselinking.CaseLinkRetrievalService;
+import uk.gov.hmcts.ccd.domain.service.caselinking.GetLinkedCasesResponseCreator;
+import uk.gov.hmcts.ccd.domain.service.common.UIDService;
+import uk.gov.hmcts.ccd.domain.service.createcase.CreateCaseOperation;
+import uk.gov.hmcts.ccd.domain.service.createevent.CreateEventOperation;
+import uk.gov.hmcts.ccd.domain.service.getcase.GetCaseOperation;
+import uk.gov.hmcts.ccd.domain.service.getevents.GetEventsOperation;
+import uk.gov.hmcts.ccd.domain.service.supplementarydata.SupplementaryDataUpdateOperation;
+
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+/**
+ * Provider PACT verification for the Update Case Supplementary Data endpoint
+ * (POST /cases/{caseId}/supplementary-data, served by {@link CaseController}).
+ *
+ * <p>Verifies consumer contracts published under the provider name
+ * {@code ccdDataStoreAPI_supplementaryUpdate} (consumers: ia_caseApi, ia-bail-case-api;
+ * see e.g. ia-case-api src/contractTest/.../ccd/CcdSupplementaryConsumerTest.java).</p>
+ *
+ * <p>NB: the endpoint responds with the updated values wrapped in a
+ * {@code supplementary_data} object. If the consumer contract expects the values at the
+ * root of the body, verification will report a body mismatch — that is genuine contract
+ * feedback for the consumer team rather than a provider-test defect.</p>
+ */
+@Provider("ccdDataStoreAPI_supplementaryUpdate")
+@PactBroker(url = "${PACT_BROKER_FULL_URL:http://localhost:9292}",
+    consumerVersionSelectors = {@VersionSelector(tag = "${PACT_BRANCH_NAME:Dev}")},
+    providerTags = "${pactbroker.providerTags:master}",
+    enablePendingPacts = "${pactbroker.enablePending:true}")
+@TestPropertySource(locations = "/application.properties")
+@WebMvcTest({CaseController.class})
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("SECURITY_MOCK")
+@ContextConfiguration(classes = {TestIdamConfiguration.class})
+@IgnoreNoPactsToVerify
+@ExtendWith(SpringExtension.class)
+public class CaseSupplementaryDataProviderTest extends WireMockBaseContractTest {
+
+    @MockitoBean
+    ApplicationParams applicationParams;
+
+    @MockitoBean
+    SecurityUtils securityUtils;
+
+    @MockitoBean
+    @Qualifier("creator")
+    GetCaseOperation getCaseOperation;
+
+    @MockitoBean
+    @Qualifier("authorised")
+    CreateEventOperation createEventOperation;
+
+    @MockitoBean
+    @Qualifier("authorised")
+    CreateCaseOperation createCaseOperation;
+
+    @MockitoBean
+    UIDService caseReferenceService;
+
+    @MockitoBean
+    @Qualifier("authorised")
+    GetEventsOperation getEventsOperation;
+
+    @MockitoBean
+    @Qualifier("authorised")
+    SupplementaryDataUpdateOperation supplementaryDataUpdateOperation;
+
+    @MockitoBean
+    SupplementaryDataUpdateRequestValidator requestValidator;
+
+    @MockitoBean
+    CaseLinkRetrievalService caseLinkRetrievalService;
+
+    @MockitoBean
+    GetLinkedCasesResponseCreator getLinkedCasesResponseCreator;
+
+    @Autowired
+    CaseController caseController;
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider.class)
+    void pactVerificationTestTemplate(PactVerificationContext context) {
+        if (context != null) {
+            context.verifyInteraction();
+        }
+    }
+
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        System.getProperties().setProperty("pact.verifier.publishResults", "true");
+        MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        testTarget.setControllers(caseController);
+        if (context != null) {
+            context.setTarget(testTarget);
+        }
+    }
+
+    @State("Supplementary data updated successfully")
+    public void supplementaryDataUpdated() {
+        when(caseReferenceService.validateUID(anyString())).thenReturn(true);
+        when(supplementaryDataUpdateOperation.updateSupplementaryData(anyString(), any()))
+            .thenReturn(new SupplementaryData(Map.of("HMCTSServiceId", "some-id")));
+    }
+}

--- a/src/contractTest/java/uk/gov/hmcts/ccd/v2/external/controller/CaseUserProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/ccd/v2/external/controller/CaseUserProviderTest.java
@@ -11,53 +11,47 @@ import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.mockito.Mock;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import uk.gov.hmcts.ccd.ApplicationParams;
-import uk.gov.hmcts.ccd.WireMockBaseContractTest;
-import uk.gov.hmcts.ccd.data.SecurityUtils;
 import uk.gov.hmcts.ccd.data.casedetails.CaseDetailsRepository;
 import uk.gov.hmcts.ccd.domain.service.caseaccess.CaseAccessOperation;
 import uk.gov.hmcts.ccd.domain.service.common.UIDService;
 import uk.gov.hmcts.ccd.infrastructure.user.UserAuthorisation;
 
-/** Provider PACT verification for PUT /cases/{caseReference}/users (CaseUserController). */
+/**
+ * Provider PACT verification for PUT /cases/{caseReference}/users (CaseUserController).
+ */
 @Provider("ccdDataStoreAPI_caseUsers")
 @PactBroker(url = "${PACT_BROKER_FULL_URL:http://localhost:9292}",
     consumerVersionSelectors = {@VersionSelector(tag = "${PACT_BRANCH_NAME:Dev}")},
     providerTags = "${pactbroker.providerTags:master}",
     enablePendingPacts = "${pactbroker.enablePending:true}")
-@TestPropertySource(locations = "/application.properties")
-@WebMvcTest({CaseUserController.class})
-@AutoConfigureMockMvc(addFilters = false)
-@ActiveProfiles("SECURITY_MOCK")
-@ContextConfiguration(classes = {TestIdamConfiguration.class})
 @IgnoreNoPactsToVerify
 @ExtendWith(SpringExtension.class)
-public class CaseUserProviderTest extends WireMockBaseContractTest {
+public class CaseUserProviderTest {
 
-    @MockitoBean
-    ApplicationParams applicationParams;
-    @MockitoBean
-    SecurityUtils securityUtils;
-    @MockitoBean
-    UIDService caseReferenceService;
-    @MockitoBean
-    UserAuthorisation userAuthorisation;
-    @MockitoBean
-    @Qualifier("cached")
-    CaseDetailsRepository caseRepository;
-    @MockitoBean
-    CaseAccessOperation caseAccessOperation;
-    @Autowired
-    CaseUserController caseUserController;
+    @Mock
+    private UIDService caseReferenceService;
+
+    @Mock
+    private UserAuthorisation userAuthorisation;
+
+    @Mock
+    private CaseDetailsRepository caseRepository;
+
+    @Mock
+    private CaseAccessOperation caseAccessOperation;
+
+
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        testTarget.setControllers(new CaseUserController(
+            caseReferenceService, userAuthorisation, caseRepository, caseAccessOperation));
+        if (context != null) {
+            context.setTarget(testTarget);
+        }
+    }
 
     @TestTemplate
     @ExtendWith(PactVerificationInvocationContextProvider.class)
@@ -67,15 +61,6 @@ public class CaseUserProviderTest extends WireMockBaseContractTest {
         }
     }
 
-    @BeforeEach
-    void before(PactVerificationContext context) {
-        System.getProperties().setProperty("pact.verifier.publishResults", "true");
-        MockMvcTestTarget testTarget = new MockMvcTestTarget();
-        testTarget.setControllers(caseUserController);
-        if (context != null) {
-            context.setTarget(testTarget);
-        }
-    }
 
     @State("A case user role is updated")
     public void caseUserRoleUpdated() {

--- a/src/contractTest/java/uk/gov/hmcts/ccd/v2/external/controller/CaseUserProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/ccd/v2/external/controller/CaseUserProviderTest.java
@@ -1,0 +1,84 @@
+package uk.gov.hmcts.ccd.v2.external.controller;
+
+import au.com.dius.pact.provider.junit5.PactVerificationContext;
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify;
+import au.com.dius.pact.provider.junitsupport.Provider;
+import au.com.dius.pact.provider.junitsupport.State;
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker;
+import au.com.dius.pact.provider.junitsupport.loader.VersionSelector;
+import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.ccd.ApplicationParams;
+import uk.gov.hmcts.ccd.WireMockBaseContractTest;
+import uk.gov.hmcts.ccd.data.SecurityUtils;
+import uk.gov.hmcts.ccd.data.casedetails.CaseDetailsRepository;
+import uk.gov.hmcts.ccd.domain.service.caseaccess.CaseAccessOperation;
+import uk.gov.hmcts.ccd.domain.service.common.UIDService;
+import uk.gov.hmcts.ccd.infrastructure.user.UserAuthorisation;
+
+/** Provider PACT verification for PUT /cases/{caseReference}/users (CaseUserController). */
+@Provider("ccdDataStoreAPI_caseUsers")
+@PactBroker(url = "${PACT_BROKER_FULL_URL:http://localhost:9292}",
+    consumerVersionSelectors = {@VersionSelector(tag = "${PACT_BRANCH_NAME:Dev}")},
+    providerTags = "${pactbroker.providerTags:master}",
+    enablePendingPacts = "${pactbroker.enablePending:true}")
+@TestPropertySource(locations = "/application.properties")
+@WebMvcTest({CaseUserController.class})
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("SECURITY_MOCK")
+@ContextConfiguration(classes = {TestIdamConfiguration.class})
+@IgnoreNoPactsToVerify
+@ExtendWith(SpringExtension.class)
+public class CaseUserProviderTest extends WireMockBaseContractTest {
+
+    @MockitoBean
+    ApplicationParams applicationParams;
+    @MockitoBean
+    SecurityUtils securityUtils;
+    @MockitoBean
+    UIDService caseReferenceService;
+    @MockitoBean
+    UserAuthorisation userAuthorisation;
+    @MockitoBean
+    @Qualifier("cached")
+    CaseDetailsRepository caseRepository;
+    @MockitoBean
+    CaseAccessOperation caseAccessOperation;
+    @Autowired
+    CaseUserController caseUserController;
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider.class)
+    void pactVerificationTestTemplate(PactVerificationContext context) {
+        if (context != null) {
+            context.verifyInteraction();
+        }
+    }
+
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        System.getProperties().setProperty("pact.verifier.publishResults", "true");
+        MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        testTarget.setControllers(caseUserController);
+        if (context != null) {
+            context.setTarget(testTarget);
+        }
+    }
+
+    @State("A case user role is updated")
+    public void caseUserRoleUpdated() {
+        // State setup (mock caseAccessOperation) to be completed when a consumer contract is published.
+    }
+}

--- a/src/contractTest/java/uk/gov/hmcts/ccd/v2/external/controller/DocumentProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/ccd/v2/external/controller/DocumentProviderTest.java
@@ -11,45 +11,38 @@ import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.mockito.Mock;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import uk.gov.hmcts.ccd.ApplicationParams;
-import uk.gov.hmcts.ccd.WireMockBaseContractTest;
-import uk.gov.hmcts.ccd.data.SecurityUtils;
 import uk.gov.hmcts.ccd.domain.service.common.UIDService;
 import uk.gov.hmcts.ccd.domain.service.stdapi.DocumentsOperation;
 
-/** Provider PACT verification for GET /cases/{cid}/documents (DocumentController). */
+/**
+ * Provider PACT verification for GET /cases/{caseId}/documents (DocumentController).
+ */
 @Provider("ccdDataStoreAPI_documents")
 @PactBroker(url = "${PACT_BROKER_FULL_URL:http://localhost:9292}",
     consumerVersionSelectors = {@VersionSelector(tag = "${PACT_BRANCH_NAME:Dev}")},
     providerTags = "${pactbroker.providerTags:master}",
     enablePendingPacts = "${pactbroker.enablePending:true}")
-@TestPropertySource(locations = "/application.properties")
-@WebMvcTest({DocumentController.class})
-@AutoConfigureMockMvc(addFilters = false)
-@ActiveProfiles("SECURITY_MOCK")
-@ContextConfiguration(classes = {TestIdamConfiguration.class})
 @IgnoreNoPactsToVerify
 @ExtendWith(SpringExtension.class)
-public class DocumentProviderTest extends WireMockBaseContractTest {
+public class DocumentProviderTest {
 
-    @MockitoBean
-    ApplicationParams applicationParams;
-    @MockitoBean
-    SecurityUtils securityUtils;
-    @MockitoBean
-    UIDService caseReferenceService;
-    @MockitoBean
-    DocumentsOperation documentsOperation;
-    @Autowired
-    DocumentController documentController;
+    @Mock
+    private UIDService caseReferenceService;
+
+    @Mock
+    private DocumentsOperation documentsOperation;
+
+
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        testTarget.setControllers(new DocumentController(caseReferenceService, documentsOperation));
+        if (context != null) {
+            context.setTarget(testTarget);
+        }
+    }
 
     @TestTemplate
     @ExtendWith(PactVerificationInvocationContextProvider.class)
@@ -59,15 +52,6 @@ public class DocumentProviderTest extends WireMockBaseContractTest {
         }
     }
 
-    @BeforeEach
-    void before(PactVerificationContext context) {
-        System.getProperties().setProperty("pact.verifier.publishResults", "true");
-        MockMvcTestTarget testTarget = new MockMvcTestTarget();
-        testTarget.setControllers(documentController);
-        if (context != null) {
-            context.setTarget(testTarget);
-        }
-    }
 
     @State("Case documents exist for a case")
     public void caseDocumentsExist() {

--- a/src/contractTest/java/uk/gov/hmcts/ccd/v2/external/controller/DocumentProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/ccd/v2/external/controller/DocumentProviderTest.java
@@ -1,0 +1,76 @@
+package uk.gov.hmcts.ccd.v2.external.controller;
+
+import au.com.dius.pact.provider.junit5.PactVerificationContext;
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify;
+import au.com.dius.pact.provider.junitsupport.Provider;
+import au.com.dius.pact.provider.junitsupport.State;
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker;
+import au.com.dius.pact.provider.junitsupport.loader.VersionSelector;
+import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.ccd.ApplicationParams;
+import uk.gov.hmcts.ccd.WireMockBaseContractTest;
+import uk.gov.hmcts.ccd.data.SecurityUtils;
+import uk.gov.hmcts.ccd.domain.service.common.UIDService;
+import uk.gov.hmcts.ccd.domain.service.stdapi.DocumentsOperation;
+
+/** Provider PACT verification for GET /cases/{cid}/documents (DocumentController). */
+@Provider("ccdDataStoreAPI_documents")
+@PactBroker(url = "${PACT_BROKER_FULL_URL:http://localhost:9292}",
+    consumerVersionSelectors = {@VersionSelector(tag = "${PACT_BRANCH_NAME:Dev}")},
+    providerTags = "${pactbroker.providerTags:master}",
+    enablePendingPacts = "${pactbroker.enablePending:true}")
+@TestPropertySource(locations = "/application.properties")
+@WebMvcTest({DocumentController.class})
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("SECURITY_MOCK")
+@ContextConfiguration(classes = {TestIdamConfiguration.class})
+@IgnoreNoPactsToVerify
+@ExtendWith(SpringExtension.class)
+public class DocumentProviderTest extends WireMockBaseContractTest {
+
+    @MockitoBean
+    ApplicationParams applicationParams;
+    @MockitoBean
+    SecurityUtils securityUtils;
+    @MockitoBean
+    UIDService caseReferenceService;
+    @MockitoBean
+    DocumentsOperation documentsOperation;
+    @Autowired
+    DocumentController documentController;
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider.class)
+    void pactVerificationTestTemplate(PactVerificationContext context) {
+        if (context != null) {
+            context.verifyInteraction();
+        }
+    }
+
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        System.getProperties().setProperty("pact.verifier.publishResults", "true");
+        MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        testTarget.setControllers(documentController);
+        if (context != null) {
+            context.setTarget(testTarget);
+        }
+    }
+
+    @State("Case documents exist for a case")
+    public void caseDocumentsExist() {
+        // State setup (mock documentsOperation) to be completed when a consumer contract is published.
+    }
+}

--- a/src/contractTest/java/uk/gov/hmcts/ccd/v2/external/controller/GetCaseByIdProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/ccd/v2/external/controller/GetCaseByIdProviderTest.java
@@ -11,21 +11,8 @@ import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.mockito.Mock;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-import uk.gov.hmcts.ccd.ApplicationParams;
-import uk.gov.hmcts.ccd.WireMockBaseContractTest;
-import uk.gov.hmcts.ccd.data.SecurityUtils;
-import uk.gov.hmcts.ccd.data.casedetails.SecurityClassification;
-import uk.gov.hmcts.ccd.domain.model.definition.CaseDetails;
 import uk.gov.hmcts.ccd.domain.model.std.validator.SupplementaryDataUpdateRequestValidator;
 import uk.gov.hmcts.ccd.domain.service.caselinking.CaseLinkRetrievalService;
 import uk.gov.hmcts.ccd.domain.service.caselinking.GetLinkedCasesResponseCreator;
@@ -35,6 +22,11 @@ import uk.gov.hmcts.ccd.domain.service.createevent.CreateEventOperation;
 import uk.gov.hmcts.ccd.domain.service.getcase.GetCaseOperation;
 import uk.gov.hmcts.ccd.domain.service.getevents.GetEventsOperation;
 import uk.gov.hmcts.ccd.domain.service.supplementarydata.SupplementaryDataUpdateOperation;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import uk.gov.hmcts.ccd.data.casedetails.SecurityClassification;
+import uk.gov.hmcts.ccd.domain.model.definition.CaseDetails;
 import uk.gov.hmcts.ccd.v2.V2;
 
 import java.util.Optional;
@@ -43,92 +35,71 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 /**
- * Provider PACT verification for the Retrieve Case by ID endpoint
- * (GET /cases/{caseId}, served by {@link CaseController}).
- *
- * <p>Verifies the consumer contract published by wa_task_management_api under the provider
- * name {@code ccd_data_store_get_case_by_id} (see wa-task-management-api
- * src/contractTest/.../ccd/CcdGetCasesByCaseIdPactTest.java, state "a case exists").</p>
- *
- * <p>The endpoint requires the {@code experimental} header, which the consumer contract does
- * not declare; it is injected into the replayed request via the
- * {@link MockHttpServletRequestBuilder} test-template parameter.</p>
+ * Provider PACT verification for GET /cases/{caseId} (CaseController). Verifies the consumer
+ * contract published by wa_task_management_api (state "a case exists"). The endpoint requires the
+ * experimental header, which the contract does not declare; it is injected into every replayed
+ * request via a standalone MockMvc default request header.
  */
 @Provider("ccd_data_store_get_case_by_id")
 @PactBroker(url = "${PACT_BROKER_FULL_URL:http://localhost:9292}",
     consumerVersionSelectors = {@VersionSelector(tag = "${PACT_BRANCH_NAME:Dev}")},
     providerTags = "${pactbroker.providerTags:master}",
     enablePendingPacts = "${pactbroker.enablePending:true}")
-@TestPropertySource(locations = "/application.properties")
-@WebMvcTest({CaseController.class})
-@AutoConfigureMockMvc(addFilters = false)
-@ActiveProfiles("SECURITY_MOCK")
-@ContextConfiguration(classes = {TestIdamConfiguration.class})
 @IgnoreNoPactsToVerify
 @ExtendWith(SpringExtension.class)
-public class GetCaseByIdProviderTest extends WireMockBaseContractTest {
+public class GetCaseByIdProviderTest {
 
-    @MockitoBean
-    ApplicationParams applicationParams;
+    @Mock
+    private GetCaseOperation getCaseOperation;
 
-    @MockitoBean
-    SecurityUtils securityUtils;
+    @Mock
+    private CreateEventOperation createEventOperation;
 
-    @MockitoBean
-    @Qualifier("creator")
-    GetCaseOperation getCaseOperation;
+    @Mock
+    private CreateCaseOperation createCaseOperation;
 
-    @MockitoBean
-    @Qualifier("authorised")
-    CreateEventOperation createEventOperation;
+    @Mock
+    private UIDService caseReferenceService;
 
-    @MockitoBean
-    @Qualifier("authorised")
-    CreateCaseOperation createCaseOperation;
+    @Mock
+    private GetEventsOperation getEventsOperation;
 
-    @MockitoBean
-    UIDService caseReferenceService;
+    @Mock
+    private SupplementaryDataUpdateOperation supplementaryDataUpdateOperation;
 
-    @MockitoBean
-    @Qualifier("authorised")
-    GetEventsOperation getEventsOperation;
+    @Mock
+    private SupplementaryDataUpdateRequestValidator requestValidator;
 
-    @MockitoBean
-    @Qualifier("authorised")
-    SupplementaryDataUpdateOperation supplementaryDataUpdateOperation;
+    @Mock
+    private CaseLinkRetrievalService caseLinkRetrievalService;
 
-    @MockitoBean
-    SupplementaryDataUpdateRequestValidator requestValidator;
+    @Mock
+    private GetLinkedCasesResponseCreator getLinkedCasesResponseCreator;
 
-    @MockitoBean
-    CaseLinkRetrievalService caseLinkRetrievalService;
 
-    @MockitoBean
-    GetLinkedCasesResponseCreator getLinkedCasesResponseCreator;
-
-    @Autowired
-    CaseController caseController;
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        CaseController caseController = new CaseController(
+            getCaseOperation, createEventOperation, createCaseOperation, caseReferenceService,
+            getEventsOperation, supplementaryDataUpdateOperation, requestValidator, caseLinkRetrievalService,
+            getLinkedCasesResponseCreator);
+        MockMvc mockMvc = MockMvcBuilders.standaloneSetup(caseController)
+            .defaultRequest(MockMvcRequestBuilders.get("/").header(V2.EXPERIMENTAL_HEADER, "true"))
+            .build();
+        MockMvcTestTarget testTarget = new MockMvcTestTarget(mockMvc);
+        if (context != null) {
+            context.setTarget(testTarget);
+        }
+    }
 
     @TestTemplate
     @ExtendWith(PactVerificationInvocationContextProvider.class)
-    void pactVerificationTestTemplate(PactVerificationContext context, MockHttpServletRequestBuilder request) {
-        if (request != null) {
-            request.header(V2.EXPERIMENTAL_HEADER, "true");
-        }
+    void pactVerificationTestTemplate(PactVerificationContext context) {
         if (context != null) {
             context.verifyInteraction();
         }
     }
 
-    @BeforeEach
-    void before(PactVerificationContext context) {
-        System.getProperties().setProperty("pact.verifier.publishResults", "true");
-        MockMvcTestTarget testTarget = new MockMvcTestTarget();
-        testTarget.setControllers(caseController);
-        if (context != null) {
-            context.setTarget(testTarget);
-        }
-    }
 
     @State("a case exists")
     public void caseExists() {

--- a/src/contractTest/java/uk/gov/hmcts/ccd/v2/external/controller/GetCaseByIdProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/ccd/v2/external/controller/GetCaseByIdProviderTest.java
@@ -1,0 +1,146 @@
+package uk.gov.hmcts.ccd.v2.external.controller;
+
+import au.com.dius.pact.provider.junit5.PactVerificationContext;
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify;
+import au.com.dius.pact.provider.junitsupport.Provider;
+import au.com.dius.pact.provider.junitsupport.State;
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker;
+import au.com.dius.pact.provider.junitsupport.loader.VersionSelector;
+import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import uk.gov.hmcts.ccd.ApplicationParams;
+import uk.gov.hmcts.ccd.WireMockBaseContractTest;
+import uk.gov.hmcts.ccd.data.SecurityUtils;
+import uk.gov.hmcts.ccd.data.casedetails.SecurityClassification;
+import uk.gov.hmcts.ccd.domain.model.definition.CaseDetails;
+import uk.gov.hmcts.ccd.domain.model.std.validator.SupplementaryDataUpdateRequestValidator;
+import uk.gov.hmcts.ccd.domain.service.caselinking.CaseLinkRetrievalService;
+import uk.gov.hmcts.ccd.domain.service.caselinking.GetLinkedCasesResponseCreator;
+import uk.gov.hmcts.ccd.domain.service.common.UIDService;
+import uk.gov.hmcts.ccd.domain.service.createcase.CreateCaseOperation;
+import uk.gov.hmcts.ccd.domain.service.createevent.CreateEventOperation;
+import uk.gov.hmcts.ccd.domain.service.getcase.GetCaseOperation;
+import uk.gov.hmcts.ccd.domain.service.getevents.GetEventsOperation;
+import uk.gov.hmcts.ccd.domain.service.supplementarydata.SupplementaryDataUpdateOperation;
+import uk.gov.hmcts.ccd.v2.V2;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+/**
+ * Provider PACT verification for the Retrieve Case by ID endpoint
+ * (GET /cases/{caseId}, served by {@link CaseController}).
+ *
+ * <p>Verifies the consumer contract published by wa_task_management_api under the provider
+ * name {@code ccd_data_store_get_case_by_id} (see wa-task-management-api
+ * src/contractTest/.../ccd/CcdGetCasesByCaseIdPactTest.java, state "a case exists").</p>
+ *
+ * <p>The endpoint requires the {@code experimental} header, which the consumer contract does
+ * not declare; it is injected into the replayed request via the
+ * {@link MockHttpServletRequestBuilder} test-template parameter.</p>
+ */
+@Provider("ccd_data_store_get_case_by_id")
+@PactBroker(url = "${PACT_BROKER_FULL_URL:http://localhost:9292}",
+    consumerVersionSelectors = {@VersionSelector(tag = "${PACT_BRANCH_NAME:Dev}")},
+    providerTags = "${pactbroker.providerTags:master}",
+    enablePendingPacts = "${pactbroker.enablePending:true}")
+@TestPropertySource(locations = "/application.properties")
+@WebMvcTest({CaseController.class})
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("SECURITY_MOCK")
+@ContextConfiguration(classes = {TestIdamConfiguration.class})
+@IgnoreNoPactsToVerify
+@ExtendWith(SpringExtension.class)
+public class GetCaseByIdProviderTest extends WireMockBaseContractTest {
+
+    @MockitoBean
+    ApplicationParams applicationParams;
+
+    @MockitoBean
+    SecurityUtils securityUtils;
+
+    @MockitoBean
+    @Qualifier("creator")
+    GetCaseOperation getCaseOperation;
+
+    @MockitoBean
+    @Qualifier("authorised")
+    CreateEventOperation createEventOperation;
+
+    @MockitoBean
+    @Qualifier("authorised")
+    CreateCaseOperation createCaseOperation;
+
+    @MockitoBean
+    UIDService caseReferenceService;
+
+    @MockitoBean
+    @Qualifier("authorised")
+    GetEventsOperation getEventsOperation;
+
+    @MockitoBean
+    @Qualifier("authorised")
+    SupplementaryDataUpdateOperation supplementaryDataUpdateOperation;
+
+    @MockitoBean
+    SupplementaryDataUpdateRequestValidator requestValidator;
+
+    @MockitoBean
+    CaseLinkRetrievalService caseLinkRetrievalService;
+
+    @MockitoBean
+    GetLinkedCasesResponseCreator getLinkedCasesResponseCreator;
+
+    @Autowired
+    CaseController caseController;
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider.class)
+    void pactVerificationTestTemplate(PactVerificationContext context, MockHttpServletRequestBuilder request) {
+        if (request != null) {
+            request.header(V2.EXPERIMENTAL_HEADER, "true");
+        }
+        if (context != null) {
+            context.verifyInteraction();
+        }
+    }
+
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        System.getProperties().setProperty("pact.verifier.publishResults", "true");
+        MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        testTarget.setControllers(caseController);
+        if (context != null) {
+            context.setTarget(testTarget);
+        }
+    }
+
+    @State("a case exists")
+    public void caseExists() {
+        when(caseReferenceService.validateUID(anyString())).thenReturn(true);
+
+        CaseDetails caseDetails = new CaseDetails();
+        caseDetails.setReference(1593694526480034L);
+        caseDetails.setJurisdiction("IA");
+        caseDetails.setCaseTypeId("Asylum");
+        caseDetails.setSecurityClassification(SecurityClassification.PRIVATE);
+        caseDetails.setState("appealStarted");
+
+        when(getCaseOperation.execute(anyString())).thenReturn(Optional.of(caseDetails));
+    }
+}

--- a/src/contractTest/java/uk/gov/hmcts/ccd/v2/external/controller/StartEventProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/ccd/v2/external/controller/StartEventProviderTest.java
@@ -1,0 +1,78 @@
+package uk.gov.hmcts.ccd.v2.external.controller;
+
+import au.com.dius.pact.provider.junit5.PactVerificationContext;
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify;
+import au.com.dius.pact.provider.junitsupport.Provider;
+import au.com.dius.pact.provider.junitsupport.State;
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker;
+import au.com.dius.pact.provider.junitsupport.loader.VersionSelector;
+import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.ccd.ApplicationParams;
+import uk.gov.hmcts.ccd.WireMockBaseContractTest;
+import uk.gov.hmcts.ccd.data.SecurityUtils;
+import uk.gov.hmcts.ccd.domain.service.common.UIDService;
+import uk.gov.hmcts.ccd.domain.service.startevent.StartEventOperation;
+
+/** Provider PACT verification for the external Start Event triggers (StartEventController). */
+@Provider("ccdDataStoreAPI_startEvent")
+@PactBroker(url = "${PACT_BROKER_FULL_URL:http://localhost:9292}",
+    consumerVersionSelectors = {@VersionSelector(tag = "${PACT_BRANCH_NAME:Dev}")},
+    providerTags = "${pactbroker.providerTags:master}",
+    enablePendingPacts = "${pactbroker.enablePending:true}")
+@TestPropertySource(locations = "/application.properties")
+@WebMvcTest({StartEventController.class})
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("SECURITY_MOCK")
+@ContextConfiguration(classes = {TestIdamConfiguration.class})
+@IgnoreNoPactsToVerify
+@ExtendWith(SpringExtension.class)
+public class StartEventProviderTest extends WireMockBaseContractTest {
+
+    @MockitoBean
+    ApplicationParams applicationParams;
+    @MockitoBean
+    SecurityUtils securityUtils;
+    @MockitoBean
+    @Qualifier("authorised")
+    StartEventOperation startEventOperation;
+    @MockitoBean
+    UIDService caseReferenceService;
+    @Autowired
+    StartEventController startEventController;
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider.class)
+    void pactVerificationTestTemplate(PactVerificationContext context) {
+        if (context != null) {
+            context.verifyInteraction();
+        }
+    }
+
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        System.getProperties().setProperty("pact.verifier.publishResults", "true");
+        MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        testTarget.setControllers(startEventController);
+        if (context != null) {
+            context.setTarget(testTarget);
+        }
+    }
+
+    @State("A start event trigger is requested")
+    public void startEventTriggerRequested() {
+        // State setup (mock startEventOperation) to be completed when a consumer contract is published.
+    }
+}

--- a/src/contractTest/java/uk/gov/hmcts/ccd/v2/external/controller/StartEventProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/ccd/v2/external/controller/StartEventProviderTest.java
@@ -11,47 +11,38 @@ import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.mockito.Mock;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import uk.gov.hmcts.ccd.ApplicationParams;
-import uk.gov.hmcts.ccd.WireMockBaseContractTest;
-import uk.gov.hmcts.ccd.data.SecurityUtils;
 import uk.gov.hmcts.ccd.domain.service.common.UIDService;
 import uk.gov.hmcts.ccd.domain.service.startevent.StartEventOperation;
 
-/** Provider PACT verification for the external Start Event triggers (StartEventController). */
+/**
+ * Provider PACT verification for the v2 start-event trigger endpoints (StartEventController).
+ */
 @Provider("ccdDataStoreAPI_startEvent")
 @PactBroker(url = "${PACT_BROKER_FULL_URL:http://localhost:9292}",
     consumerVersionSelectors = {@VersionSelector(tag = "${PACT_BRANCH_NAME:Dev}")},
     providerTags = "${pactbroker.providerTags:master}",
     enablePendingPacts = "${pactbroker.enablePending:true}")
-@TestPropertySource(locations = "/application.properties")
-@WebMvcTest({StartEventController.class})
-@AutoConfigureMockMvc(addFilters = false)
-@ActiveProfiles("SECURITY_MOCK")
-@ContextConfiguration(classes = {TestIdamConfiguration.class})
 @IgnoreNoPactsToVerify
 @ExtendWith(SpringExtension.class)
-public class StartEventProviderTest extends WireMockBaseContractTest {
+public class StartEventProviderTest {
 
-    @MockitoBean
-    ApplicationParams applicationParams;
-    @MockitoBean
-    SecurityUtils securityUtils;
-    @MockitoBean
-    @Qualifier("authorised")
-    StartEventOperation startEventOperation;
-    @MockitoBean
-    UIDService caseReferenceService;
-    @Autowired
-    StartEventController startEventController;
+    @Mock
+    private StartEventOperation startEventOperation;
+
+    @Mock
+    private UIDService caseReferenceService;
+
+
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        testTarget.setControllers(new StartEventController(startEventOperation, caseReferenceService));
+        if (context != null) {
+            context.setTarget(testTarget);
+        }
+    }
 
     @TestTemplate
     @ExtendWith(PactVerificationInvocationContextProvider.class)
@@ -61,15 +52,6 @@ public class StartEventProviderTest extends WireMockBaseContractTest {
         }
     }
 
-    @BeforeEach
-    void before(PactVerificationContext context) {
-        System.getProperties().setProperty("pact.verifier.publishResults", "true");
-        MockMvcTestTarget testTarget = new MockMvcTestTarget();
-        testTarget.setControllers(startEventController);
-        if (context != null) {
-            context.setTarget(testTarget);
-        }
-    }
 
     @State("A start event trigger is requested")
     public void startEventTriggerRequested() {

--- a/src/contractTest/java/uk/gov/hmcts/ccd/v2/internal/controller/UICaseProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/ccd/v2/internal/controller/UICaseProviderTest.java
@@ -11,55 +11,47 @@ import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.mockito.Mock;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import uk.gov.hmcts.ccd.ApplicationParams;
-import uk.gov.hmcts.ccd.WireMockBaseContractTest;
-import uk.gov.hmcts.ccd.data.SecurityUtils;
 import uk.gov.hmcts.ccd.domain.service.aggregated.GetCaseHistoryViewOperation;
 import uk.gov.hmcts.ccd.domain.service.aggregated.GetCaseViewOperation;
 import uk.gov.hmcts.ccd.domain.service.casedataaccesscontrol.CaseDataAccessControl;
 import uk.gov.hmcts.ccd.domain.service.common.UIDService;
-import uk.gov.hmcts.ccd.v2.external.controller.TestIdamConfiguration;
 
-/** Provider PACT verification for the internal case-view endpoints (UICaseController). */
+/**
+ * Provider PACT verification for GET /internal/cases/{cid} (UICaseController).
+ */
 @Provider("ccdDataStoreAPI_caseView")
 @PactBroker(url = "${PACT_BROKER_FULL_URL:http://localhost:9292}",
     consumerVersionSelectors = {@VersionSelector(tag = "${PACT_BRANCH_NAME:Dev}")},
     providerTags = "${pactbroker.providerTags:master}",
     enablePendingPacts = "${pactbroker.enablePending:true}")
-@TestPropertySource(locations = "/application.properties")
-@WebMvcTest({UICaseController.class})
-@AutoConfigureMockMvc(addFilters = false)
-@ActiveProfiles("SECURITY_MOCK")
-@ContextConfiguration(classes = {TestIdamConfiguration.class})
 @IgnoreNoPactsToVerify
 @ExtendWith(SpringExtension.class)
-public class UICaseProviderTest extends WireMockBaseContractTest {
+public class UICaseProviderTest {
 
-    @MockitoBean
-    ApplicationParams applicationParams;
-    @MockitoBean
-    SecurityUtils securityUtils;
-    @MockitoBean
-    @Qualifier("authorised")
-    GetCaseViewOperation getCaseViewOperation;
-    @MockitoBean
-    @Qualifier("authorised-case-history")
-    GetCaseHistoryViewOperation getCaseHistoryOperation;
-    @MockitoBean
-    UIDService caseReferenceService;
-    @MockitoBean
-    CaseDataAccessControl caseDataAccessControl;
-    @Autowired
-    UICaseController uiCaseController;
+    @Mock
+    private GetCaseViewOperation getCaseViewOperation;
+
+    @Mock
+    private GetCaseHistoryViewOperation getCaseHistoryOperation;
+
+    @Mock
+    private UIDService caseReferenceService;
+
+    @Mock
+    private CaseDataAccessControl caseDataAccessControl;
+
+
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        testTarget.setControllers(new UICaseController(
+            getCaseViewOperation, getCaseHistoryOperation, caseReferenceService, caseDataAccessControl));
+        if (context != null) {
+            context.setTarget(testTarget);
+        }
+    }
 
     @TestTemplate
     @ExtendWith(PactVerificationInvocationContextProvider.class)
@@ -69,18 +61,9 @@ public class UICaseProviderTest extends WireMockBaseContractTest {
         }
     }
 
-    @BeforeEach
-    void before(PactVerificationContext context) {
-        System.getProperties().setProperty("pact.verifier.publishResults", "true");
-        MockMvcTestTarget testTarget = new MockMvcTestTarget();
-        testTarget.setControllers(uiCaseController);
-        if (context != null) {
-            context.setTarget(testTarget);
-        }
-    }
 
     @State("A case is requested for dynamic display")
-    public void caseRequestedForDisplay() {
+    public void caseRequestedForDynamicDisplay() {
         // State setup (mock getCaseViewOperation) to be completed when a consumer contract is published.
     }
 }

--- a/src/contractTest/java/uk/gov/hmcts/ccd/v2/internal/controller/UICaseProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/ccd/v2/internal/controller/UICaseProviderTest.java
@@ -1,0 +1,86 @@
+package uk.gov.hmcts.ccd.v2.internal.controller;
+
+import au.com.dius.pact.provider.junit5.PactVerificationContext;
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify;
+import au.com.dius.pact.provider.junitsupport.Provider;
+import au.com.dius.pact.provider.junitsupport.State;
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker;
+import au.com.dius.pact.provider.junitsupport.loader.VersionSelector;
+import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.ccd.ApplicationParams;
+import uk.gov.hmcts.ccd.WireMockBaseContractTest;
+import uk.gov.hmcts.ccd.data.SecurityUtils;
+import uk.gov.hmcts.ccd.domain.service.aggregated.GetCaseHistoryViewOperation;
+import uk.gov.hmcts.ccd.domain.service.aggregated.GetCaseViewOperation;
+import uk.gov.hmcts.ccd.domain.service.casedataaccesscontrol.CaseDataAccessControl;
+import uk.gov.hmcts.ccd.domain.service.common.UIDService;
+import uk.gov.hmcts.ccd.v2.external.controller.TestIdamConfiguration;
+
+/** Provider PACT verification for the internal case-view endpoints (UICaseController). */
+@Provider("ccdDataStoreAPI_caseView")
+@PactBroker(url = "${PACT_BROKER_FULL_URL:http://localhost:9292}",
+    consumerVersionSelectors = {@VersionSelector(tag = "${PACT_BRANCH_NAME:Dev}")},
+    providerTags = "${pactbroker.providerTags:master}",
+    enablePendingPacts = "${pactbroker.enablePending:true}")
+@TestPropertySource(locations = "/application.properties")
+@WebMvcTest({UICaseController.class})
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("SECURITY_MOCK")
+@ContextConfiguration(classes = {TestIdamConfiguration.class})
+@IgnoreNoPactsToVerify
+@ExtendWith(SpringExtension.class)
+public class UICaseProviderTest extends WireMockBaseContractTest {
+
+    @MockitoBean
+    ApplicationParams applicationParams;
+    @MockitoBean
+    SecurityUtils securityUtils;
+    @MockitoBean
+    @Qualifier("authorised")
+    GetCaseViewOperation getCaseViewOperation;
+    @MockitoBean
+    @Qualifier("authorised-case-history")
+    GetCaseHistoryViewOperation getCaseHistoryOperation;
+    @MockitoBean
+    UIDService caseReferenceService;
+    @MockitoBean
+    CaseDataAccessControl caseDataAccessControl;
+    @Autowired
+    UICaseController uiCaseController;
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider.class)
+    void pactVerificationTestTemplate(PactVerificationContext context) {
+        if (context != null) {
+            context.verifyInteraction();
+        }
+    }
+
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        System.getProperties().setProperty("pact.verifier.publishResults", "true");
+        MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        testTarget.setControllers(uiCaseController);
+        if (context != null) {
+            context.setTarget(testTarget);
+        }
+    }
+
+    @State("A case is requested for dynamic display")
+    public void caseRequestedForDisplay() {
+        // State setup (mock getCaseViewOperation) to be completed when a consumer contract is published.
+    }
+}

--- a/src/contractTest/java/uk/gov/hmcts/ccd/v2/internal/controller/UICaseSearchProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/ccd/v2/internal/controller/UICaseSearchProviderTest.java
@@ -11,54 +11,47 @@ import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.mockito.Mock;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import uk.gov.hmcts.ccd.ApplicationParams;
-import uk.gov.hmcts.ccd.WireMockBaseContractTest;
-import uk.gov.hmcts.ccd.data.SecurityUtils;
 import uk.gov.hmcts.ccd.domain.service.search.CaseSearchResultViewGenerator;
 import uk.gov.hmcts.ccd.domain.service.search.elasticsearch.CaseSearchOperation;
 import uk.gov.hmcts.ccd.domain.service.search.elasticsearch.ElasticsearchQueryHelper;
 import uk.gov.hmcts.ccd.domain.service.search.elasticsearch.ElasticsearchSortService;
-import uk.gov.hmcts.ccd.v2.external.controller.TestIdamConfiguration;
 
-/** Provider PACT verification for POST /internal/searchCases (UICaseSearchController). */
+/**
+ * Provider PACT verification for POST /internal/searchCases (UICaseSearchController).
+ */
 @Provider("ccdDataStoreAPI_internalSearch")
 @PactBroker(url = "${PACT_BROKER_FULL_URL:http://localhost:9292}",
     consumerVersionSelectors = {@VersionSelector(tag = "${PACT_BRANCH_NAME:Dev}")},
     providerTags = "${pactbroker.providerTags:master}",
     enablePendingPacts = "${pactbroker.enablePending:true}")
-@TestPropertySource(locations = "/application.properties")
-@WebMvcTest({UICaseSearchController.class})
-@AutoConfigureMockMvc(addFilters = false)
-@ActiveProfiles("SECURITY_MOCK")
-@ContextConfiguration(classes = {TestIdamConfiguration.class})
 @IgnoreNoPactsToVerify
 @ExtendWith(SpringExtension.class)
-public class UICaseSearchProviderTest extends WireMockBaseContractTest {
+public class UICaseSearchProviderTest {
 
-    @MockitoBean
-    ApplicationParams applicationParams;
-    @MockitoBean
-    SecurityUtils securityUtils;
-    @MockitoBean
-    @Qualifier("AuthorisedCaseSearchOperation")
-    CaseSearchOperation caseSearchOperation;
-    @MockitoBean
-    ElasticsearchQueryHelper elasticsearchQueryHelper;
-    @MockitoBean
-    CaseSearchResultViewGenerator caseSearchResultViewGenerator;
-    @MockitoBean
-    ElasticsearchSortService elasticsearchSortService;
-    @Autowired
-    UICaseSearchController uiCaseSearchController;
+    @Mock
+    private CaseSearchOperation caseSearchOperation;
+
+    @Mock
+    private ElasticsearchQueryHelper elasticsearchQueryHelper;
+
+    @Mock
+    private CaseSearchResultViewGenerator caseSearchResultViewGenerator;
+
+    @Mock
+    private ElasticsearchSortService elasticsearchSortService;
+
+
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        testTarget.setControllers(new UICaseSearchController(
+            caseSearchOperation, elasticsearchQueryHelper, caseSearchResultViewGenerator, elasticsearchSortService));
+        if (context != null) {
+            context.setTarget(testTarget);
+        }
+    }
 
     @TestTemplate
     @ExtendWith(PactVerificationInvocationContextProvider.class)
@@ -68,15 +61,6 @@ public class UICaseSearchProviderTest extends WireMockBaseContractTest {
         }
     }
 
-    @BeforeEach
-    void before(PactVerificationContext context) {
-        System.getProperties().setProperty("pact.verifier.publishResults", "true");
-        MockMvcTestTarget testTarget = new MockMvcTestTarget();
-        testTarget.setControllers(uiCaseSearchController);
-        if (context != null) {
-            context.setTarget(testTarget);
-        }
-    }
 
     @State("A search for cases is requested")
     public void searchForCasesRequested() {

--- a/src/contractTest/java/uk/gov/hmcts/ccd/v2/internal/controller/UICaseSearchProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/ccd/v2/internal/controller/UICaseSearchProviderTest.java
@@ -1,0 +1,85 @@
+package uk.gov.hmcts.ccd.v2.internal.controller;
+
+import au.com.dius.pact.provider.junit5.PactVerificationContext;
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify;
+import au.com.dius.pact.provider.junitsupport.Provider;
+import au.com.dius.pact.provider.junitsupport.State;
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker;
+import au.com.dius.pact.provider.junitsupport.loader.VersionSelector;
+import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.ccd.ApplicationParams;
+import uk.gov.hmcts.ccd.WireMockBaseContractTest;
+import uk.gov.hmcts.ccd.data.SecurityUtils;
+import uk.gov.hmcts.ccd.domain.service.search.CaseSearchResultViewGenerator;
+import uk.gov.hmcts.ccd.domain.service.search.elasticsearch.CaseSearchOperation;
+import uk.gov.hmcts.ccd.domain.service.search.elasticsearch.ElasticsearchQueryHelper;
+import uk.gov.hmcts.ccd.domain.service.search.elasticsearch.ElasticsearchSortService;
+import uk.gov.hmcts.ccd.v2.external.controller.TestIdamConfiguration;
+
+/** Provider PACT verification for POST /internal/searchCases (UICaseSearchController). */
+@Provider("ccdDataStoreAPI_internalSearch")
+@PactBroker(url = "${PACT_BROKER_FULL_URL:http://localhost:9292}",
+    consumerVersionSelectors = {@VersionSelector(tag = "${PACT_BRANCH_NAME:Dev}")},
+    providerTags = "${pactbroker.providerTags:master}",
+    enablePendingPacts = "${pactbroker.enablePending:true}")
+@TestPropertySource(locations = "/application.properties")
+@WebMvcTest({UICaseSearchController.class})
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("SECURITY_MOCK")
+@ContextConfiguration(classes = {TestIdamConfiguration.class})
+@IgnoreNoPactsToVerify
+@ExtendWith(SpringExtension.class)
+public class UICaseSearchProviderTest extends WireMockBaseContractTest {
+
+    @MockitoBean
+    ApplicationParams applicationParams;
+    @MockitoBean
+    SecurityUtils securityUtils;
+    @MockitoBean
+    @Qualifier("AuthorisedCaseSearchOperation")
+    CaseSearchOperation caseSearchOperation;
+    @MockitoBean
+    ElasticsearchQueryHelper elasticsearchQueryHelper;
+    @MockitoBean
+    CaseSearchResultViewGenerator caseSearchResultViewGenerator;
+    @MockitoBean
+    ElasticsearchSortService elasticsearchSortService;
+    @Autowired
+    UICaseSearchController uiCaseSearchController;
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider.class)
+    void pactVerificationTestTemplate(PactVerificationContext context) {
+        if (context != null) {
+            context.verifyInteraction();
+        }
+    }
+
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        System.getProperties().setProperty("pact.verifier.publishResults", "true");
+        MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        testTarget.setControllers(uiCaseSearchController);
+        if (context != null) {
+            context.setTarget(testTarget);
+        }
+    }
+
+    @State("A search for cases is requested")
+    public void searchForCasesRequested() {
+        // State setup (mock caseSearchOperation) to be completed when a consumer contract is published.
+    }
+}

--- a/src/contractTest/java/uk/gov/hmcts/ccd/v2/internal/controller/UIDefinitionProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/ccd/v2/internal/controller/UIDefinitionProviderTest.java
@@ -1,0 +1,89 @@
+package uk.gov.hmcts.ccd.v2.internal.controller;
+
+import au.com.dius.pact.provider.junit5.PactVerificationContext;
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify;
+import au.com.dius.pact.provider.junitsupport.Provider;
+import au.com.dius.pact.provider.junitsupport.State;
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker;
+import au.com.dius.pact.provider.junitsupport.loader.VersionSelector;
+import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.ccd.ApplicationParams;
+import uk.gov.hmcts.ccd.WireMockBaseContractTest;
+import uk.gov.hmcts.ccd.data.SecurityUtils;
+import uk.gov.hmcts.ccd.domain.service.aggregated.GetBannerOperation;
+import uk.gov.hmcts.ccd.domain.service.aggregated.GetCriteriaOperation;
+import uk.gov.hmcts.ccd.domain.service.aggregated.GetJurisdictionUiConfigOperation;
+import uk.gov.hmcts.ccd.domain.service.aggregated.GetUserProfileOperation;
+import uk.gov.hmcts.ccd.v2.external.controller.TestIdamConfiguration;
+
+/** Provider PACT verification for the internal UI definition endpoints
+ *  (banners, jurisdiction-ui-configs, work-basket/search inputs) in UIDefinitionController. */
+@Provider("ccdDataStoreAPI_uiDefinition")
+@PactBroker(url = "${PACT_BROKER_FULL_URL:http://localhost:9292}",
+    consumerVersionSelectors = {@VersionSelector(tag = "${PACT_BRANCH_NAME:Dev}")},
+    providerTags = "${pactbroker.providerTags:master}",
+    enablePendingPacts = "${pactbroker.enablePending:true}")
+@TestPropertySource(locations = "/application.properties")
+@WebMvcTest({UIDefinitionController.class})
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("SECURITY_MOCK")
+@ContextConfiguration(classes = {TestIdamConfiguration.class})
+@IgnoreNoPactsToVerify
+@ExtendWith(SpringExtension.class)
+public class UIDefinitionProviderTest extends WireMockBaseContractTest {
+
+    @MockitoBean
+    ApplicationParams applicationParams;
+    @MockitoBean
+    SecurityUtils securityUtils;
+    @MockitoBean
+    @Qualifier("authorised")
+    GetCriteriaOperation getCriteriaOperation;
+    @MockitoBean
+    @Qualifier("default")
+    GetBannerOperation getBannerOperation;
+    @MockitoBean
+    @Qualifier("authorised")
+    GetUserProfileOperation getUserProfileOperation;
+    @MockitoBean
+    @Qualifier("default")
+    GetJurisdictionUiConfigOperation getJurisdictionUiConfigOperation;
+    @Autowired
+    UIDefinitionController uiDefinitionController;
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider.class)
+    void pactVerificationTestTemplate(PactVerificationContext context) {
+        if (context != null) {
+            context.verifyInteraction();
+        }
+    }
+
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        System.getProperties().setProperty("pact.verifier.publishResults", "true");
+        MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        testTarget.setControllers(uiDefinitionController);
+        if (context != null) {
+            context.setTarget(testTarget);
+        }
+    }
+
+    @State("UI definition information is requested for jurisdictions")
+    public void uiDefinitionRequested() {
+        // State setup (mock the get operations) to be completed when a consumer contract is published.
+    }
+}

--- a/src/contractTest/java/uk/gov/hmcts/ccd/v2/internal/controller/UIDefinitionProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/ccd/v2/internal/controller/UIDefinitionProviderTest.java
@@ -11,58 +11,47 @@ import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.mockito.Mock;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import uk.gov.hmcts.ccd.ApplicationParams;
-import uk.gov.hmcts.ccd.WireMockBaseContractTest;
-import uk.gov.hmcts.ccd.data.SecurityUtils;
 import uk.gov.hmcts.ccd.domain.service.aggregated.GetBannerOperation;
 import uk.gov.hmcts.ccd.domain.service.aggregated.GetCriteriaOperation;
 import uk.gov.hmcts.ccd.domain.service.aggregated.GetJurisdictionUiConfigOperation;
 import uk.gov.hmcts.ccd.domain.service.aggregated.GetUserProfileOperation;
-import uk.gov.hmcts.ccd.v2.external.controller.TestIdamConfiguration;
 
-/** Provider PACT verification for the internal UI definition endpoints
- *  (banners, jurisdiction-ui-configs, work-basket/search inputs) in UIDefinitionController. */
+/**
+ * Provider PACT verification for the internal UI definition endpoints (UIDefinitionController).
+ */
 @Provider("ccdDataStoreAPI_uiDefinition")
 @PactBroker(url = "${PACT_BROKER_FULL_URL:http://localhost:9292}",
     consumerVersionSelectors = {@VersionSelector(tag = "${PACT_BRANCH_NAME:Dev}")},
     providerTags = "${pactbroker.providerTags:master}",
     enablePendingPacts = "${pactbroker.enablePending:true}")
-@TestPropertySource(locations = "/application.properties")
-@WebMvcTest({UIDefinitionController.class})
-@AutoConfigureMockMvc(addFilters = false)
-@ActiveProfiles("SECURITY_MOCK")
-@ContextConfiguration(classes = {TestIdamConfiguration.class})
 @IgnoreNoPactsToVerify
 @ExtendWith(SpringExtension.class)
-public class UIDefinitionProviderTest extends WireMockBaseContractTest {
+public class UIDefinitionProviderTest {
 
-    @MockitoBean
-    ApplicationParams applicationParams;
-    @MockitoBean
-    SecurityUtils securityUtils;
-    @MockitoBean
-    @Qualifier("authorised")
-    GetCriteriaOperation getCriteriaOperation;
-    @MockitoBean
-    @Qualifier("default")
-    GetBannerOperation getBannerOperation;
-    @MockitoBean
-    @Qualifier("authorised")
-    GetUserProfileOperation getUserProfileOperation;
-    @MockitoBean
-    @Qualifier("default")
-    GetJurisdictionUiConfigOperation getJurisdictionUiConfigOperation;
-    @Autowired
-    UIDefinitionController uiDefinitionController;
+    @Mock
+    private GetCriteriaOperation getCriteriaOperation;
+
+    @Mock
+    private GetBannerOperation getBannerOperation;
+
+    @Mock
+    private GetUserProfileOperation getUserProfileOperation;
+
+    @Mock
+    private GetJurisdictionUiConfigOperation getJurisdictionUiConfigOperation;
+
+
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        testTarget.setControllers(new UIDefinitionController(
+            getCriteriaOperation, getBannerOperation, getUserProfileOperation, getJurisdictionUiConfigOperation));
+        if (context != null) {
+            context.setTarget(testTarget);
+        }
+    }
 
     @TestTemplate
     @ExtendWith(PactVerificationInvocationContextProvider.class)
@@ -72,15 +61,6 @@ public class UIDefinitionProviderTest extends WireMockBaseContractTest {
         }
     }
 
-    @BeforeEach
-    void before(PactVerificationContext context) {
-        System.getProperties().setProperty("pact.verifier.publishResults", "true");
-        MockMvcTestTarget testTarget = new MockMvcTestTarget();
-        testTarget.setControllers(uiDefinitionController);
-        if (context != null) {
-            context.setTarget(testTarget);
-        }
-    }
 
     @State("UI definition information is requested for jurisdictions")
     public void uiDefinitionRequested() {

--- a/src/contractTest/java/uk/gov/hmcts/ccd/v2/internal/controller/UIDraftsProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/ccd/v2/internal/controller/UIDraftsProviderTest.java
@@ -11,53 +11,42 @@ import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.mockito.Mock;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import uk.gov.hmcts.ccd.ApplicationParams;
-import uk.gov.hmcts.ccd.WireMockBaseContractTest;
-import uk.gov.hmcts.ccd.data.SecurityUtils;
 import uk.gov.hmcts.ccd.data.draft.DraftGateway;
 import uk.gov.hmcts.ccd.domain.service.aggregated.GetCaseViewOperation;
 import uk.gov.hmcts.ccd.domain.service.upsertdraft.UpsertDraftOperation;
-import uk.gov.hmcts.ccd.v2.external.controller.TestIdamConfiguration;
 
-/** Provider PACT verification for the internal drafts endpoints (UIDraftsController). */
+/**
+ * Provider PACT verification for the internal drafts endpoints (UIDraftsController).
+ */
 @Provider("ccdDataStoreAPI_drafts")
 @PactBroker(url = "${PACT_BROKER_FULL_URL:http://localhost:9292}",
     consumerVersionSelectors = {@VersionSelector(tag = "${PACT_BRANCH_NAME:Dev}")},
     providerTags = "${pactbroker.providerTags:master}",
     enablePendingPacts = "${pactbroker.enablePending:true}")
-@TestPropertySource(locations = "/application.properties")
-@WebMvcTest({UIDraftsController.class})
-@AutoConfigureMockMvc(addFilters = false)
-@ActiveProfiles("SECURITY_MOCK")
-@ContextConfiguration(classes = {TestIdamConfiguration.class})
 @IgnoreNoPactsToVerify
 @ExtendWith(SpringExtension.class)
-public class UIDraftsProviderTest extends WireMockBaseContractTest {
+public class UIDraftsProviderTest {
 
-    @MockitoBean
-    ApplicationParams applicationParams;
-    @MockitoBean
-    SecurityUtils securityUtils;
-    @MockitoBean
-    @Qualifier("default")
-    UpsertDraftOperation upsertDraftOperation;
-    @MockitoBean
-    @Qualifier("defaultDraft")
-    GetCaseViewOperation getDraftViewOperation;
-    @MockitoBean
-    @Qualifier("cached")
-    DraftGateway draftGateway;
-    @Autowired
-    UIDraftsController uiDraftsController;
+    @Mock
+    private UpsertDraftOperation upsertDraftOperation;
+
+    @Mock
+    private GetCaseViewOperation getDraftViewOperation;
+
+    @Mock
+    private DraftGateway draftGateway;
+
+
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        testTarget.setControllers(new UIDraftsController(upsertDraftOperation, getDraftViewOperation, draftGateway));
+        if (context != null) {
+            context.setTarget(testTarget);
+        }
+    }
 
     @TestTemplate
     @ExtendWith(PactVerificationInvocationContextProvider.class)
@@ -67,15 +56,6 @@ public class UIDraftsProviderTest extends WireMockBaseContractTest {
         }
     }
 
-    @BeforeEach
-    void before(PactVerificationContext context) {
-        System.getProperties().setProperty("pact.verifier.publishResults", "true");
-        MockMvcTestTarget testTarget = new MockMvcTestTarget();
-        testTarget.setControllers(uiDraftsController);
-        if (context != null) {
-            context.setTarget(testTarget);
-        }
-    }
 
     @State("A draft is requested for display")
     public void draftRequested() {

--- a/src/contractTest/java/uk/gov/hmcts/ccd/v2/internal/controller/UIDraftsProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/ccd/v2/internal/controller/UIDraftsProviderTest.java
@@ -1,0 +1,84 @@
+package uk.gov.hmcts.ccd.v2.internal.controller;
+
+import au.com.dius.pact.provider.junit5.PactVerificationContext;
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify;
+import au.com.dius.pact.provider.junitsupport.Provider;
+import au.com.dius.pact.provider.junitsupport.State;
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker;
+import au.com.dius.pact.provider.junitsupport.loader.VersionSelector;
+import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.ccd.ApplicationParams;
+import uk.gov.hmcts.ccd.WireMockBaseContractTest;
+import uk.gov.hmcts.ccd.data.SecurityUtils;
+import uk.gov.hmcts.ccd.data.draft.DraftGateway;
+import uk.gov.hmcts.ccd.domain.service.aggregated.GetCaseViewOperation;
+import uk.gov.hmcts.ccd.domain.service.upsertdraft.UpsertDraftOperation;
+import uk.gov.hmcts.ccd.v2.external.controller.TestIdamConfiguration;
+
+/** Provider PACT verification for the internal drafts endpoints (UIDraftsController). */
+@Provider("ccdDataStoreAPI_drafts")
+@PactBroker(url = "${PACT_BROKER_FULL_URL:http://localhost:9292}",
+    consumerVersionSelectors = {@VersionSelector(tag = "${PACT_BRANCH_NAME:Dev}")},
+    providerTags = "${pactbroker.providerTags:master}",
+    enablePendingPacts = "${pactbroker.enablePending:true}")
+@TestPropertySource(locations = "/application.properties")
+@WebMvcTest({UIDraftsController.class})
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("SECURITY_MOCK")
+@ContextConfiguration(classes = {TestIdamConfiguration.class})
+@IgnoreNoPactsToVerify
+@ExtendWith(SpringExtension.class)
+public class UIDraftsProviderTest extends WireMockBaseContractTest {
+
+    @MockitoBean
+    ApplicationParams applicationParams;
+    @MockitoBean
+    SecurityUtils securityUtils;
+    @MockitoBean
+    @Qualifier("default")
+    UpsertDraftOperation upsertDraftOperation;
+    @MockitoBean
+    @Qualifier("defaultDraft")
+    GetCaseViewOperation getDraftViewOperation;
+    @MockitoBean
+    @Qualifier("cached")
+    DraftGateway draftGateway;
+    @Autowired
+    UIDraftsController uiDraftsController;
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider.class)
+    void pactVerificationTestTemplate(PactVerificationContext context) {
+        if (context != null) {
+            context.verifyInteraction();
+        }
+    }
+
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        System.getProperties().setProperty("pact.verifier.publishResults", "true");
+        MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        testTarget.setControllers(uiDraftsController);
+        if (context != null) {
+            context.setTarget(testTarget);
+        }
+    }
+
+    @State("A draft is requested for display")
+    public void draftRequested() {
+        // State setup (mock getDraftViewOperation) to be completed when a consumer contract is published.
+    }
+}

--- a/src/contractTest/java/uk/gov/hmcts/ccd/v2/internal/controller/UIStartTriggerProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/ccd/v2/internal/controller/UIStartTriggerProviderTest.java
@@ -11,48 +11,38 @@ import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.mockito.Mock;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import uk.gov.hmcts.ccd.ApplicationParams;
-import uk.gov.hmcts.ccd.WireMockBaseContractTest;
-import uk.gov.hmcts.ccd.data.SecurityUtils;
 import uk.gov.hmcts.ccd.domain.service.aggregated.GetEventTriggerOperation;
 import uk.gov.hmcts.ccd.domain.service.common.UIDService;
-import uk.gov.hmcts.ccd.v2.external.controller.TestIdamConfiguration;
 
-/** Provider PACT verification for the internal start-trigger endpoints (UIStartTriggerController). */
+/**
+ * Provider PACT verification for the internal start-trigger endpoints (UIStartTriggerController).
+ */
 @Provider("ccdDataStoreAPI_startTrigger")
 @PactBroker(url = "${PACT_BROKER_FULL_URL:http://localhost:9292}",
     consumerVersionSelectors = {@VersionSelector(tag = "${PACT_BRANCH_NAME:Dev}")},
     providerTags = "${pactbroker.providerTags:master}",
     enablePendingPacts = "${pactbroker.enablePending:true}")
-@TestPropertySource(locations = "/application.properties")
-@WebMvcTest({UIStartTriggerController.class})
-@AutoConfigureMockMvc(addFilters = false)
-@ActiveProfiles("SECURITY_MOCK")
-@ContextConfiguration(classes = {TestIdamConfiguration.class})
 @IgnoreNoPactsToVerify
 @ExtendWith(SpringExtension.class)
-public class UIStartTriggerProviderTest extends WireMockBaseContractTest {
+public class UIStartTriggerProviderTest {
 
-    @MockitoBean
-    ApplicationParams applicationParams;
-    @MockitoBean
-    SecurityUtils securityUtils;
-    @MockitoBean
-    @Qualifier("authorised")
-    GetEventTriggerOperation getEventTriggerOperation;
-    @MockitoBean
-    UIDService caseReferenceService;
-    @Autowired
-    UIStartTriggerController uiStartTriggerController;
+    @Mock
+    private GetEventTriggerOperation getEventTriggerOperation;
+
+    @Mock
+    private UIDService caseReferenceService;
+
+
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        testTarget.setControllers(new UIStartTriggerController(getEventTriggerOperation, caseReferenceService));
+        if (context != null) {
+            context.setTarget(testTarget);
+        }
+    }
 
     @TestTemplate
     @ExtendWith(PactVerificationInvocationContextProvider.class)
@@ -62,15 +52,6 @@ public class UIStartTriggerProviderTest extends WireMockBaseContractTest {
         }
     }
 
-    @BeforeEach
-    void before(PactVerificationContext context) {
-        System.getProperties().setProperty("pact.verifier.publishResults", "true");
-        MockMvcTestTarget testTarget = new MockMvcTestTarget();
-        testTarget.setControllers(uiStartTriggerController);
-        if (context != null) {
-            context.setTarget(testTarget);
-        }
-    }
 
     @State("A start trigger is requested for dynamic display")
     public void startTriggerRequested() {

--- a/src/contractTest/java/uk/gov/hmcts/ccd/v2/internal/controller/UIStartTriggerProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/ccd/v2/internal/controller/UIStartTriggerProviderTest.java
@@ -1,0 +1,79 @@
+package uk.gov.hmcts.ccd.v2.internal.controller;
+
+import au.com.dius.pact.provider.junit5.PactVerificationContext;
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify;
+import au.com.dius.pact.provider.junitsupport.Provider;
+import au.com.dius.pact.provider.junitsupport.State;
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker;
+import au.com.dius.pact.provider.junitsupport.loader.VersionSelector;
+import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.ccd.ApplicationParams;
+import uk.gov.hmcts.ccd.WireMockBaseContractTest;
+import uk.gov.hmcts.ccd.data.SecurityUtils;
+import uk.gov.hmcts.ccd.domain.service.aggregated.GetEventTriggerOperation;
+import uk.gov.hmcts.ccd.domain.service.common.UIDService;
+import uk.gov.hmcts.ccd.v2.external.controller.TestIdamConfiguration;
+
+/** Provider PACT verification for the internal start-trigger endpoints (UIStartTriggerController). */
+@Provider("ccdDataStoreAPI_startTrigger")
+@PactBroker(url = "${PACT_BROKER_FULL_URL:http://localhost:9292}",
+    consumerVersionSelectors = {@VersionSelector(tag = "${PACT_BRANCH_NAME:Dev}")},
+    providerTags = "${pactbroker.providerTags:master}",
+    enablePendingPacts = "${pactbroker.enablePending:true}")
+@TestPropertySource(locations = "/application.properties")
+@WebMvcTest({UIStartTriggerController.class})
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("SECURITY_MOCK")
+@ContextConfiguration(classes = {TestIdamConfiguration.class})
+@IgnoreNoPactsToVerify
+@ExtendWith(SpringExtension.class)
+public class UIStartTriggerProviderTest extends WireMockBaseContractTest {
+
+    @MockitoBean
+    ApplicationParams applicationParams;
+    @MockitoBean
+    SecurityUtils securityUtils;
+    @MockitoBean
+    @Qualifier("authorised")
+    GetEventTriggerOperation getEventTriggerOperation;
+    @MockitoBean
+    UIDService caseReferenceService;
+    @Autowired
+    UIStartTriggerController uiStartTriggerController;
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider.class)
+    void pactVerificationTestTemplate(PactVerificationContext context) {
+        if (context != null) {
+            context.verifyInteraction();
+        }
+    }
+
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        System.getProperties().setProperty("pact.verifier.publishResults", "true");
+        MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        testTarget.setControllers(uiStartTriggerController);
+        if (context != null) {
+            context.setTarget(testTarget);
+        }
+    }
+
+    @State("A start trigger is requested for dynamic display")
+    public void startTriggerRequested() {
+        // State setup (mock getEventTriggerOperation) to be completed when a consumer contract is published.
+    }
+}

--- a/src/contractTest/java/uk/gov/hmcts/ccd/v2/internal/controller/UIUserProfileProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/ccd/v2/internal/controller/UIUserProfileProviderTest.java
@@ -1,0 +1,76 @@
+package uk.gov.hmcts.ccd.v2.internal.controller;
+
+import au.com.dius.pact.provider.junit5.PactVerificationContext;
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify;
+import au.com.dius.pact.provider.junitsupport.Provider;
+import au.com.dius.pact.provider.junitsupport.State;
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker;
+import au.com.dius.pact.provider.junitsupport.loader.VersionSelector;
+import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.ccd.ApplicationParams;
+import uk.gov.hmcts.ccd.WireMockBaseContractTest;
+import uk.gov.hmcts.ccd.data.SecurityUtils;
+import uk.gov.hmcts.ccd.domain.service.aggregated.GetUserProfileOperation;
+import uk.gov.hmcts.ccd.v2.external.controller.TestIdamConfiguration;
+
+/** Provider PACT verification for GET /internal/profile (UIUserProfileController). */
+@Provider("ccdDataStoreAPI_userProfile")
+@PactBroker(url = "${PACT_BROKER_FULL_URL:http://localhost:9292}",
+    consumerVersionSelectors = {@VersionSelector(tag = "${PACT_BRANCH_NAME:Dev}")},
+    providerTags = "${pactbroker.providerTags:master}",
+    enablePendingPacts = "${pactbroker.enablePending:true}")
+@TestPropertySource(locations = "/application.properties")
+@WebMvcTest({UIUserProfileController.class})
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("SECURITY_MOCK")
+@ContextConfiguration(classes = {TestIdamConfiguration.class})
+@IgnoreNoPactsToVerify
+@ExtendWith(SpringExtension.class)
+public class UIUserProfileProviderTest extends WireMockBaseContractTest {
+
+    @MockitoBean
+    ApplicationParams applicationParams;
+    @MockitoBean
+    SecurityUtils securityUtils;
+    @MockitoBean
+    @Qualifier("authorised")
+    GetUserProfileOperation getUserProfileOperation;
+    @Autowired
+    UIUserProfileController uiUserProfileController;
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider.class)
+    void pactVerificationTestTemplate(PactVerificationContext context) {
+        if (context != null) {
+            context.verifyInteraction();
+        }
+    }
+
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        System.getProperties().setProperty("pact.verifier.publishResults", "true");
+        MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        testTarget.setControllers(uiUserProfileController);
+        if (context != null) {
+            context.setTarget(testTarget);
+        }
+    }
+
+    @State("A user profile is requested")
+    public void userProfileRequested() {
+        // State setup (mock getUserProfileOperation) to be completed when a consumer contract is published.
+    }
+}

--- a/src/contractTest/java/uk/gov/hmcts/ccd/v2/internal/controller/UIUserProfileProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/ccd/v2/internal/controller/UIUserProfileProviderTest.java
@@ -11,45 +11,34 @@ import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.mockito.Mock;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import uk.gov.hmcts.ccd.ApplicationParams;
-import uk.gov.hmcts.ccd.WireMockBaseContractTest;
-import uk.gov.hmcts.ccd.data.SecurityUtils;
 import uk.gov.hmcts.ccd.domain.service.aggregated.GetUserProfileOperation;
-import uk.gov.hmcts.ccd.v2.external.controller.TestIdamConfiguration;
 
-/** Provider PACT verification for GET /internal/profile (UIUserProfileController). */
+/**
+ * Provider PACT verification for GET /internal/profile (UIUserProfileController).
+ */
 @Provider("ccdDataStoreAPI_userProfile")
 @PactBroker(url = "${PACT_BROKER_FULL_URL:http://localhost:9292}",
     consumerVersionSelectors = {@VersionSelector(tag = "${PACT_BRANCH_NAME:Dev}")},
     providerTags = "${pactbroker.providerTags:master}",
     enablePendingPacts = "${pactbroker.enablePending:true}")
-@TestPropertySource(locations = "/application.properties")
-@WebMvcTest({UIUserProfileController.class})
-@AutoConfigureMockMvc(addFilters = false)
-@ActiveProfiles("SECURITY_MOCK")
-@ContextConfiguration(classes = {TestIdamConfiguration.class})
 @IgnoreNoPactsToVerify
 @ExtendWith(SpringExtension.class)
-public class UIUserProfileProviderTest extends WireMockBaseContractTest {
+public class UIUserProfileProviderTest {
 
-    @MockitoBean
-    ApplicationParams applicationParams;
-    @MockitoBean
-    SecurityUtils securityUtils;
-    @MockitoBean
-    @Qualifier("authorised")
-    GetUserProfileOperation getUserProfileOperation;
-    @Autowired
-    UIUserProfileController uiUserProfileController;
+    @Mock
+    private GetUserProfileOperation getUserProfileOperation;
+
+
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        testTarget.setControllers(new UIUserProfileController(getUserProfileOperation));
+        if (context != null) {
+            context.setTarget(testTarget);
+        }
+    }
 
     @TestTemplate
     @ExtendWith(PactVerificationInvocationContextProvider.class)
@@ -59,15 +48,6 @@ public class UIUserProfileProviderTest extends WireMockBaseContractTest {
         }
     }
 
-    @BeforeEach
-    void before(PactVerificationContext context) {
-        System.getProperties().setProperty("pact.verifier.publishResults", "true");
-        MockMvcTestTarget testTarget = new MockMvcTestTarget();
-        testTarget.setControllers(uiUserProfileController);
-        if (context != null) {
-            context.setTarget(testTarget);
-        }
-    }
 
     @State("A user profile is requested")
     public void userProfileRequested() {


### PR DESCRIPTION
Verifies consumer contracts published under provider name ccdDataStoreAPI_validateCaseData against POST /case-types/{caseTypeId}/validate (CaseDataValidatorController). Uses @IgnoreNoPactsToVerify so the build stays green when no such contract exists yet.

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] the `keep-helm` label has been added, if the helm release should be persisted after a successful build

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
