### PR TITLE
CCD-2008: Add @Ignore'd BEFTA scenarios validating Postcode field

### DIFF
--- a/src/aat/resources/features/F-1008 - Postcode Field Validation/F-1008.feature
+++ b/src/aat/resources/features/F-1008 - Postcode Field Validation/F-1008.feature
@@ -1,0 +1,50 @@
+#=========================================================================================================================================================
+# CCD-2008: Postcode field type must accept valid UK postcodes (e.g. W1U 3BW) and reject invalid ones.
+#
+# End-to-end value validation for the Postcode base-type regex fix (def-store PR#1762). The def-store
+# fix only changes the regex *string*; this feature proves data-store actually accepts/rejects postcode
+# *values* against it when a case is created with a Postcode field.
+#
+# @Ignore until BOTH preconditions are met in the data-store preview environment:
+#   1. ccd-test-definitions branch ccd-2008-postcode-field is released and picked up by data-store
+#      (adds the PostcodeField of FieldType Postcode to FT_Regex - without it there is no field to set).
+#   2. ccd-definition-store-api PR#1762 (the corrected Postcode regex) is released, so the deployed
+#      def-store serves the new regex. Until then the live regex still rejects W1U 3BW and S-1008.1 fails.
+# When both are live, remove the @Ignore tags. On first enable, confirm the S-1008.1 expected case_data
+# shape (FT_Regex create response) and the S-1008.2 422 body shape match the deployed responses.
+#=========================================================================================================
+@F-1008
+Feature: F-1008: Postcode field type accepts valid UK postcodes and rejects invalid ones
+
+  Background:
+    Given an appropriate test context as detailed in the test data source
+
+  #-------------------------------------------------------------------------------------------------------
+  @S-1008.1 @Ignore # CCD-2008: enable once def-store PR#1762 regex + ccd-test-definitions PostcodeField are released to data-store preview
+  Scenario: A case created with a valid UK postcode (W1U 3BW) in a Postcode field is accepted
+
+    Given a user with [an active caseworker profile in CCD with full permissions on the postcode field],
+      And a successful call [to create a token for case creation] as in [F-1008_Postcode_Token_Creation],
+
+     When a request is prepared with appropriate values,
+      And the request [contains a valid UK postcode in the Postcode field],
+      And it is submitted to call the [Submit Case Creation] operation of [CCD Data Store],
+
+     Then a positive response is received,
+      And the response [is accepted and the postcode is persisted],
+      And the response has all other details as expected.
+
+  #-------------------------------------------------------------------------------------------------------
+  @S-1008.2 @Ignore # CCD-2008: enable once def-store PR#1762 regex + ccd-test-definitions PostcodeField are released to data-store preview
+  Scenario: A case created with an invalid postcode in a Postcode field is rejected
+
+    Given a user with [an active caseworker profile in CCD with full permissions on the postcode field],
+      And a successful call [to create a token for case creation] as in [F-1008_Postcode_Token_Creation],
+
+     When a request is prepared with appropriate values,
+      And the request [contains a value that is not a valid UK postcode in the Postcode field],
+      And it is submitted to call the [Submit Case Creation] operation of [CCD Data Store],
+
+     Then a negative response is received,
+      And the response [is rejected with an unprocessable entity error],
+      And the response has all other details as expected.

--- a/src/aat/resources/features/F-1008 - Postcode Field Validation/F-1008_Postcode_Token_Creation.td.json
+++ b/src/aat/resources/features/F-1008 - Postcode Field Validation/F-1008_Postcode_Token_Creation.td.json
@@ -1,0 +1,33 @@
+{
+  "_guid_": "F-1008_Postcode_Token_Creation",
+  "_extends_": "Standard_Token_Creation_Data_For_Case_Creation",
+
+  "specs": [
+    "to create a token for case creation"
+  ],
+
+  "users": {
+    "invokingUser": {
+      "_extends_": "BeftaMasterCaseworker"
+    }
+  },
+
+  "request": {
+    "pathVariables": {
+      "uid": "[[DEFAULT_AUTO_VALUE]]",
+      "jid": "BEFTA_MASTER",
+      "ctid": "FT_Regex",
+      "etid": "createCase"
+    }
+  },
+
+  "expectedResponse": {
+    "body": {
+      "case_details": {
+        "jurisdiction": "BEFTA_MASTER",
+        "case_type_id": "FT_Regex"
+      },
+      "event_id": "createCase"
+    }
+  }
+}

--- a/src/aat/resources/features/F-1008 - Postcode Field Validation/S-1008.1.td.json
+++ b/src/aat/resources/features/F-1008 - Postcode Field Validation/S-1008.1.td.json
@@ -1,0 +1,67 @@
+{
+  "_guid_": "S-1008.1",
+  "productName": "CCD Data Store",
+  "operationName": "Submit Case Creation",
+  "title": "A valid UK postcode (W1U 3BW) in a Postcode field is accepted",
+
+  "specs": [
+    "an active caseworker profile in CCD with full permissions on the postcode field",
+    "contains a valid UK postcode in the Postcode field",
+    "is accepted and the postcode is persisted"
+  ],
+
+  "users": {
+    "invokingUser": {
+      "_extends_": "BeftaMasterCaseworker"
+    }
+  },
+
+  "method": "POST",
+  "uri": "case-types/{CaseTypeID}/cases",
+
+  "request": {
+    "headers": {
+      "Authorization": "[[DEFAULT_AUTO_VALUE]]",
+      "ServiceAuthorization": "[[DEFAULT_AUTO_VALUE]]",
+      "Content-Type": "application/json;charset=UTF-8",
+      "experimental": true
+    },
+    "pathVariables": {
+      "CaseTypeID": "FT_Regex"
+    },
+    "body": {
+      "data": {
+        "TextField": "ABC",
+        "PostcodeField": "W1U 3BW"
+      },
+      "event": {
+        "id": "createCase",
+        "summary": "",
+        "description": ""
+      },
+      "event_token": "${[scenarioContext][childContexts][F-1008_Postcode_Token_Creation][testData][actualResponse][body][token]}",
+      "ignore_warning": false,
+      "draft_id": null
+    }
+  },
+
+  "expectedResponse": {
+    "_extends_": "Common_201_Response",
+    "headers": {
+      "Content-Encoding": "[[ANYTHING_PRESENT]]",
+      "Content-Length": "[[ANYTHING_PRESENT]]",
+      "Content-Type": "[[ANYTHING_PRESENT]]"
+    },
+    "body": {
+      "id": "[[ANYTHING_PRESENT]]",
+      "jurisdiction": "BEFTA_MASTER",
+      "case_type": "FT_Regex",
+      "state": "CaseCreated",
+      "security_classification": "PUBLIC",
+      "data": {
+        "TextField": "ABC",
+        "PostcodeField": "W1U 3BW"
+      }
+    }
+  }
+}

--- a/src/aat/resources/features/F-1008 - Postcode Field Validation/S-1008.2.td.json
+++ b/src/aat/resources/features/F-1008 - Postcode Field Validation/S-1008.2.td.json
@@ -1,0 +1,58 @@
+{
+  "_guid_": "S-1008.2",
+  "productName": "CCD Data Store",
+  "operationName": "Submit Case Creation",
+  "title": "An invalid postcode in a Postcode field is rejected",
+
+  "specs": [
+    "an active caseworker profile in CCD with full permissions on the postcode field",
+    "contains a value that is not a valid UK postcode in the Postcode field",
+    "is rejected with an unprocessable entity error"
+  ],
+
+  "users": {
+    "invokingUser": {
+      "_extends_": "BeftaMasterCaseworker"
+    }
+  },
+
+  "method": "POST",
+  "uri": "case-types/{CaseTypeID}/cases",
+
+  "request": {
+    "headers": {
+      "Authorization": "[[DEFAULT_AUTO_VALUE]]",
+      "ServiceAuthorization": "[[DEFAULT_AUTO_VALUE]]",
+      "Content-Type": "application/json;charset=UTF-8",
+      "experimental": true
+    },
+    "pathVariables": {
+      "CaseTypeID": "FT_Regex"
+    },
+    "body": {
+      "data": {
+        "TextField": "ABC",
+        "PostcodeField": "12345"
+      },
+      "event": {
+        "id": "createCase",
+        "summary": "",
+        "description": ""
+      },
+      "event_token": "${[scenarioContext][childContexts][F-1008_Postcode_Token_Creation][testData][actualResponse][body][token]}",
+      "ignore_warning": false,
+      "draft_id": null
+    }
+  },
+
+  "expectedResponse": {
+    "responseCode": 422,
+    "responseMessage": "[[ANYTHING_PRESENT]]",
+    "headers": {
+      "_extends_": "Common_Response_Headers"
+    },
+    "body": {
+      "message": "[[ANYTHING_PRESENT]]"
+    }
+  }
+}


### PR DESCRIPTION
…epts W1U 3BW and rejects invalid postcodes

End-to-end value validation on FT_Regex (PostcodeField). @Ignore'd until (1) ccd-test-definitions ccd-2008-postcode-field is released (adds the field) and (2) def-store PR#1762 regex is live in data-store preview. Pairs with ccd-test-definitions branch ccd-2008-postcode-field.

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] the `keep-helm` label has been added, if the helm release should be persisted after a successful build

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
