### PR TITLE
Onboard CVE dashboard ingestion

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -11,7 +11,7 @@ properties(
     ]
 )
 
-@Library("Infrastructure@2.4.0")
+@Library("Infrastructure@cve-dashboard")
 
 import uk.gov.hmcts.contino.GradleBuilder
 def type = "java"
@@ -118,6 +118,7 @@ env.BEFTA_USER_TOKEN_CACHE_TTL_SECONDS = "1"
 env.TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX = "hmctsprod.azurecr.io/imported/"
 
 withPipeline(type, product, component) {
+    enableCveDashboardIngestion()
     onMaster {
         enableSlackNotifications('#ccd-master-builds')
         enablePactAs([


### PR DESCRIPTION
## Summary
- pin the shared Jenkins library to cve-dashboard, now based on version 2.4.9
- enable CVE dashboard ingestion for the first time

## Testing
- Jenkinsfile-only configuration change