### PR TITLE
Update renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -21,7 +21,7 @@
       "allowedVersions": "/^[0-9]+\\.[0-9]+\\.[0-9]+$/",
       "prPriority": 100,
       "schedule": ["at any time"],
-      "automerge": false,
+      "automerge": true,
       "dependencyDashboardApproval": false,
       "minimumReleaseAge": null
     }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,14 +7,18 @@
   "labels": ["Renovate Dependencies"],
   "schedule": ["* 16-19 * * 1-5"],
   "automergeSchedule": ["* 14-18 * * 1-4"],
+  "platformAutomerge": false,
   "packageRules": [
     {
-      "description": "Prioritise BEFTA and CCD test definition updates",
+      "description": "Always update BEFTA dependencies to latest stable release",
       "matchManagers": ["gradle"],
       "matchDepNames": [
         "ccd-test-definitions",
         "befta-fw"
       ],
+      "matchCurrentValue": "!/^[0-9]+\\.[0-9]+\\.[0-9]+$/",
+      "enabled": false
+      "allowedVersions": "/^[0-9]+\\.[0-9]+\\.[0-9]+$/",
       "prPriority": 100,
       "schedule": ["at any time"],
       "automerge": false,

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,13 +9,17 @@
   "automergeSchedule": ["* 14-18 * * 1-4"],
   "packageRules": [
     {
+      "description": "Prioritise BEFTA and CCD test definition updates",
       "matchManagers": ["gradle"],
       "matchDepNames": [
         "ccd-test-definitions",
         "befta-fw"
       ],
-      "matchCurrentValue": "!/^[0-9]+\\.[0-9]+\\.[0-9]+$/",
-      "enabled": false
+      "prPriority": 100,
+      "schedule": ["at any time"],
+      "automerge": false,
+      "dependencyDashboardApproval": false,
+      "minimumReleaseAge": null
     }
   ]
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

AN

### Change description ###

"prPriority": 100 — these updates jump ahead of normal Renovate PRs. The default priority is 0.
"schedule": ["at any time"] — overrides your repository-level 16-19 schedule for these two dependencies, so Renovate doesn't deliberately wait for that window.
"automerge": false — creates the PR in readiness, but doesn't merge it automatically. This is particularly relevant because you're extending HMCTS's automerge-minor preset.
"dependencyDashboardApproval": false — don't leave these waiting for someone to approve PR creation via the dashboard.
"minimumReleaseAge": null — don't make these packages wait because of a release-age policy inherited from the HMCTS shared config. Renovate specifically documents null as the way to opt selected dependencies out of minimumReleaseAge

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
