### PR TITLE
DTSCCI-6319 Updated RoleAssignmentService to return an empty list when CCD/RAS returns no role assignments

### DIFF
--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/casedataaccesscontrol/RoleAssignmentService.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/casedataaccesscontrol/RoleAssignmentService.java
@@ -178,6 +178,9 @@ public class RoleAssignmentService implements AccessControl {
 
         final var roleAssignments = roleAssignmentsMapper.toRoleAssignments(roleAssignmentResponse);
         var caseIdError = new RuntimeException(RoleAssignmentAttributes.ATTRIBUTE_NOT_DEFINED);
+        if (roleAssignments == null || roleAssignments.getRoleAssignments() == null) {
+            return List.of();
+        }
         return roleAssignments.getRoleAssignments().stream()
             .filter(this::isValidRoleAssignment)
             .map(roleAssignment ->

--- a/src/test/java/uk/gov/hmcts/ccd/domain/service/casedataaccesscontrol/RoleAssignmentServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/domain/service/casedataaccesscontrol/RoleAssignmentServiceTest.java
@@ -514,6 +514,23 @@ class RoleAssignmentServiceTest {
             assertThat(caseAssignedUserRole.get(0).getCaseDataId(), is(CASE_ID));
         }
 
+        @Test
+        void shouldReturnEmptyWhenRoleAssignmentsAreMissing() {
+
+            // GIVEN
+            given(roleAssignmentRepository.findRoleAssignmentsByCasesAndUsers(caseIds, userIds))
+                .willReturn(mockedRoleAssignmentResponse);
+            given(roleAssignmentsMapper.toRoleAssignments(mockedRoleAssignmentResponse))
+                .willReturn(new RoleAssignments());
+
+            // WHEN
+            final List<CaseAssignedUserRole> caseAssignedUserRole =
+                roleAssignmentService.findRoleAssignmentsByCasesAndUsers(caseIds, userIds);
+
+            // THEN
+            assertTrue(caseAssignedUserRole.isEmpty());
+        }
+
     }
 
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSCCI-6319

### Change description ###

The functional test was failing on https://github.com/hmcts/cmc-citizen-frontend preview pipelines because claim creation triggered LINK_LETTER_HOLDER. CCD data-store queried role assignments for the new user and returned a response with no role list. RoleAssignmentService then called .stream() on the null list, causing a 500 response.

The claim-store wrapped this as:

- Failed updating claim in CCD store on event LINK_LETTER_HOLDER

 - The claim therefore never reached OPEN, and the later DisputesAll request failed with 422: The case status did not qualify for the event.

 - This allows CCD data-store to continue granting case access when the user has no existing role assignments. The normal role-assignment path is unchanged.
  This allows:

  1. Claim creation to complete LINK_LETTER_HOLDER.
  2. The claim to transition to OPEN.
  3. Defendant linking to complete.
  4. The Playwright FT to submit the DisputesAll response successfully.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
